### PR TITLE
docs: update MCP tab and features reference for named servers

### DIFF
--- a/backend/app/services/mcp_tool_executor.py
+++ b/backend/app/services/mcp_tool_executor.py
@@ -93,6 +93,14 @@ def _normalize_connection(connection: dict[str, Any]) -> dict[str, Any]:
             conn["headers"] = {}
     elif not isinstance(headers, dict):
         conn["headers"] = headers or {}
+    env = conn.get("env")
+    if isinstance(env, str) and env.strip():
+        try:
+            conn["env"] = json.loads(env)
+        except json.JSONDecodeError:
+            conn["env"] = {}
+    elif env is not None and not isinstance(env, dict):
+        conn["env"] = {}
     return conn
 
 

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -687,7 +687,7 @@ The agent will return structured JSON matching the schema, accessible via `$agen
 - `transport`: "stdio" | "sse" | "streamable_http"
 - `timeoutSeconds`: Timeout for this connection (default: 30)
 - `label`: Optional display name for the server
-- **stdio**: `command` (e.g. "npx"), `args` (JSON array, e.g. `["-y", "@modelcontextprotocol/server-filesystem", "--path", "/tmp"]`)
+- **stdio**: `command` (e.g. "npx"), `args` (JSON array, e.g. `["-y", "@modelcontextprotocol/server-filesystem", "--path", "/tmp"]`), `env` (JSON object of environment variables injected into the process, e.g. `{"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."}`) — most API-keyed stdio MCP servers (GitHub, Slack, Linear…) authenticate via `env`, NOT via args, because they read `process.env.X` directly in their source code
 - **sse**: `url` (SSE endpoint), `headers` (JSON object for auth/custom headers)
 - **streamable_http**: `url` (MCP endpoint, e.g. "https://example.com/mcp"), `headers` (JSON object for auth/custom headers)
 
@@ -734,7 +734,7 @@ The agent will return structured JSON matching the schema, accessible via `$agen
 }
 ```
 
-**Agent with MCP Example (stdio):**
+**Agent with MCP Example (stdio — filesystem, no auth needed):**
 ```json
 {
   "type": "agent",
@@ -757,6 +757,58 @@ The agent will return structured JSON matching the schema, accessible via `$agen
   }
 }
 ```
+
+**Agent with MCP Example (stdio — GitHub, env-based auth):**
+```json
+{
+  "type": "agent",
+  "data": {
+    "label": "githubAgent",
+    "credentialId": "YOUR_CREDENTIAL_ID",
+    "model": "gpt-4o",
+    "systemInstruction": "You are a GitHub assistant. Use GitHub tools to manage repos, issues, and pull requests.",
+    "userMessage": "$userInput.body.text",
+    "mcpConnections": [
+      {
+        "id": "github1",
+        "transport": "stdio",
+        "label": "github",
+        "timeoutSeconds": 60,
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_YOUR_TOKEN_HERE"}
+      }
+    ]
+  }
+}
+```
+
+**Agent with MCP Example (stdio — Slack, env-based auth):**
+```json
+{
+  "type": "agent",
+  "data": {
+    "label": "slackAgent",
+    "credentialId": "YOUR_CREDENTIAL_ID",
+    "model": "gpt-4o",
+    "systemInstruction": "You are a Slack assistant. Use Slack tools to read and send messages.",
+    "userMessage": "$userInput.body.text",
+    "mcpConnections": [
+      {
+        "id": "slack1",
+        "transport": "stdio",
+        "label": "slack",
+        "timeoutSeconds": 60,
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-slack"],
+        "env": {"SLACK_BOT_TOKEN": "xoxb-YOUR_TOKEN", "SLACK_TEAM_ID": "T0123456"}
+      }
+    ]
+  }
+}
+```
+
+**⚠️ CRITICAL for stdio MCP servers with API keys**: Always use `env` field (NOT args) for credentials. GitHub, Slack, Linear, and virtually all API-keyed stdio MCP servers read credentials from environment variables (e.g. `process.env.GITHUB_PERSONAL_ACCESS_TOKEN`), not from command-line arguments. Putting a token in `args` will NOT work for these servers.
 
 **Agent with MCP Example (SSE):**
 ```json

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -6467,6 +6467,16 @@ onUnmounted(() => {
                         @update:model-value="updateAgentMCPConnection(idx, 'args', $event)"
                       />
                     </div>
+                    <div>
+                      <Label class="text-xs">Env (JSON object)</Label>
+                      <Textarea
+                        :model-value="typeof conn.env === 'string' ? conn.env : JSON.stringify(conn.env ?? {}, null, 2)"
+                        placeholder="{&quot;API_KEY&quot;: &quot;your_key&quot;}"
+                        :rows="2"
+                        class="font-mono text-xs"
+                        @update:model-value="updateAgentMCPConnection(idx, 'env', $event)"
+                      />
+                    </div>
                   </template>
                   <template v-else-if="conn.transport === 'sse' || conn.transport === 'streamable_http'">
                     <div>

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -6463,7 +6463,8 @@ onUnmounted(() => {
                         :model-value="typeof conn.args === 'string' ? conn.args : JSON.stringify(conn.args ?? [], null, 2)"
                         placeholder="[&quot;-y&quot;, &quot;@modelcontextprotocol/server-filesystem&quot;, &quot;--path&quot;, &quot;/tmp&quot;]"
                         :rows="2"
-                        class="font-mono text-xs"
+                        wrap="off"
+                        class="overflow-x-auto whitespace-pre font-mono text-xs"
                         @update:model-value="updateAgentMCPConnection(idx, 'args', $event)"
                       />
                     </div>
@@ -6473,7 +6474,8 @@ onUnmounted(() => {
                         :model-value="typeof conn.env === 'string' ? conn.env : JSON.stringify(conn.env ?? {}, null, 2)"
                         placeholder="{&quot;API_KEY&quot;: &quot;your_key&quot;}"
                         :rows="2"
-                        class="font-mono text-xs"
+                        wrap="off"
+                        class="overflow-x-auto whitespace-pre font-mono text-xs"
                         @update:model-value="updateAgentMCPConnection(idx, 'env', $event)"
                       />
                     </div>
@@ -6493,7 +6495,8 @@ onUnmounted(() => {
                         :model-value="typeof conn.headers === 'string' ? conn.headers : JSON.stringify(conn.headers ?? {}, null, 2)"
                         placeholder="{&quot;Authorization&quot;: &quot;Bearer ...&quot;, &quot;X-Custom&quot;: &quot;value&quot;}"
                         :rows="2"
-                        class="font-mono text-xs"
+                        wrap="off"
+                        class="overflow-x-auto whitespace-pre font-mono text-xs"
                         @update:model-value="updateAgentMCPConnection(idx, 'headers', $event)"
                       />
                     </div>

--- a/frontend/src/components/ui/Textarea.vue
+++ b/frontend/src/components/ui/Textarea.vue
@@ -8,6 +8,7 @@ interface Props {
   placeholder?: string;
   disabled?: boolean;
   rows?: number;
+  wrap?: "soft" | "hard" | "off";
 }
 
 withDefaults(defineProps<Props>(), {
@@ -15,6 +16,7 @@ withDefaults(defineProps<Props>(), {
   placeholder: "",
   disabled: false,
   rows: 3,
+  wrap: "soft",
 });
 
 const emit = defineEmits<{
@@ -45,6 +47,7 @@ function handleInput(event: Event): void {
     :placeholder="placeholder"
     :disabled="disabled"
     :rows="rows"
+    :wrap="wrap"
     :class="classes"
     @input="handleInput"
   />

--- a/frontend/src/docs/content/nodes/agent-node.md
+++ b/frontend/src/docs/content/nodes/agent-node.md
@@ -187,6 +187,29 @@ Connect to [Model Context Protocol](https://modelcontextprotocol.io/) servers to
 |-------|-------------|
 | `command` | Command to run (e.g. `npx`) |
 | `args` | JSON array (e.g. `["-y", "@modelcontextprotocol/server-filesystem", "--path", "/tmp"]`) |
+| `env` | JSON object of environment variables injected into the process (e.g. `{"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."}`) |
+
+Most API-keyed stdio servers authenticate via environment variables rather than command arguments. Set `env` per-connection so each agent node can use a different credential without touching the host environment.
+
+Example — GitHub MCP:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxxxxxxxxxxx" }
+}
+```
+
+Example — Slack MCP:
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-slack"],
+  "env": { "SLACK_BOT_TOKEN": "xoxb-...", "SLACK_TEAM_ID": "T0123456" }
+}
+```
 
 **SSE** (remote server):
 

--- a/frontend/src/docs/content/reference/features.md
+++ b/frontend/src/docs/content/reference/features.md
@@ -569,7 +569,11 @@ See also [Qdrant RAG](../nodes/rag-node.md), [Credentials](./credentials.md), an
 
 ### [MCP](../tabs/mcp-tab.md)
 
-The MCP tab configures Model Context Protocol integration. View and regenerate your MCP API key, copy ready-to-use client JSON, connect Cursor in one click, or follow the Claude setup flow with automatic OAuth registration. Each workflow with an [Agent Node](../nodes/agent-node.md) can expose its tools via MCP; toggle per workflow from this tab. Clients connect to the [SSE](./sse-streaming.md) endpoint at `/api/mcp/sse`.
+The MCP tab configures Model Context Protocol integration. Heym supports two modes:
+
+**Default server** – A single endpoint at `/api/mcp/sse` exposes all MCP-enabled workflows. View and regenerate your API key, copy ready-to-use client JSON, connect Cursor in one click, or follow the Claude setup flow with automatic OAuth registration.
+
+**Named servers** – Create multiple isolated MCP endpoints, each with its own UUID-based URL (`/api/mcp/servers/{uuid}/sse`) and independent API key. Assign specific workflows to each server so different AI clients or teams see only the tools they need. Each named server supports the same auth methods (API key, Claude OAuth) and has its own Copy JSON and Add to Cursor shortcuts. Both endpoints support SSE transport (GET) and Streamable HTTP transport (POST).
 
 See also [Agent Architecture](./agent-architecture.md), [Agent Node](../nodes/agent-node.md), and [SSE Streaming](./sse-streaming.md).
 

--- a/frontend/src/docs/content/tabs/mcp-tab.md
+++ b/frontend/src/docs/content/tabs/mcp-tab.md
@@ -1,41 +1,81 @@
 # MCP Tab
 
-The **MCP** tab configures Model Context Protocol (MCP) integration. MCP lets external tools and data sources expose capabilities to [Agent](../nodes/agent-node.md) nodes.
+The **MCP** tab configures Model Context Protocol (MCP) integration. MCP lets AI clients (Claude, Cursor, and any MCP-compatible tool) call your Heym workflows as tools.
+
+Heym supports two modes: a **default server** that exposes all MCP-enabled workflows under a single endpoint, and **named servers** that give each logical group of workflows its own dedicated URL and API key.
 
 <video src="/features/showcase/mcp.webm" controls playsinline muted preload="metadata" style="width:100%;border-radius:12px;margin:16px 0"></video>
 <p class="github-video-link"><a href="../../../../public/features/showcase/mcp.webm">▶ Watch MCP demo</a></p>
 
-## MCP API Key
+## Default MCP Server
+
+The default server is always available at `{origin}/api/mcp/sse`. All workflows with MCP toggled on appear as tools here.
+
+### MCP API Key
 
 - The tab shows your MCP API key (masked)
 - **Regenerate** – Create a new API key if needed
 - Use this key when connecting Claude Desktop, Cursor, or other MCP clients to Heym
 
-## Connection Methods
+### Connection Methods
 
-- **API Key** – Use the MCP API key for programmatic connections. The tab can copy a ready-to-use JSON config and includes an **Add to Cursor** button for Cursor.
+- **API Key** – Use the MCP API key for programmatic connections. The tab can copy a ready-to-use JSON config and includes an **Add to Cursor** button for one-click Cursor setup.
 - **Claude** – The tab shows the MCP server URL and setup steps for Claude. Leave OAuth Client ID and Secret blank; Claude registers automatically and authenticates via Heym OAuth.
 
-## Workflow MCP Toggle
+### Workflow MCP Toggle
 
-Each workflow with an [Agent](../nodes/agent-node.md) node can expose its tools via MCP:
+Each workflow can be exposed as an MCP tool:
 
-- **Enable** – The workflow's tools become available to MCP clients
+- **Enable** – The workflow's tools become available to all clients connected to the default server
 - **Disable** – The workflow is not exposed
 
-Toggle MCP per workflow from the workflow list on this tab.
+Workflow cards show the description and a preview of input field names so you can see what each tool expects before enabling it.
 
-Workflow cards also show the workflow description and a preview of input field names so you can see what each exposed tool expects before enabling it.
+## Named MCP Servers
+
+Named servers let you segment workflows into isolated MCP endpoints. Each server has its own URL and API key, so different AI clients, teams, or use cases can connect to exactly the workflows they need.
+
+### Creating a Named Server
+
+1. Type a name in the input field at the bottom of the MCP tab (e.g. **CRM Tools**)
+2. Click **Create** — a new server card appears immediately
+3. Click the card to expand it
+
+### Per-Server Settings
+
+Each server card shows:
+
+| Setting | Description |
+|---------|-------------|
+| **SSE Endpoint** | Unique URL: `{origin}/api/mcp/servers/{uuid}/sse` |
+| **API Key** | Independent key; reveal with the eye icon, copy or regenerate as needed |
+| **How to connect** | **Copy JSON** copies the ready-to-paste MCP config; **Add to Cursor** installs it in one click |
+| **Assigned Workflows** | Toggle which of your workflows this server exposes |
+
+### Workflow Assignment
+
+Workflow assignment is per-server and independent of the default server toggle. A workflow can be enabled on the default server and on multiple named servers simultaneously, or on none.
+
+### Authentication
+
+Named servers support the same authentication methods as the default server:
+
+- **X-MCP-Key header** – Pass the server's API key directly (API clients, Cursor)
+- **Claude OAuth** – Add the server URL to Claude integrations; leave credentials blank and Claude registers via OAuth automatically
+- **Session token** – Issued during the SSE handshake; scoped to the specific server so tokens from one named server cannot access another
+
+### Deleting a Named Server
+
+Click the **X** icon on a server card header. Deletion removes the server and all its workflow assignments; workflows themselves are not affected.
 
 ## SSE Endpoint
 
-MCP clients connect to the Heym backend via Server-Sent Events (SSE). The endpoint is:
+| Server | Endpoint |
+|--------|----------|
+| Default | `{origin}/api/mcp/sse` |
+| Named | `{origin}/api/mcp/servers/{server-uuid}/sse` |
 
-```
-{origin}/api/mcp/sse
-```
-
-Claude uses OAuth 2.1 / PKCE for secure sign-in. API key clients can connect directly with the generated config snippet.
+Both endpoints support the SSE transport (GET, MCP spec 2024-11-05) and Streamable HTTP transport (POST, MCP spec 2025-03-26). Claude uses OAuth 2.1 / PKCE for secure sign-in on both.
 
 ## Related
 


### PR DESCRIPTION
- mcp-tab.md: restructure into Default MCP Server + Named MCP Servers
  sections; document server creation, per-server API key/URL/workflow
  assignment, auth methods, and both SSE transport modes
- features.md: expand MCP section to describe default vs named server
  modes, per-server endpoints, and Streamable HTTP transport support