### PR TITLE
[security] fix(workflows): enforce subworkflow access checks

### DIFF
--- a/backend/app/api/ai_assistant.py
+++ b/backend/app/api/ai_assistant.py
@@ -1221,7 +1221,7 @@ async def run_execute_workflow_tool(
     if not workflow.nodes:
         return json.dumps({"status": "error", "error": "Workflow has no nodes"})
 
-    workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+    workflow_cache = await collect_referenced_workflows(db, workflow.nodes, actor_user_id=user_id)
     credentials_context = await get_credentials_context(db, user_id)
 
     enriched_inputs = {

--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -590,7 +590,9 @@ async def call_mcp_tool(
         "body": arguments,
     }
 
-    workflow_cache = await collect_referenced_workflows(db, target_workflow.nodes)
+    workflow_cache = await collect_referenced_workflows(
+        db, target_workflow.nodes, actor_user_id=mcp_user.id
+    )
     credentials_context = await get_credentials_context_for_user(db, mcp_user.id)
     global_variables_context = await get_global_variables_context(db, mcp_user.id)
 
@@ -759,7 +761,9 @@ async def _dispatch_mcp_jsonrpc(
             "body": arguments,
         }
 
-        workflow_cache = await collect_referenced_workflows(db, target_workflow.nodes)
+        workflow_cache = await collect_referenced_workflows(
+            db, target_workflow.nodes, actor_user_id=mcp_user.id
+        )
         credentials_context = await get_credentials_context_for_user(db, mcp_user.id)
 
         execution_id = uuid.uuid4()

--- a/backend/app/api/mcp_servers.py
+++ b/backend/app/api/mcp_servers.py
@@ -449,7 +449,9 @@ async def _dispatch_named_server_jsonrpc(
             }
 
         enriched_inputs = {"headers": {}, "query": {}, "body": arguments}
-        workflow_cache = await collect_referenced_workflows(db, target_workflow.nodes)
+        workflow_cache = await collect_referenced_workflows(
+            db, target_workflow.nodes, actor_user_id=user.id
+        )
         credentials_context = await get_credentials_context_for_user(db, user.id)
         global_variables_context = await get_global_variables_context(db, user.id)
 

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -241,7 +241,9 @@ async def portal_execute(
         "body": execute_data.inputs,
     }
 
-    workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+    workflow_cache = await collect_referenced_workflows(
+        db, workflow.nodes, actor_user_id=workflow.owner_id
+    )
     credentials_context = await get_credentials_context(db, workflow.owner_id)
     global_variables_context = await get_global_variables_context(db, workflow.owner_id)
 
@@ -394,7 +396,9 @@ async def portal_execute_stream(
         "body": execute_data.inputs,
     }
 
-    workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+    workflow_cache = await collect_referenced_workflows(
+        db, workflow.nodes, actor_user_id=workflow.owner_id
+    )
     credentials_context = await get_credentials_context(db, workflow.owner_id)
     global_variables_context = await get_global_variables_context(db, workflow.owner_id)
     public_base_url = build_public_base_url(request)

--- a/backend/app/api/slack.py
+++ b/backend/app/api/slack.py
@@ -127,7 +127,9 @@ async def _execute_workflow_background(
                 logger.error("Workflow %s not found for Slack execution", workflow.id)
                 return
 
-            workflow_cache = await collect_referenced_workflows(db, fresh_workflow.nodes)
+            workflow_cache = await collect_referenced_workflows(
+                db, fresh_workflow.nodes, actor_user_id=fresh_workflow.owner_id
+            )
             credentials_context = await get_credentials_context(db, fresh_workflow.owner_id)
             global_variables_context = await get_global_variables_context(
                 db, fresh_workflow.owner_id

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -128,7 +128,9 @@ async def _execute_workflow_background(
                 logger.error("Workflow %s not found for Telegram execution", workflow.id)
                 return
 
-            workflow_cache = await collect_referenced_workflows(db, fresh_workflow.nodes)
+            workflow_cache = await collect_referenced_workflows(
+                db, fresh_workflow.nodes, actor_user_id=fresh_workflow.owner_id
+            )
             credentials_context = await get_credentials_context(db, fresh_workflow.owner_id)
             global_variables_context = await get_global_variables_context(
                 db, fresh_workflow.owner_id

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1931,10 +1931,55 @@ async def validate_workflow_auth(
         return
 
 
+async def _add_referenced_workflow_to_cache(
+    db: AsyncSession,
+    target_id: str,
+    collected: dict[str, dict],
+    actor_user_id: uuid.UUID | None,
+) -> None:
+    if not target_id or target_id in collected:
+        return
+
+    try:
+        target_uuid = uuid.UUID(target_id)
+    except ValueError:
+        return
+
+    result = await db.execute(select(Workflow).where(Workflow.id == target_uuid))
+    target_workflow = result.scalar_one_or_none()
+    if not target_workflow or not target_workflow.nodes:
+        return
+
+    if actor_user_id is not None and not await user_has_workflow_access(
+        db,
+        target_workflow,
+        actor_user_id,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Referenced workflow access denied",
+        )
+
+    input_fields = extract_input_fields_from_workflow(target_workflow)
+    collected[target_id] = {
+        "nodes": target_workflow.nodes,
+        "edges": target_workflow.edges,
+        "name": target_workflow.name or "",
+        "input_fields": [f.model_dump(by_alias=True) for f in input_fields],
+    }
+    await collect_referenced_workflows(
+        db,
+        target_workflow.nodes,
+        collected,
+        actor_user_id=actor_user_id,
+    )
+
+
 async def collect_referenced_workflows(
     db: AsyncSession,
     nodes: list[dict],
     collected: dict[str, dict] | None = None,
+    actor_user_id: uuid.UUID | None = None,
 ) -> dict[str, dict]:
     if collected is None:
         collected = {}
@@ -1942,43 +1987,11 @@ async def collect_referenced_workflows(
     for node in nodes:
         if node.get("type") == "execute":
             target_id = node.get("data", {}).get("executeWorkflowId", "")
-            if target_id and target_id not in collected:
-                try:
-                    result = await db.execute(
-                        select(Workflow).where(Workflow.id == uuid.UUID(target_id))
-                    )
-                    target_workflow = result.scalar_one_or_none()
-                    if target_workflow and target_workflow.nodes:
-                        input_fields = extract_input_fields_from_workflow(target_workflow)
-                        collected[target_id] = {
-                            "nodes": target_workflow.nodes,
-                            "edges": target_workflow.edges,
-                            "name": target_workflow.name or "",
-                            "input_fields": [f.model_dump(by_alias=True) for f in input_fields],
-                        }
-                        await collect_referenced_workflows(db, target_workflow.nodes, collected)
-                except Exception:
-                    pass
+            await _add_referenced_workflow_to_cache(db, target_id, collected, actor_user_id)
 
         if node.get("type") == "agent":
             for target_id in node.get("data", {}).get("subWorkflowIds") or []:
-                if target_id and target_id not in collected:
-                    try:
-                        result = await db.execute(
-                            select(Workflow).where(Workflow.id == uuid.UUID(target_id))
-                        )
-                        target_workflow = result.scalar_one_or_none()
-                        if target_workflow and target_workflow.nodes:
-                            input_fields = extract_input_fields_from_workflow(target_workflow)
-                            collected[target_id] = {
-                                "nodes": target_workflow.nodes,
-                                "edges": target_workflow.edges,
-                                "name": target_workflow.name or "",
-                                "input_fields": [f.model_dump(by_alias=True) for f in input_fields],
-                            }
-                            await collect_referenced_workflows(db, target_workflow.nodes, collected)
-                    except Exception:
-                        pass
+                await _add_referenced_workflow_to_cache(db, target_id, collected, actor_user_id)
 
     return collected
 
@@ -2171,7 +2184,9 @@ async def execute_workflow_endpoint(
             detail="Workflow has no nodes",
         )
 
-    workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+    workflow_cache = await collect_referenced_workflows(
+        db, workflow.nodes, actor_user_id=current_user.id if current_user else workflow.owner_id
+    )
 
     credentials_owner_id = current_user.id if current_user else workflow.owner_id
     credentials_context = await get_credentials_context(db, credentials_owner_id)
@@ -2729,7 +2744,9 @@ async def execute_workflow_stream(
             detail="Workflow has no nodes",
         )
 
-    workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+    workflow_cache = await collect_referenced_workflows(
+        db, workflow.nodes, actor_user_id=current_user.id if current_user else workflow.owner_id
+    )
 
     credentials_owner_id = current_user.id if current_user else workflow.owner_id
     credentials_context = await get_credentials_context(db, credentials_owner_id)

--- a/backend/app/services/cron_scheduler.py
+++ b/backend/app/services/cron_scheduler.py
@@ -146,7 +146,9 @@ class CronScheduler:
     async def _execute_workflow(self, db: AsyncSession, workflow: Workflow) -> None:
         logger.info("Executing workflow %s via cron trigger", workflow.id)
         try:
-            workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+            workflow_cache = await collect_referenced_workflows(
+                db, workflow.nodes, actor_user_id=workflow.owner_id
+            )
             credentials_context = await get_credentials_context(db, workflow.owner_id)
             global_variables_context = await get_global_variables_context(db, workflow.owner_id)
             enriched_inputs = {"triggered_by": "cron"}

--- a/backend/app/services/imap_trigger_service.py
+++ b/backend/app/services/imap_trigger_service.py
@@ -418,7 +418,9 @@ class ImapTriggerManager:
                 logger.warning("Workflow %s disappeared before IMAP execution", workflow.id)
                 return
 
-            workflow_cache = await collect_referenced_workflows(db, fresh_workflow.nodes)
+            workflow_cache = await collect_referenced_workflows(
+                db, fresh_workflow.nodes, actor_user_id=fresh_workflow.owner_id
+            )
             credentials_context = await get_credentials_context(db, fresh_workflow.owner_id)
             global_variables_context = await get_global_variables_context(
                 db, fresh_workflow.owner_id

--- a/backend/app/services/rabbitmq_consumer.py
+++ b/backend/app/services/rabbitmq_consumer.py
@@ -321,7 +321,9 @@ class RabbitMQConsumerManager:
                     await message.nack(requeue=True)
                     return
 
-                workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+                workflow_cache = await collect_referenced_workflows(
+                    db, workflow.nodes, actor_user_id=workflow.owner_id
+                )
                 credentials_context = await get_credentials_context(db, workflow.owner_id)
                 global_variables_context = await get_global_variables_context(db, workflow.owner_id)
 

--- a/backend/app/services/websocket_trigger_service.py
+++ b/backend/app/services/websocket_trigger_service.py
@@ -367,7 +367,9 @@ class WebSocketTriggerManager:
                 )
                 return
 
-            workflow_cache = await collect_referenced_workflows(db, workflow.nodes)
+            workflow_cache = await collect_referenced_workflows(
+                db, workflow.nodes, actor_user_id=workflow.owner_id
+            )
             credentials_context = await get_credentials_context(db, workflow.owner_id)
             global_variables_context = await get_global_variables_context(db, workflow.owner_id)
 

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -12,7 +12,12 @@ from fastapi import HTTPException, Request
 
 from app.api.ai_assistant import run_execute_workflow_tool
 from app.api.portal import portal_cancel_execution
-from app.api.workflows import execute_workflow_endpoint, execute_workflow_stream, parse_execute_body
+from app.api.workflows import (
+    collect_referenced_workflows,
+    execute_workflow_endpoint,
+    execute_workflow_stream,
+    parse_execute_body,
+)
 from app.db.models import DataTable, DataTableRow
 from app.services.workflow_executor import (
     ExecutionResult,
@@ -43,6 +48,109 @@ def make_request(
         "query_string": query_string,
     }
     return Request(scope, receive)
+
+
+class CollectReferencedWorkflowsAccessTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _result(value: object) -> MagicMock:
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = value
+        return result
+
+    async def test_execute_node_rejects_referenced_workflow_without_actor_access(self) -> None:
+        actor_id = uuid.uuid4()
+        victim_workflow_id = uuid.uuid4()
+        victim_workflow = SimpleNamespace(
+            id=victim_workflow_id,
+            owner_id=uuid.uuid4(),
+            name="victim",
+            nodes=[{"id": "start", "type": "manual", "data": {}}],
+            edges=[],
+        )
+        db = AsyncMock()
+        db.execute.side_effect = [
+            self._result(victim_workflow),
+            self._result(None),
+            self._result(None),
+        ]
+
+        with self.assertRaises(HTTPException) as ctx:
+            await collect_referenced_workflows(
+                db,
+                [
+                    {
+                        "id": "execute-1",
+                        "type": "execute",
+                        "data": {"executeWorkflowId": str(victim_workflow_id)},
+                    }
+                ],
+                actor_user_id=actor_id,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertEqual(ctx.exception.detail, "Referenced workflow access denied")
+
+    async def test_agent_subworkflow_rejects_referenced_workflow_without_actor_access(self) -> None:
+        actor_id = uuid.uuid4()
+        victim_workflow_id = uuid.uuid4()
+        victim_workflow = SimpleNamespace(
+            id=victim_workflow_id,
+            owner_id=uuid.uuid4(),
+            name="victim",
+            nodes=[{"id": "start", "type": "manual", "data": {}}],
+            edges=[],
+        )
+        db = AsyncMock()
+        db.execute.side_effect = [
+            self._result(victim_workflow),
+            self._result(None),
+            self._result(None),
+        ]
+
+        with self.assertRaises(HTTPException) as ctx:
+            await collect_referenced_workflows(
+                db,
+                [
+                    {
+                        "id": "agent-1",
+                        "type": "agent",
+                        "data": {"subWorkflowIds": [str(victim_workflow_id)]},
+                    }
+                ],
+                actor_user_id=actor_id,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertEqual(ctx.exception.detail, "Referenced workflow access denied")
+
+    async def test_actor_owned_referenced_workflow_is_cached(self) -> None:
+        actor_id = uuid.uuid4()
+        target_workflow_id = uuid.uuid4()
+        target_workflow = SimpleNamespace(
+            id=target_workflow_id,
+            owner_id=actor_id,
+            name="owned child",
+            nodes=[{"id": "start", "type": "manual", "data": {}}],
+            edges=[],
+        )
+        db = AsyncMock()
+        db.execute.return_value = self._result(target_workflow)
+
+        cache = await collect_referenced_workflows(
+            db,
+            [
+                {
+                    "id": "execute-1",
+                    "type": "execute",
+                    "data": {"executeWorkflowId": str(target_workflow_id)},
+                }
+            ],
+            actor_user_id=actor_id,
+        )
+
+        self.assertIn(str(target_workflow_id), cache)
+        self.assertEqual(cache[str(target_workflow_id)]["name"], "owned child")
+        self.assertEqual(cache[str(target_workflow_id)]["nodes"], target_workflow.nodes)
 
 
 class ParseExecuteBodyTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

This PR fixes a sub-workflow authorization gap in workflow execution. The root workflow execution path validated the workflow being invoked, but referenced execute-node and agent sub-workflow targets were loaded by UUID only and cached for execution without checking whether the actor was allowed to access each referenced workflow.

The patch threads an actor user id through referenced-workflow collection, checks access for every referenced workflow before caching it, and applies the same boundary across direct workflow execution, streaming execution, dashboard assistant execution, portal execution, MCP workflow execution, and background trigger executions.

## Security issues covered

| Issue | Severity | Affected surface | Fix |
| --- | --- | --- | --- |
| Cross-workflow sub-workflow authorization bypass | High | Execute nodes and agent `subWorkflowIds` that reference another workflow by UUID | Require actor access before referenced workflows enter the execution cache |

## Before this PR

- The execution endpoint validated access to the root workflow only.
- `collect_referenced_workflows()` loaded execute-node targets with `select(Workflow).where(Workflow.id == uuid.UUID(target_id))`.
- Agent `subWorkflowIds` used the same UUID-only lookup.
- Referenced workflows were cached and then executed by the workflow executor without a per-target access check.
- Unauthorized referenced workflows were not distinguished from authorized workflows before being added to the cache.

## After this PR

- `collect_referenced_workflows()` accepts an `actor_user_id` for access decisions.
- Every referenced execute-node or agent sub-workflow target must pass `user_has_workflow_access()` before it is cached.
- Unauthorized referenced workflows fail closed with `403 Forbidden`.
- Execution entry points pass the user or owner context that will execute the workflow.
- Regression tests cover both execute-node and agent sub-workflow references to workflows the actor cannot access.

## Why this matters

Workflow UUIDs are authorization-sensitive. If a user can create and execute their own workflow, and referenced workflows are loaded by UUID only, the user can make their workflow point at another user's workflow once they learn or obtain its id.

That can expose target workflow outputs and can also trigger workflow nodes with owner-intended side effects through an attacker-controlled root execution path.

## Attack flow

1. Attacker has an account and can create/execute a workflow they own.
2. Attacker learns or obtains a victim workflow UUID.
3. Attacker creates either:
   - an execute node with `data.executeWorkflowId` set to the victim UUID, or
   - an agent node with `data.subWorkflowIds` containing the victim UUID.
4. Attacker runs their own workflow.
5. The root workflow access check passes because the attacker owns the root workflow.
6. The referenced victim workflow is loaded by UUID and cached for execution.
7. The executor runs the referenced workflow and returns/stores sub-workflow outputs in the attacker-triggered execution path.

## Affected code

- `backend/app/api/workflows.py`
  - `collect_referenced_workflows()`
  - `execute_workflow_endpoint()`
  - `execute_workflow_stream()`
- Other execution entry points that build workflow caches:
  - `backend/app/api/ai_assistant.py`
  - `backend/app/api/portal.py`
  - `backend/app/api/mcp.py`
  - `backend/app/api/mcp_servers.py`
  - `backend/app/api/slack.py`
  - `backend/app/api/telegram.py`
  - `backend/app/services/cron_scheduler.py`
  - `backend/app/services/imap_trigger_service.py`
  - `backend/app/services/rabbitmq_consumer.py`
  - `backend/app/services/websocket_trigger_service.py`

## Root cause

- Root workflow authorization was treated as sufficient for execution.
- Referenced workflows crossed from user-controlled workflow JSON into privileged execution cache lookup without a per-target authorization predicate.
- The workflow cache trusted UUID references instead of reusing the existing owner/share/team-share access model for each target.

## CVSS assessment

- CVSS v3.1: 7.1 High
- Vector: `CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:L`
- Rationale: exploitation is network-reachable for an authenticated low-privilege user and requires no user interaction. The UUID knowledge prerequisite raises attack complexity. Successful exploitation can disclose referenced workflow outputs and can trigger workflow side effects, depending on the victim workflow's nodes.

## Safe reproduction steps

On vulnerable code:

1. Create user A and user B.
2. As user B, create a workflow that returns a recognizable output.
3. As user A, create a separate workflow with an execute node whose `executeWorkflowId` is user B's workflow id, or an agent node whose `subWorkflowIds` contains that id.
4. Execute user A's workflow.
5. Observe that the referenced user B workflow is loaded into the cache and can be executed without user A having owner/share/team-share access.

This PR adds focused unit coverage for both execute-node and agent sub-workflow reference rejection.

## Expected vulnerable behavior

A user who can execute their own workflow can cause a referenced workflow owned by another user to be loaded and executed by UUID, even when the user has no access to that referenced workflow.

## Changes in this PR

- Add `_add_referenced_workflow_to_cache()` to centralize referenced-workflow loading and access enforcement.
- Add `actor_user_id` to `collect_referenced_workflows()`.
- Reuse `user_has_workflow_access()` for referenced workflow authorization.
- Fail closed with `403 Forbidden` when a referenced workflow exists but is not accessible to the actor.
- Pass the appropriate actor/owner id from all workflow-cache-building execution paths.
- Add regression tests for execute-node and agent sub-workflow unauthorized references.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Authorization hardening | `backend/app/api/workflows.py` | Adds referenced-workflow access checks and passes actor ids from primary execution endpoints |
| Execution entry points | `backend/app/api/ai_assistant.py`, `backend/app/api/portal.py`, `backend/app/api/mcp.py`, `backend/app/api/mcp_servers.py`, `backend/app/api/slack.py`, `backend/app/api/telegram.py`, trigger services | Pass actor/owner context when collecting referenced workflows |
| Tests | `backend/tests/test_workflow_execution_api.py` | Adds execute-node and agent sub-workflow authorization regression tests |

## Maintainer impact

This preserves normal sub-workflow execution for workflows the actor owns or can access through existing individual/team share mechanisms. The behavior change is limited to references that point to workflows the actor is not allowed to access.

If a deployment intentionally relies on owner-run background triggers, those paths pass the workflow owner as the actor so owner-owned sub-workflow composition continues to work.

## Fix rationale

The referenced workflow cache is the boundary immediately before sub-workflow execution. Enforcing access there prevents both execute-node and agent sub-workflow references from bypassing the root workflow authorization check, and it keeps the fix centralized instead of relying on every caller to pre-filter node JSON.

## Type of change

- [x] Security fix
- [x] Bug fix
- [x] Tests added or updated
- [ ] Documentation update
- [ ] Breaking change

## Test plan

Commands run:

```bash
cd backend
ENCRYPTION_KEY=<64-byte-test-key> uv run pytest tests/test_workflow_execution_api.py::CollectReferencedWorkflowsAccessTests -q
```

```bash
ENCRYPTION_KEY=<64-byte-test-key> uv run pytest tests/test_workflow_execution_api.py tests/test_mcp_workflow_traces.py tests/test_cancellation_by_trigger.py tests/test_cron_scheduler.py tests/test_websocket_trigger_service.py tests/test_imap_trigger_service.py -q
```

```bash
ENCRYPTION_KEY=<64-byte-test-key> uv run ruff check app/api/workflows.py app/api/ai_assistant.py app/api/portal.py app/api/telegram.py app/api/slack.py app/api/mcp_servers.py app/api/mcp.py app/services/cron_scheduler.py app/services/websocket_trigger_service.py app/services/imap_trigger_service.py app/services/rabbitmq_consumer.py tests/test_workflow_execution_api.py
```

```bash
ENCRYPTION_KEY=<64-byte-test-key> ./run_tests.sh
```

Result:

- New focused authorization tests: 3 passed
- Related workflow/MCP/trigger tests: 60 passed
- Backend test suite: 741 passed
- Ruff check passed for touched files

Note: `./check.sh` could not complete in this local environment because `bun` is not installed (`./check.sh: line 10: bun: command not found`).

## Disclosure notes

This PR is intentionally bounded to sub-workflow authorization for referenced workflows. It does not claim broader changes to workflow UUID secrecy, sharing semantics, or node-level sandboxing.
