### PR TITLE
[security] fix(tools): harden Python tool sandbox

### DIFF
--- a/backend/app/services/python_tool_executor.py
+++ b/backend/app/services/python_tool_executor.py
@@ -4,6 +4,7 @@ Execute user-defined Python tool code with blacklist and timeout.
 
 import json
 import logging
+import os
 import subprocess
 import sys
 import tempfile
@@ -37,6 +38,21 @@ BLACKLIST_BUILTINS = frozenset(
         "staticmethod",
         "classmethod",
         "__build_class__",
+        "object",
+        "type",
+    }
+)
+
+FORBIDDEN_CODE_FRAGMENTS = frozenset(
+    {
+        "__",
+        "catch_warnings",
+        "_module",
+        "func_globals",
+        "f_globals",
+        "gi_frame",
+        "cr_frame",
+        "tb_frame",
     }
 )
 
@@ -87,7 +103,26 @@ import sys
 
 BLACKLIST_BUILTINS = set(json.loads("""__BLACKLIST_BUILTINS__"""))
 BLACKLIST_MODULES = set(json.loads("""__BLACKLIST_MODULES__"""))
+FORBIDDEN_CODE_FRAGMENTS = set(json.loads("""__FORBIDDEN_CODE_FRAGMENTS__"""))
 _real_import = __import__
+
+def _validate_code_safety(code):
+    import ast
+
+    for fragment in FORBIDDEN_CODE_FRAGMENTS:
+        if fragment in code:
+            raise ValueError("Tool code contains a restricted Python introspection primitive")
+
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
+            raise ValueError("Tool code may not access private Python attributes")
+        if isinstance(node, ast.Name) and node.id in BLACKLIST_BUILTINS:
+            raise ValueError(f"Builtin '{node.id}' is not allowed")
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            for fragment in FORBIDDEN_CODE_FRAGMENTS:
+                if fragment in node.value:
+                    raise ValueError("Tool code contains a restricted Python introspection primitive")
 
 def _safe_import(name, *args, **kwargs):
     root = name.split(".")[0]
@@ -109,6 +144,8 @@ def main():
     code = data["code"]
     function_name = data["function_name"]
     arguments = data["arguments"]
+
+    _validate_code_safety(code)
 
     safe_builtins = _create_safe_builtins()
     namespace = {"__builtins__": safe_builtins}
@@ -133,8 +170,11 @@ if __name__ == "__main__":
 def _get_runner_script() -> str:
     bl_builtins = json.dumps(list(BLACKLIST_BUILTINS))
     bl_modules = json.dumps(list(BLACKLIST_MODULES))
