### PR TITLE
fix: parameterize node_id lookup to prevent SQL injection in webhook handlers

### DIFF
--- a/backend/app/api/slack.py
+++ b/backend/app/api/slack.py
@@ -3,11 +3,10 @@
 Handles URL verification challenge and routes events to workflow execution.
 """
 
-import json
-
 import asyncio
 import hashlib
 import hmac
+import json
 import logging
 import time
 import uuid
@@ -82,7 +81,7 @@ async def _find_workflow_by_node_id(
     """Use JSONB containment to find the workflow containing this node_id."""
     result = await db.execute(
         select(Workflow).where(
-            text("nodes::jsonb @> :node_filter::jsonb").bindparams(
+            text("nodes::jsonb @> (:node_filter)::jsonb").bindparams(
                 node_filter=json.dumps([{"id": node_id}])
             )
         )

--- a/backend/app/api/slack.py
+++ b/backend/app/api/slack.py
@@ -3,6 +3,8 @@
 Handles URL verification challenge and routes events to workflow execution.
 """
 
+import json
+
 import asyncio
 import hashlib
 import hmac
@@ -78,9 +80,12 @@ async def _find_workflow_by_node_id(
     node_id: str,
 ) -> Workflow | None:
     """Use JSONB containment to find the workflow containing this node_id."""
-    safe_node_id = node_id.replace("'", "").replace('"', "")
     result = await db.execute(
-        select(Workflow).where(text(f'nodes::jsonb @> \'[{{"id": "{safe_node_id}"}}]\'::jsonb'))
+        select(Workflow).where(
+            text("nodes::jsonb @> :node_filter::jsonb").bindparams(
+                node_filter=json.dumps([{"id": node_id}])
+            )
+        )
     )
     return result.scalar_one_or_none()
 

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import hmac
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -74,9 +75,12 @@ async def _find_workflow_by_node_id(
     node_id: str,
 ) -> Workflow | None:
     """Use JSONB containment to find the workflow containing this node_id."""
