### PR TITLE
Fix chat compression fallback and tool UI

### DIFF
--- a/backend/app/api/ai_assistant.py
+++ b/backend/app/api/ai_assistant.py
@@ -1692,9 +1692,41 @@ async def get_teams_tool(
     return json.dumps({"teams": out, "count": len(out)}, default=str)
 
 
-MAX_DASHBOARD_CHAT_TOOL_ROUNDS = 33
+MAX_DASHBOARD_CHAT_TOOL_ROUNDS = 66
 
 IMAGE_PLACEHOLDER = "[image omitted - see workflow execution in UI]"
+
+
+def _is_context_overflow_error(exc: Exception) -> bool:
+    """Return true for provider errors that indicate context/token overflow."""
+    code = str(getattr(exc, "code", "") or "").lower()
+    if "context_length" in code or "context" in code and "exceed" in code:
+        return True
+
+    message = str(exc).lower()
+    has_context_signal = any(
+        fragment in message
+        for fragment in (
+            "context",
+            "token",
+            "input length",
+            "maximum length",
+            "too long",
+        )
+    )
+    has_overflow_signal = any(
+        fragment in message
+        for fragment in (
+            "exceed",
+            "exceeded",
+            "maximum",
+            "too many",
+            "too large",
+            "length",
+            "limit",
+        )
+    )
+    return has_context_signal and has_overflow_signal
 
 
 def _is_base64_image(s: str) -> bool:
@@ -2061,9 +2093,14 @@ async def stream_dashboard_chat(
     last_user_message = messages[-1].get("content", "") if messages else ""
     last_trace_request: dict[str, Any] | None = None
 
-    from app.services.context_compressor import _estimate_tokens, get_context_limit
+    from app.services.context_compressor import (
+        _estimate_tokens,
+        get_context_limit,
+        hard_compression_target_tokens,
+    )
 
     _context_limit = get_context_limit(model, client)
+    _hard_compression_target = hard_compression_target_tokens(_context_limit)
 
     def _emit_context(used_tokens: int) -> str:
         if system_prompt_parts is None:
@@ -2097,6 +2134,21 @@ async def stream_dashboard_chat(
             + "\n\n"
         )
 
+    def _emit_compressed(comp_info: dict[str, Any]) -> str:
+        return (
+            "data: "
+            + json.dumps(
+                {
+                    "type": "compressed",
+                    "messages_compressed": comp_info["messages_compressed"],
+                    "tokens_before": comp_info["tokens_before"],
+                    "tokens_after": comp_info["tokens_after"],
+                    "elapsed_ms": comp_info["elapsed_ms"],
+                }
+            )
+            + "\n\n"
+        )
+
     def _record_dashboard_run(status: str, elapsed_ms: float) -> None:
         record_run_history(
             user_id=user_id,
@@ -2117,7 +2169,10 @@ async def stream_dashboard_chat(
                 _record_dashboard_run("cancelled", round(elapsed_ms, 2))
                 return
             rounds += 1
-            from app.services.context_compressor import maybe_compress_messages
+            from app.services.context_compressor import (
+                hard_compress_messages,
+                maybe_compress_messages,
+            )
 
             messages_for_call = [{"role": "system", "content": system_prompt}] + messages_to_use
             compressed, comp_info = await maybe_compress_messages(
@@ -2128,26 +2183,52 @@ async def stream_dashboard_chat(
             )
             if comp_info is not None:
                 messages_to_use = [m for m in compressed if m.get("role") != "system"]
-                yield (
-                    "data: "
-                    + json.dumps(
-                        {
-                            "type": "compressed",
-                            "messages_compressed": comp_info["messages_compressed"],
-                            "tokens_before": comp_info["tokens_before"],
-                            "tokens_after": comp_info["tokens_after"],
-                            "elapsed_ms": comp_info["elapsed_ms"],
-                        }
-                    )
-                    + "\n\n"
+                yield _emit_compressed(comp_info)
+
+            messages_for_call = [{"role": "system", "content": system_prompt}] + messages_to_use
+            if _estimate_tokens(messages_for_call) >= _context_limit:
+                compressed, comp_info = await hard_compress_messages(
+                    messages_for_call,
+                    model=model,
+                    client=client,
+                    target_tokens=_hard_compression_target,
                 )
+                if comp_info is not None:
+                    messages_to_use = [m for m in compressed if m.get("role") != "system"]
+                    yield _emit_compressed(comp_info)
+
             kwargs = {
                 **base_kwargs,
                 "messages": [{"role": "system", "content": system_prompt}] + messages_to_use,
             }
             last_trace_request = {**kwargs, "messages": kwargs["messages"]}
             round_start = time.time()
-            response = await asyncio.to_thread(client.chat.completions.create, **kwargs)
+            try:
+                response = await asyncio.to_thread(client.chat.completions.create, **kwargs)
+            except Exception as exc:
+                if not _is_context_overflow_error(exc):
+                    raise
+                retry_target = max(
+                    2_000,
+                    min(_hard_compression_target, int(_context_limit * 0.5)),
+                )
+                compressed, comp_info = await hard_compress_messages(
+                    [{"role": "system", "content": system_prompt}] + messages_to_use,
+                    model=model,
+                    client=client,
+                    target_tokens=retry_target,
+                )
+                if comp_info is None:
+                    raise
+                messages_to_use = [m for m in compressed if m.get("role") != "system"]
+                yield _emit_compressed(comp_info)
+                kwargs = {
+                    **base_kwargs,
+                    "messages": [{"role": "system", "content": system_prompt}] + messages_to_use,
+                }
+                last_trace_request = {**kwargs, "messages": kwargs["messages"]}
+                round_start = time.time()
+                response = await asyncio.to_thread(client.chat.completions.create, **kwargs)
             round_elapsed_ms = (time.time() - round_start) * 1000
             usage = getattr(response, "usage", None)
             used_tokens = (

--- a/backend/app/services/context_compressor.py
+++ b/backend/app/services/context_compressor.py
@@ -14,6 +14,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_CHARS_PER_TOKEN = 4
+
 # Context window sizes by model name (substring match, case-insensitive).
 # Sources: OpenAI API docs, Anthropic API docs, Google AI Studio — 2025-06.
 # The provider API is always tried first; these are fallback values.
@@ -50,6 +52,8 @@ KNOWN_LIMITS: dict[str, int] = {
 }
 
 _DEFAULT_LIMIT = 128_000
+_HARD_COMPRESSION_TARGET_TOKENS = 16_000
+_HARD_COMPRESSION_MIN_TARGET_TOKENS = 2_000
 
 # Number of trailing messages (after the first user message) to always keep
 # intact when compressing a single-turn tool-calling loop.
@@ -59,7 +63,142 @@ _SINGLE_TURN_KEEP_TAIL = 4
 def _estimate_tokens(messages: list[dict[str, Any]]) -> int:
     """Estimate token count from messages using a 4-chars-per-token heuristic."""
     total_chars = sum(len(json.dumps(m, default=str)) for m in messages)
-    return total_chars // 4
+    return total_chars // _CHARS_PER_TOKEN
+
+
+def hard_compression_target_tokens(context_limit_tokens: int) -> int:
+    """Return a conservative target for hard context compression."""
+    if context_limit_tokens <= 0:
+        return _HARD_COMPRESSION_TARGET_TOKENS
+    return max(
+        _HARD_COMPRESSION_MIN_TARGET_TOKENS,
+        min(_HARD_COMPRESSION_TARGET_TOKENS, int(context_limit_tokens * 0.75)),
+    )
+
+
+def _chunk_text(text: str, max_chars: int) -> list[str]:
+    if len(text) <= max_chars:
+        return [text]
+
+    chunks: list[str] = []
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + max_chars)
+        if end < len(text):
+            split_at = text.rfind("\n\n", start, end)
+            if split_at > start + max_chars // 2:
+                end = split_at
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+        start = max(end, start + 1)
+    return chunks
+
+
+def _fit_text_to_token_budget(text: str, token_budget: int) -> str:
+    max_chars = max(1, token_budget * _CHARS_PER_TOKEN)
+    if len(text) <= max_chars:
+        return text
+
+    marker = "\n\n[... content omitted during hard context compression ...]\n\n"
+    available = max(1, max_chars - len(marker))
+    head_chars = max(1, int(available * 0.65))
+    tail_chars = max(1, available - head_chars)
+    return text[:head_chars].rstrip() + marker + text[-tail_chars:].lstrip()
+
+
+def _serialize_messages_for_summary(messages: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for index, message in enumerate(messages, start=1):
+        role = str(message.get("role") or "unknown")
+        parts.append(f"[{index}] role={role}")
+        if message.get("name"):
+            parts.append(f"name={message['name']}")
+        if message.get("tool_call_id"):
+            parts.append(f"tool_call_id={message['tool_call_id']}")
+        if message.get("tool_calls"):
+            parts.append("tool_calls=" + json.dumps(message["tool_calls"], default=str))
+        content = message.get("content", "")
+        if not isinstance(content, str):
+            content = json.dumps(content, default=str, ensure_ascii=False)
+        parts.append(content)
+    return "\n".join(parts)
+
+
+async def _summarize_text_chunk(
+    *,
+    text: str,
+    model: str,
+    client: Any,
+    max_tokens: int,
+    part_label: str,
+) -> str:
+    prompt = [
+        {
+            "role": "system",
+            "content": (
+                "You are compressing oversized chat context. Preserve the user's request, "
+                "important facts, tool results, IDs, decisions, and unresolved next steps. "
+                "Do not invent information."
+            ),
+        },
+        {
+            "role": "user",
+            "content": f"Compress this chat context section ({part_label}):\n\n{text}",
+        },
+    ]
+    try:
+        response = await asyncio.to_thread(
+            client.chat.completions.create,
+            model=model,
+            messages=prompt,
+            max_tokens=max_tokens,
+        )
+        summary = (response.choices[0].message.content or "").strip()
+        if summary:
+            return summary
+    except Exception as exc:
+        logger.warning("Hard context compression chunk failed: %s", exc)
+
+    return _fit_text_to_token_budget(text, max_tokens)
+
+
+async def _summarize_text_to_budget(
+    *,
+    text: str,
+    model: str,
+    client: Any,
+    target_tokens: int,
+) -> str:
+    chunk_token_budget = max(
+        1_000,
+        min(12_000, max(_HARD_COMPRESSION_MIN_TARGET_TOKENS, target_tokens - 2_000)),
+    )
+    max_chunk_chars = chunk_token_budget * _CHARS_PER_TOKEN
+    summary = text
+
+    for _pass_number in range(3):
+        chunks = _chunk_text(summary, max_chunk_chars)
+        if len(chunks) == 1 and len(summary) <= target_tokens * _CHARS_PER_TOKEN:
+            break
+
+        chunk_summary_tokens = max(256, min(1_024, target_tokens // max(len(chunks), 1)))
+        summaries: list[str] = []
+        for index, chunk in enumerate(chunks, start=1):
+            summaries.append(
+                await _summarize_text_chunk(
+                    text=chunk,
+                    model=model,
+                    client=client,
+                    max_tokens=chunk_summary_tokens,
+                    part_label=f"{index}/{len(chunks)}",
+                )
+            )
+        summary = "\n\n".join(summaries)
+        if len(summary) <= target_tokens * _CHARS_PER_TOKEN:
+            break
+
+    return _fit_text_to_token_budget(summary, target_tokens)
 
 
 def get_context_limit(model: str, client: Any) -> int:
@@ -212,3 +351,76 @@ async def maybe_compress_messages(
         "elapsed_ms": compress_elapsed_ms,
     }
     return result_messages, info
+
+
+async def hard_compress_messages(
+    messages: list[dict[str, Any]],
+    model: str,
+    client: Any,
+    target_tokens: int = _HARD_COMPRESSION_TARGET_TOKENS,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Aggressively collapse all non-system context into one compact user message.
+
+    This is used as a last-resort fallback when normal middle-message compression
+    cannot make the request fit, such as a single oversized first user message.
+    It intentionally does not preserve user/tool messages verbatim.
+    """
+    non_system = [message for message in messages if message.get("role") != "system"]
+    if not non_system:
+        return messages, None
+
+    compress_start = time.time()
+    tokens_before = _estimate_tokens(messages)
+    system_msg = next((message for message in messages if message.get("role") == "system"), None)
+    system_tokens = _estimate_tokens([system_msg]) if system_msg is not None else 0
+    summary_token_budget = max(
+        500,
+        target_tokens - system_tokens - 250,
+    )
+
+    serialized = _serialize_messages_for_summary(non_system)
+    summary = await _summarize_text_to_budget(
+        text=serialized,
+        model=model,
+        client=client,
+        target_tokens=summary_token_budget,
+    )
+    content = (
+        f"[Context hard-compressed - {len(non_system)} messages summarized to fit the "
+        "model limit]\n"
+        f"{_fit_text_to_token_budget(summary, summary_token_budget)}"
+    )
+
+    result_messages: list[dict[str, Any]] = []
+    if system_msg is not None:
+        result_messages.append(system_msg)
+    result_messages.append({"role": "user", "content": content})
+
+    tokens_after = _estimate_tokens(result_messages)
+    if tokens_after > target_tokens:
+        overflow_budget = max(250, summary_token_budget - (tokens_after - target_tokens) - 250)
+        result_messages[-1]["content"] = (
+            f"[Context hard-compressed - {len(non_system)} messages summarized to fit the "
+            "model limit]\n"
+            f"{_fit_text_to_token_budget(summary, overflow_budget)}"
+        )
+        tokens_after = _estimate_tokens(result_messages)
+
+    elapsed_ms = round((time.time() - compress_start) * 1000, 2)
+    logger.info(
+        "Hard context compressed: %d messages -> %d messages, ~%d -> ~%d tokens",
+        len(messages),
+        len(result_messages),
+        tokens_before,
+        tokens_after,
+    )
+
+    return result_messages, {
+        "messages_compressed": len(non_system),
+        "messages_before_count": len(messages),
+        "messages_after_count": len(result_messages),
+        "tokens_before": tokens_before,
+        "tokens_after": tokens_after,
+        "elapsed_ms": elapsed_ms,
+        "mode": "hard",
+    }

--- a/backend/tests/test_context_compressor.py
+++ b/backend/tests/test_context_compressor.py
@@ -261,6 +261,52 @@ class TestMaybeCompressMessages(unittest.IsolatedAsyncioTestCase):
         assert info is not None
         self.assertEqual(info["messages_compressed"], 4)
 
+    async def test_hard_compresses_single_oversized_user_message(self) -> None:
+        from app.services.context_compressor import hard_compress_messages
+
+        msgs = [
+            {"role": "system", "content": "System."},
+            {"role": "user", "content": "large input " * 8000},
+        ]
+        client = self._make_mock_client("Compressed request summary.")
+
+        result, info = await hard_compress_messages(
+            msgs,
+            model="gpt-4o",
+            client=client,
+            target_tokens=2_000,
+        )
+
+        self.assertIsNotNone(info)
+        assert info is not None
+        self.assertEqual(info["mode"], "hard")
+        self.assertEqual(info["messages_compressed"], 1)
+        self.assertEqual(result[0], msgs[0])
+        self.assertEqual(result[1]["role"], "user")
+        self.assertIn("Context hard-compressed", result[1]["content"])
+        self.assertNotEqual(result[1]["content"], msgs[1]["content"])
+
+    async def test_hard_compression_falls_back_to_excerpt_when_llm_fails(self) -> None:
+        from app.services.context_compressor import hard_compress_messages
+
+        msgs = [
+            {"role": "system", "content": "System."},
+            {"role": "user", "content": "oversized " * 5000},
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = Exception("LLM error")
+
+        result, info = await hard_compress_messages(
+            msgs,
+            model="gpt-4o",
+            client=mock_client,
+            target_tokens=2_000,
+        )
+
+        self.assertIsNotNone(info)
+        self.assertEqual(result[1]["role"], "user")
+        self.assertIn("Context hard-compressed", result[1]["content"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_dashboard_chat_api.py
+++ b/backend/tests/test_dashboard_chat_api.py
@@ -1036,6 +1036,69 @@ class DashboardChatCompressionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('"messages_compressed": 18', joined)
         self.assertIn('"tokens_before": 98000', joined)
 
+    async def test_stream_retries_context_overflow_with_hard_compression(self) -> None:
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        final_msg = MagicMock()
+        final_msg.content = "ok"
+        final_msg.tool_calls = None
+        response = MagicMock()
+        response.choices = [MagicMock(message=final_msg)]
+        response.usage = MagicMock(prompt_tokens=12, completion_tokens=3, total_tokens=15)
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.side_effect = [
+            Exception("maximum context length exceeded"),
+            response,
+        ]
+        hard_compressed = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "[Context hard-compressed]\nsummary"},
+        ]
+        hard_info = {
+            "messages_compressed": 1,
+            "messages_before_count": 2,
+            "messages_after_count": 2,
+            "tokens_before": 18_000,
+            "tokens_after": 1_200,
+            "elapsed_ms": 55.0,
+            "mode": "hard",
+        }
+
+        with (
+            patch("app.api.ai_assistant.record_run_history"),
+            patch(
+                "app.services.context_compressor.maybe_compress_messages",
+                new=AsyncMock(return_value=([], None)),
+            ),
+            patch(
+                "app.services.context_compressor.hard_compress_messages",
+                new=AsyncMock(return_value=(hard_compressed, hard_info)),
+            ) as hard_compress,
+        ):
+            chunks = _normalize_chunks(
+                [
+                    chunk
+                    async for chunk in stream_dashboard_chat(
+                        fake_client,
+                        "gpt-4o-mini",
+                        "system",
+                        [{"role": "user", "content": "large input"}],
+                        AsyncMock(),
+                        user,
+                        "OpenAI",
+                        "http://localhost",
+                    )
+                ]
+            )
+
+        joined = "".join(chunks)
+        self.assertIn('"type": "compressed"', joined)
+        self.assertIn('"tokens_after": 1200', joined)
+        self.assertIn('"type": "content"', joined)
+        hard_compress.assert_awaited_once()
+        retry_messages = fake_client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        self.assertEqual(retry_messages[-1]["content"], "[Context hard-compressed]\nsummary")
+
 
 class ContextSummaryEndpointTests(unittest.IsolatedAsyncioTestCase):
     async def test_get_context_summary_returns_breakdown(self) -> None:

--- a/frontend/src/components/Chat/ChatConversation.vue
+++ b/frontend/src/components/Chat/ChatConversation.vue
@@ -15,6 +15,7 @@ import {
   MicOff,
   Paperclip,
   Pencil,
+  TriangleAlert,
   X,
 } from "lucide-vue-next";
 import { marked } from "marked";
@@ -219,6 +220,16 @@ watch(
   () => streamState.value.content,
   () => {
     if (!isThisConvStreaming.value) return;
+    nextTick(() => {
+      scrollToBottom();
+      updateMessageScrollbar();
+    });
+  },
+);
+
+watch(
+  () => streamState.value.error,
+  () => {
     nextTick(() => {
       scrollToBottom();
       updateMessageScrollbar();
@@ -1096,6 +1107,23 @@ onUnmounted(() => {
                 />
               </div>
             </div>
+          </div>
+        </div>
+
+        <div
+          v-if="streamState.error"
+          class="flex gap-3 justify-start"
+        >
+          <div class="w-7 h-7 rounded-full bg-destructive/10 flex items-center justify-center shrink-0 mt-0.5">
+            <TriangleAlert class="w-4 h-4 text-destructive" />
+          </div>
+          <div class="max-w-[72%] rounded-2xl rounded-tl-sm border border-destructive/30 bg-destructive/10 px-4 py-2.5 text-sm leading-relaxed text-destructive break-words">
+            <p class="font-medium">
+              Chat error
+            </p>
+            <p class="mt-1 whitespace-pre-wrap">
+              {{ streamState.error }}
+            </p>
           </div>
         </div>
 

--- a/frontend/src/components/Chat/ChatToolCall.vue
+++ b/frontend/src/components/Chat/ChatToolCall.vue
@@ -8,9 +8,9 @@ interface Props {
   toolCall: ToolCall;
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 
-const isOpen = ref(props.toolCall.status === "running");
+const isOpen = ref(false);
 
 function toggle(): void {
   isOpen.value = !isOpen.value;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2518,7 +2518,17 @@ export const chatApi = {
           const parsed = JSON.parse(line.slice(6));
           if (parsed.type === "content") onChunk(parsed.text);
           else if (parsed.type === "done") { onDone(); reading = false; break; }
-          else if (parsed.type === "error") onError(parsed.text);
+          else if (parsed.type === "error") {
+            let message = "Dashboard chat failed";
+            if (typeof parsed.text === "string") {
+              message = parsed.text;
+            } else if (typeof parsed.message === "string") {
+              message = parsed.message;
+            }
+            onError(message);
+            reading = false;
+            break;
+          }
           else if (parsed.type === "tool_start" && typeof parsed.id === "string") {
             onToolStart?.({
               id: parsed.id,

--- a/frontend/src/stores/chat.ts
+++ b/frontend/src/stores/chat.ts
@@ -39,6 +39,7 @@ export const useChatStore = defineStore("chat", () => {
     toolCalls: ToolCall[];
     contextUsage: ContextUsage | null;
     workflowPreview: WorkflowPreview | null;
+    error: string | null;
     isStreaming: boolean;
   }
   const EMPTY_STREAM_STATE: StreamState = Object.freeze({
@@ -47,6 +48,7 @@ export const useChatStore = defineStore("chat", () => {
     toolCalls: [],
     contextUsage: null,
     workflowPreview: null,
+    error: null,
     isStreaming: false,
   }) as StreamState;
   const streamStatesByConv = ref<Record<string, StreamState>>({});
@@ -69,6 +71,7 @@ export const useChatStore = defineStore("chat", () => {
       toolCalls: [],
       contextUsage: null,
       workflowPreview: null,
+      error: null,
       isStreaming: false,
     };
     streamStatesByConv.value = {
@@ -310,6 +313,7 @@ export const useChatStore = defineStore("chat", () => {
       toolCalls: [],
       contextUsage: null,
       workflowPreview: null,
+      error: null,
       isStreaming: true,
     });
 
@@ -340,12 +344,9 @@ export const useChatStore = defineStore("chat", () => {
       toolCalls: [],
       contextUsage: null,
       workflowPreview: null,
+      error: null,
       isStreaming: true,
     });
-
-    function clearStreamingFlag(): void {
-      _setStreamState(conversationId, { isStreaming: false });
-    }
 
     try {
       await chatApi.subscribeStream(
@@ -385,8 +386,9 @@ export const useChatStore = defineStore("chat", () => {
           _refreshConversationTimestamp(conversationId);
           if (hasContent) _playDing();
         },
-        (_err) => {
-          clearStreamingFlag();
+        (message) => {
+          const cleanMessage = message.trim() || "Dashboard chat failed";
+          _setStreamState(conversationId, { error: cleanMessage, isStreaming: false });
           _patchConversationFlag(conversationId, "is_running", false);
         },
         (payload) => {
@@ -449,8 +451,11 @@ export const useChatStore = defineStore("chat", () => {
         controller.signal,
       );
     } catch {
-      clearStreamingFlag();
       if (!controller.signal.aborted) {
+        _setStreamState(conversationId, {
+          error: "Dashboard chat failed",
+          isStreaming: false,
+        });
         _patchConversationFlag(conversationId, "is_running", false);
       }
     } finally {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -86,4 +86,4 @@ export type SSEChunk =
   | { type: 'workflow_created'; workflow: WorkflowPreview }
   | { type: 'title'; title: string }
   | { type: 'done' }
-  | { type: 'error'; text: string }
+  | { type: 'error'; text?: string; message?: string }


### PR DESCRIPTION
## Summary
- add hard context compression fallback for oversized chat context and context-limit retry
- keep chat tool call details collapsed by default and double dashboard chat tool rounds
- show stream errors in the chat UI

## Tests
- ./check.sh