-    return _RUNNER_SCRIPT.replace("__BLACKLIST_BUILTINS__", bl_builtins).replace(
-        "__BLACKLIST_MODULES__", bl_modules
+    forbidden_fragments = json.dumps(list(FORBIDDEN_CODE_FRAGMENTS))
+    return (
+        _RUNNER_SCRIPT.replace("__BLACKLIST_BUILTINS__", bl_builtins)
+        .replace("__BLACKLIST_MODULES__", bl_modules)
+        .replace("__FORBIDDEN_CODE_FRAGMENTS__", forbidden_fragments)
     )
 
 
@@ -176,35 +216,44 @@ def execute_tool(
         f.write(runner)
         runner_path = f.name
 
+    safe_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONSAFEPATH": "1",
+    }
+
     try:
-        proc = subprocess.Popen(
-            [sys.executable, runner_path],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        try:
-            stdout, stderr = proc.communicate(
-                input=payload_json,
-                timeout=timeout_seconds,
+        with tempfile.TemporaryDirectory() as execution_cwd:
+            proc = subprocess.Popen(
+                [sys.executable, runner_path],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=execution_cwd,
+                env=safe_env,
             )
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            proc.wait()
-            raise TimeoutError(f"Tool execution timed out after {timeout_seconds} seconds")
+            try:
+                stdout, stderr = proc.communicate(
+                    input=payload_json,
+                    timeout=timeout_seconds,
+                )
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                raise TimeoutError(f"Tool execution timed out after {timeout_seconds} seconds")
 
-        if stderr:
-            logger.warning("Tool stderr: %s", stderr)
+            if stderr:
+                logger.warning("Tool stderr: %s", stderr)
 
-        try:
-            out = json.loads(stdout.strip())
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Tool output invalid: {stdout[:200]}") from e
+            try:
+                out = json.loads(stdout.strip())
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Tool output invalid: {stdout[:200]}") from e
 
-        if not out.get("success") and "error" in out:
-            raise ValueError(f"Tool error: {out['error']}")
+            if not out.get("success") and "error" in out:
+                raise ValueError(f"Tool error: {out['error']}")
 
-        return out.get("result")
+            return out.get("result")
     finally:
         Path(runner_path).unlink(missing_ok=True)

--- a/backend/tests/test_python_tool_executor.py
+++ b/backend/tests/test_python_tool_executor.py
@@ -1,0 +1,63 @@
+import os
+import unittest
+
+from app.services.python_tool_executor import execute_tool
+
+
+class PythonToolExecutorSecurityTest(unittest.TestCase):
+    def test_executes_basic_tool_code(self) -> None:
+        code = """
+def add(left: int, right: int) -> int:
+    return left + right
+"""
+
+        result = execute_tool(code, "add", {"left": 2, "right": 3}, 5)
+
+        self.assertEqual(result, 5)
+
+    def test_rejects_object_graph_import_bypass(self) -> None:
+        code = """
+def leak() -> dict:
+    cw = [
+        c for c in ().__class__.__base__.__subclasses__()
+        if c.__name__ == "catch_warnings"
+    ][0]
+    imp = cw()._module.__builtins__["__import__"]
+    os_mod = imp("os")
+    return {"secret": os_mod.environ.get("HEYM_PYTHON_TOOL_SECRET")}
+"""
+
+        os.environ["HEYM_PYTHON_TOOL_SECRET"] = "should-not-leak"
+        try:
+            with self.assertRaisesRegex(ValueError, "restricted Python introspection primitive"):
+                execute_tool(code, "leak", {}, 5)
+        finally:
+            os.environ.pop("HEYM_PYTHON_TOOL_SECRET", None)
+
+    def test_rejects_private_attribute_access(self) -> None:
+        code = """
+def probe(value):
+    return value._private
+"""
+
+        with self.assertRaisesRegex(ValueError, "private Python attributes"):
+            execute_tool(code, "probe", {"value": {"_private": "x"}}, 5)
+
+    def test_does_not_inherit_backend_environment(self) -> None:
+        code = """
+def read_env() -> str:
+    import json
+    return "ok"
+"""
+
+        os.environ["HEYM_PYTHON_TOOL_SECRET"] = "should-not-leak"
+        try:
+            result = execute_tool(code, "read_env", {}, 5)
+        finally:
+            os.environ.pop("HEYM_PYTHON_TOOL_SECRET", None)
+
+        self.assertEqual(result, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR hardens custom Python tool execution for AI Agent workflows. The previous runner relied on a blacklist of dangerous builtins and modules, but tool code could still use Python object-graph introspection to recover the real `__import__`, import blocked modules such as `os`, and execute host commands or read inherited backend environment variables.

The patch adds a pre-execution safety validation step for restricted introspection primitives, removes high-risk builtins that expose the Python object graph, and launches the tool subprocess with a scrubbed environment and isolated temporary working directory.

## Security issues covered

| Issue | Severity | Boundary |
| --- | --- | --- |
| Python tool sandbox escape through object-graph introspection | Critical | User-authored workflow tool code to backend host process |

## Before this PR

- Custom Python tool code was executed with `exec(code, namespace)` in a child Python process.
- The child runner removed direct access to builtins such as `open`, `eval`, `exec`, `getattr`, and `__import__`.
- The blacklist could be bypassed with introspection primitives such as `().__class__.__base__.__subclasses__()` and `warnings.catch_warnings`.
- The child process inherited the backend process environment and current working directory.

## After this PR

- Tool code is rejected before execution if it contains restricted Python introspection primitives such as dunder access, `catch_warnings`, frame/global escape handles, or private attribute access.
- `object` and `type` are no longer available to tool code as safe builtins.
- Python tool subprocesses run with a minimal environment instead of inheriting backend secrets.
- Python tool subprocesses run from a temporary execution directory rather than the backend working tree.
- Regression coverage confirms normal tool code still executes and the object-graph import bypass is rejected.

## Why this matters

Heym exposes custom Python tools as part of AI Agent workflow execution. A user who can create or edit a workflow can provide Python tool code. Because the runner attempted to sandbox that code, blocked modules such as `os` and `subprocess` should not be reachable from the tool body.

The object-graph bypass crossed that boundary. In a hosted or multi-user deployment, a malicious workflow tool could execute commands as the backend service user, read inherited secrets such as database or encryption settings, and use those secrets to affect other tenants or backend resources.

## Attack flow

1. Attacker creates or edits a workflow containing an AI Agent node with a custom Python tool.
2. The tool body uses Python object-graph introspection to locate `warnings.catch_warnings`.
3. From that object, the tool recovers the real builtins dictionary and unrestricted `__import__`.
4. The tool imports blocked modules such as `os`.
5. The tool reads backend environment variables or runs host commands.
6. The workflow execution returns the result through the normal tool output path.

## Affected code

- `backend/app/services/python_tool_executor.py`
  - `_RUNNER_SCRIPT` executed user-provided tool code with `exec(code, namespace)`.
  - `execute_tool()` launched the runner without an explicit environment or isolated working directory.
- Workflow execution reaches this runner through AI Agent tool execution paths.

## Root cause

- The sandbox relied on blacklist-based builtin/module filtering inside Python.
- Python object-graph introspection still exposed runtime objects that reference the original builtins.
- The child process inherited ambient backend process state, so a sandbox escape could immediately read secrets from the environment.

## CVSS assessment

- Issue: Python tool sandbox escape to backend command execution / secret exposure
- CVSS v3.1: 9.9 Critical
- Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H`
- Rationale: a low-privileged authenticated workflow author can cross from intended tool-code restrictions into backend host execution and inherited backend secret access. Scope is changed because backend process secrets and host resources can affect other users/tenants in shared deployments.

## Safe reproduction steps

Run this against the vulnerable code from the backend package context:

```bash
HEYM_PYTHON_TOOL_SECRET=topsecret python3 - <<'PY'
import sys
sys.path.insert(0, '/tmp/heym-audit/backend')
from app.services.python_tool_executor import execute_tool

code = '''
def leak():
    cw = [c for c in ().__class__.__base__.__subclasses__() if c.__name__ == 'catch_warnings'][0]
    imp = cw()._module.__builtins__['__import__']
    os = imp('os')
    return {
        'env': os.environ.get('HEYM_PYTHON_TOOL_SECRET'),
        'id': os.popen('id').read().strip(),
    }
'''
print(execute_tool(code, 'leak', {}, 5))
PY
```

## Expected vulnerable behavior

On vulnerable code, the tool returns the inherited secret and command output, for example:

```text
{'env': 'topsecret', 'id': 'uid=...'}
```

With this PR, the same payload is rejected before execution with:

```text
ValueError Tool error: Tool code contains a restricted Python introspection primitive
```

## Changes in this PR

- Adds restricted-fragment and AST validation before executing custom Python tool code.
- Rejects dunder/introspection primitives and private attribute access in tool code.
- Removes `object` and `type` from the safe builtin set.
- Launches the Python tool runner with a minimal explicit environment.
- Runs tool subprocesses from a fresh temporary directory.
- Adds focused regression tests for the sandbox escape and baseline safe tool execution.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Sandbox hardening | `backend/app/services/python_tool_executor.py` | Pre-execution validation, tighter builtin filtering, scrubbed env, isolated cwd |
| Tests | `backend/tests/test_python_tool_executor.py` | Regression tests for benign execution and blocked introspection escape |

## Maintainer impact

- Normal simple Python tools continue to run.
- Tool code that depends on private/dunder Python introspection is now rejected.
- The patch is intentionally conservative because private Python runtime access is not a safe boundary for untrusted workflow tool code.
- This does not claim to make Python a perfect in-process sandbox; stronger process/container isolation remains the best long-term boundary for untrusted code.

## Fix rationale

The immediate exploitable path was Python runtime introspection plus ambient process inheritance. Blocking private/dunder introspection removes the demonstrated escape primitive, while launching the child runner with a minimal environment reduces blast radius if another escape is found later.

## Type of change

- [x] Security fix
- [x] Regression tests
- [ ] Documentation update
- [ ] Dependency change

## Test plan

Executed locally:

```bash
cd /tmp/heym-audit/backend
uv run pytest tests/test_python_tool_executor.py -q
```

Result:

```text
4 passed
```

```bash
cd /tmp/heym-audit/backend
ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
  uv run pytest tests/test_workflow_execution_api.py tests/test_workflow_executor_branching.py tests/test_python_tool_executor.py -q
```

Result:

```text
40 passed, 4 warnings
```

```bash
cd /tmp/heym-audit
ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef ./run_tests.sh
```

Result:

```text
742 tests, 742 passed — All test suites passed.
```

```bash
cd /tmp/heym-audit/backend
uv run ruff check .
uv run ruff format --check .
```

Result:

```text
All checks passed!
221 files already formatted
```

`./check.sh` could not complete locally because the environment does not have `bun` installed:

```text
Running frontend checks...
./check.sh: line 10: bun: command not found
```

## Disclosure notes

This PR is bounded to the Python tool runner sandbox escape and inherited-process-state exposure. It does not address unrelated workflow authorization or file-upload findings, which are covered separately.