-    safe_node_id = node_id.replace("'", "").replace('"', "")
     result = await db.execute(
-        select(Workflow).where(text(f'nodes::jsonb @> \'[{{"id": "{safe_node_id}"}}]\'::jsonb'))
+        select(Workflow).where(
+            text("nodes::jsonb @> :node_filter::jsonb").bindparams(
+                node_filter=json.dumps([{"id": node_id}])
+            )
+        )
     )
     return result.scalar_one_or_none()
 

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -77,7 +77,7 @@ async def _find_workflow_by_node_id(
     """Use JSONB containment to find the workflow containing this node_id."""
     result = await db.execute(
         select(Workflow).where(
-            text("nodes::jsonb @> :node_filter::jsonb").bindparams(
+            text("nodes::jsonb @> (:node_filter)::jsonb").bindparams(
                 node_filter=json.dumps([{"id": node_id}])
             )
         )

--- a/backend/tests/test_find_workflow_by_node_id.py
+++ b/backend/tests/test_find_workflow_by_node_id.py
@@ -3,8 +3,6 @@
 import json
 import unittest
 
-from sqlalchemy import text
-
 
 class _FakeResult:
     """Minimal async-compatible result for capturing executed statements."""

--- a/backend/tests/test_find_workflow_by_node_id.py
+++ b/backend/tests/test_find_workflow_by_node_id.py
@@ -1,0 +1,68 @@
+"""Tests for _find_workflow_by_node_id parameterized query in Slack and Telegram webhooks."""
+
+import json
+import unittest
+import uuid
+from unittest.mock import AsyncMock, Mock, patch
+
+from sqlalchemy import text
+
+
+class TestFindWorkflowByNodeId(unittest.TestCase):
+    """Verify _find_workflow_by_node_id uses proper parameterized JSONB containment."""
+
+    def test_bind_param_uses_parenthesized_cast(self):
+        """The SQL text must use (:node_filter)::jsonb, not :node_filter::jsonb.
+
+        SQLAlchemy's bind-param parser treats the trailing 'r' in ':node_filter::jsonb'
+        as part of the parameter name (node_filte), causing ArgumentError at runtime.
+        Wrapping in parens — (:node_filter)::jsonb — disambiguates correctly.
+        """
+        from app.api.slack import _find_workflow_by_node_id
+
+        # Inspect the text() clause by calling the function with a mock db
+        # and capturing the select() argument passed to db.execute
+        captured_sql = None
+
+        class FakeResult:
+            def scalar_one_or_none(self):
+                return None
+
+        async def capture_execute(stmt):
+            nonlocal captured_sql
+            captured_sql = stmt
+            return FakeResult()
+
+        db = AsyncMock()
+        db.execute = capture_execute
+
+        import asyncio
+
+        asyncio.get_event_loop().run_until_complete(
+            _find_workflow_by_node_id(db, "test-node-id")
+        )
+
+        # The compiled string should contain the parenthesized cast
+        compiled = str(captured_sql)
+        assert "(:node_filter)" in compiled or "node_filter" in compiled, (
+            f"Expected parenthesized bind param in compiled SQL, got: {compiled}"
+        )
+
+    def test_node_filter_value_is_valid_json(self):
+        """The node_filter bind value must be valid JSON: [{\"id\": \"<node_id>\"}]."""
+        node_id = "my-test-node"
+        filter_value = json.dumps([{"id": node_id}])
+        parsed = json.loads(filter_value)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == node_id
+
+    def test_node_id_special_chars_are_escaped(self):
+        """Characters like quotes and backslashes in node_id stay inside the JSON value."""
+        node_id = 'node"; DROP TABLE workflows;--'
+        filter_value = json.dumps([{"id": node_id}])
+        parsed = json.loads(filter_value)
+        # json.dumps escapes the inner quotes, so the value is a single JSON string
+        assert parsed[0]["id"] == node_id
+        # The serialized form should not contain raw SQL-breaking sequences
+        assert "DROP TABLE" in filter_value  # it's inside a JSON string, safe

--- a/backend/tests/test_find_workflow_by_node_id.py
+++ b/backend/tests/test_find_workflow_by_node_id.py
@@ -2,16 +2,21 @@
 
 import json
 import unittest
-import uuid
-from unittest.mock import AsyncMock, Mock, patch
 
 from sqlalchemy import text
 
 
-class TestFindWorkflowByNodeId(unittest.TestCase):
-    """Verify _find_workflow_by_node_id uses proper parameterized JSONB containment."""
+class _FakeResult:
+    """Minimal async-compatible result for capturing executed statements."""
 
-    def test_bind_param_uses_parenthesized_cast(self):
+    def scalar_one_or_none(self):
+        return None
+
+
+class TestSlackFindWorkflowByNodeId(unittest.IsolatedAsyncioTestCase):
+    """Verify _find_workflow_by_node_id in the Slack webhook uses proper parameterized JSONB containment."""
+
+    async def test_slack_bind_param_uses_parenthesized_cast(self):
         """The SQL text must use (:node_filter)::jsonb, not :node_filter::jsonb.
 
         SQLAlchemy's bind-param parser treats the trailing 'r' in ':node_filter::jsonb'
@@ -20,42 +25,106 @@ class TestFindWorkflowByNodeId(unittest.TestCase):
         """
         from app.api.slack import _find_workflow_by_node_id
 
-        # Inspect the text() clause by calling the function with a mock db
-        # and capturing the select() argument passed to db.execute
         captured_sql = None
-
-        class FakeResult:
-            def scalar_one_or_none(self):
-                return None
 
         async def capture_execute(stmt):
             nonlocal captured_sql
             captured_sql = stmt
-            return FakeResult()
+            return _FakeResult()
+
+        from unittest.mock import AsyncMock
 
         db = AsyncMock()
         db.execute = capture_execute
 
-        import asyncio
+        await _find_workflow_by_node_id(db, "test-node-id")
 
-        asyncio.get_event_loop().run_until_complete(
-            _find_workflow_by_node_id(db, "test-node-id")
-        )
-
-        # The compiled string should contain the parenthesized cast
         compiled = str(captured_sql)
-        assert "(:node_filter)" in compiled or "node_filter" in compiled, (
+        # The parenthesized cast must appear in the compiled output
+        assert "(:node_filter)" in compiled, (
             f"Expected parenthesized bind param in compiled SQL, got: {compiled}"
         )
 
-    def test_node_filter_value_is_valid_json(self):
-        """The node_filter bind value must be valid JSON: [{\"id\": \"<node_id>\"}]."""
+    async def test_slack_node_filter_value_is_valid_json(self):
+        """The node_filter bind value must be valid JSON: [{"id": "<node_id>"}]."""
+        from app.api.slack import _find_workflow_by_node_id
+
+        captured_params = None
+
+        async def capture_execute(stmt):
+            nonlocal captured_params
+            captured_params = stmt.compile().params
+            return _FakeResult()
+
+        from unittest.mock import AsyncMock
+
+        db = AsyncMock()
+        db.execute = capture_execute
+
         node_id = "my-test-node"
-        filter_value = json.dumps([{"id": node_id}])
+        await _find_workflow_by_node_id(db, node_id)
+
+        filter_value = captured_params["node_filter"]
         parsed = json.loads(filter_value)
         assert isinstance(parsed, list)
         assert len(parsed) == 1
         assert parsed[0]["id"] == node_id
+
+
+class TestTelegramFindWorkflowByNodeId(unittest.IsolatedAsyncioTestCase):
+    """Verify _find_workflow_by_node_id in the Telegram webhook uses proper parameterized JSONB containment."""
+
+    async def test_telegram_bind_param_uses_parenthesized_cast(self):
+        """Same parenthesized-cast check for the Telegram handler."""
+        from app.api.telegram import _find_workflow_by_node_id
+
+        captured_sql = None
+
+        async def capture_execute(stmt):
+            nonlocal captured_sql
+            captured_sql = stmt
+            return _FakeResult()
+
+        from unittest.mock import AsyncMock
+
+        db = AsyncMock()
+        db.execute = capture_execute
+
+        await _find_workflow_by_node_id(db, "test-node-id")
+
+        compiled = str(captured_sql)
+        assert "(:node_filter)" in compiled, (
+            f"Expected parenthesized bind param in compiled SQL, got: {compiled}"
+        )
+
+    async def test_telegram_node_filter_value_is_valid_json(self):
+        """The node_filter bind value for Telegram must be valid JSON."""
+        from app.api.telegram import _find_workflow_by_node_id
+
+        captured_params = None
+
+        async def capture_execute(stmt):
+            nonlocal captured_params
+            captured_params = stmt.compile().params
+            return _FakeResult()
+
+        from unittest.mock import AsyncMock
+
+        db = AsyncMock()
+        db.execute = capture_execute
+
+        node_id = "my-test-node"
+        await _find_workflow_by_node_id(db, node_id)
+
+        filter_value = captured_params["node_filter"]
+        parsed = json.loads(filter_value)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == node_id
+
+
+class TestNodeIdSpecialChars(unittest.TestCase):
+    """Verify that special characters in node_id are safely encoded inside JSON values."""
 
     def test_node_id_special_chars_are_escaped(self):
         """Characters like quotes and backslashes in node_id stay inside the JSON value."""


### PR DESCRIPTION
## Problem

`backend/app/api/slack.py:77` and `backend/app/api/telegram.py:73` look up the workflow for an incoming webhook by manually constructing a raw SQL fragment that interpolates the caller-supplied `node_id` path parameter into a JSON literal via f-string. The existing code strips single and double quotes from `node_id` before interpolation, so a clean SQL-string breakout could not be validated. However, hand-building SQL fragments this way is fragile and not idiomatic.

## Why change it (defense-in-depth / input robustness)

**Location:** `backend/app/api/slack.py:77`, `backend/app/api/telegram.py:73`

Both handlers used:

```python
query = text(f"SELECT ... WHERE nodes::jsonb @> '[{{\"id\": \"{node_id}\"}}]'::jsonb")
```

Relying on manual sanitization (stripping quotes) to build a SQL/JSON fragment is brittle:

- It couples query correctness to an ad-hoc character-stripping step that is easy to break in future edits.
- Inputs that are not quote-related — e.g. backslashes or other escape sequences — can still produce invalid JSON or runtime errors rather than a clean lookup.
- It is harder to read and reason about than a bound parameter.

This is a defense-in-depth / robustness improvement, not a fix for a confirmed exploitable injection. Parameter binding removes the fragile manual sanitization and lets the database driver handle escaping.

## Fix

Replace the f-string interpolation with a proper parameterized query using SQLAlchemy's `bindparams`:

```python
text("nodes::jsonb @> (:node_filter)::jsonb").bindparams(
    node_filter=json.dumps([{"id": node_id}])
)
```

`json.dumps` produces correctly-escaped JSON, and the bind parameter ensures the value is never interpolated into the SQL string. The parenthesized cast `(:node_filter)::jsonb` is required because SQLAlchemy's bind-param parser would otherwise consume the trailing `::jsonb` as part of the parameter name.

Both the Slack and Telegram handlers now share the same safe, idiomatic pattern.

## Steps to reproduce (behavior before fix)

1. Send a webhook POST to the Slack or Telegram handler with a crafted `node_id` path parameter containing characters not handled by the quote-stripping (e.g. backslashes / escape sequences).
2. Observe that the manually-built JSON fragment can become malformed, producing invalid JSON / query errors rather than a clean lookup.
3. With the parameterized query, the same input is safely encoded as a JSON string value and the lookup behaves correctly.

## Test Plan

- [x] Parenthesized cast `(:node_filter)` appears in compiled SQL for both Slack and Telegram handlers
- [x] The `node_filter` bind value is valid JSON matching `[{"id": "<node_id>"}]`
- [x] Special characters in `node_id` (quotes, semicolons, SQL keywords, backslashes) are safely encoded inside the JSON string value
- [x] `ruff check` and `ruff format` pass
- [x] Tests use `IsolatedAsyncioTestCase` (compatible with Python ≥ 3.14)