### PR TITLE
feat: add Jungle Grid MCP integration

### DIFF
--- a/backend/alembic/versions/074_add_jungle_grid_credential_type.py
+++ b/backend/alembic/versions/074_add_jungle_grid_credential_type.py
@@ -1,0 +1,22 @@
+"""add jungle grid credential type
+
+Revision ID: 074
+Revises: 073
+Create Date: 2026-06-01
+"""
+
+from alembic import op
+
+revision: str = "074"
+down_revision: str | None = "073"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE credential_type ADD VALUE IF NOT EXISTS 'jungle_grid'")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support removing enum values; downgrade is a no-op.
+    pass

--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -59,6 +59,7 @@ def get_masked_value(credential_type: CredentialType, config: dict) -> str | Non
         CredentialType.google,
         CredentialType.custom,
         CredentialType.elevenlabs,
+        CredentialType.jungle_grid,
     ):
         api_key = config.get("api_key", "")
         return mask_api_key(api_key)

--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -275,7 +275,7 @@ def workflow_to_mcp_tool(workflow: Workflow) -> MCPTool:
 
 
 async def get_credentials_context_for_user(db: AsyncSession, user_id: uuid.UUID) -> dict[str, str]:
-    from app.db.models import CredentialShare
+    from app.db.models import CredentialShare, CredentialTeamShare, TeamMember
 
     owned_result = await db.execute(select(Credential).where(Credential.owner_id == user_id))
     owned_credentials = owned_result.scalars().all()
@@ -287,7 +287,17 @@ async def get_credentials_context_for_user(db: AsyncSession, user_id: uuid.UUID)
     )
     shared_credentials = shared_result.scalars().all()
 
-    all_credentials = list(owned_credentials) + list(shared_credentials)
+    team_shared_result = await db.execute(
+        select(Credential)
+        .join(CredentialTeamShare, CredentialTeamShare.credential_id == Credential.id)
+        .join(TeamMember, TeamMember.team_id == CredentialTeamShare.team_id)
+        .where(TeamMember.user_id == user_id)
+    )
+    team_shared_credentials = team_shared_result.scalars().all()
+
+    all_credentials = (
+        list(owned_credentials) + list(shared_credentials) + list(team_shared_credentials)
+    )
 
     context: dict[str, str] = {}
     for cred in all_credentials:
@@ -321,6 +331,41 @@ def _json_compatible(value: Any) -> Any:
     if isinstance(value, tuple):
         return [_json_compatible(item) for item in value]
     return value
+
+
+def _resolve_mcp_fetch_credentials(value: Any, credentials_context: dict[str, str]) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _resolve_mcp_fetch_credentials(item, credentials_context)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_resolve_mcp_fetch_credentials(item, credentials_context) for item in value]
+    if not isinstance(value, str):
+        return value
+    prefix = "$credentials."
+    if not value.startswith(prefix):
+        return value
+    credential_name = value[len(prefix) :].strip()
+    if credential_name not in credentials_context:
+        return value
+    return credentials_context.get(credential_name, "")
+
+
+def _redact_mcp_error(message: str, credentials_context: dict[str, str]) -> str:
+    redacted = message
+    for secret in credentials_context.values():
+        if secret:
+            redacted = redacted.replace(secret, "[redacted]")
+    return redacted
+
+
+def _connection_has_unresolved_credential_reference(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(_connection_has_unresolved_credential_reference(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_connection_has_unresolved_credential_reference(item) for item in value)
+    return isinstance(value, str) and value.startswith("$credentials.")
 
 
 def _add_mcp_workflow_trace(
@@ -505,6 +550,7 @@ async def list_mcp_tools(
 async def fetch_mcp_tools(
     request: Request,
     current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> MCPFetchToolsResponse:
     """
     Connect to an MCP server (stdio or SSE) and return its tool names and descriptions.
@@ -518,6 +564,13 @@ async def fetch_mcp_tools(
 
     conn = dict(connection)
     conn.setdefault("id", conn.get("label", "default"))
+    credentials_context = await get_credentials_context_for_user(db, current_user.id)
+    conn = _resolve_mcp_fetch_credentials(conn, credentials_context)
+    if _connection_has_unresolved_credential_reference(conn):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Credential reference could not be resolved. Check the credential name and access.",
+        )
 
     # Cap the hard timeout so a silent auth failure (e.g. 401 in a background
     # SSE task) doesn't leave the frontend spinner running for the full
@@ -537,7 +590,7 @@ async def fetch_mcp_tools(
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=str(e),
+            detail=_redact_mcp_error(str(e), credentials_context),
         ) from e
 
     tools = [

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -45,6 +45,7 @@ class CredentialType(str, PyEnum):
     google_sheets = "google_sheets"
     bigquery = "bigquery"
     elevenlabs = "elevenlabs"
+    jungle_grid = "jungle_grid"
 
 
 class WorkflowAuthType(str, PyEnum):

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -460,6 +460,7 @@ class CredentialType(str, Enum):
     google_sheets = "google_sheets"
     bigquery = "bigquery"
     elevenlabs = "elevenlabs"
+    jungle_grid = "jungle_grid"
 
 
 class CredentialConfigOpenAI(BaseModel):
@@ -471,6 +472,10 @@ class CredentialConfigGoogle(BaseModel):
 
 
 class CredentialConfigElevenLabs(BaseModel):
+    api_key: str
+
+
+class CredentialConfigJungleGrid(BaseModel):
     api_key: str
 
 

--- a/backend/tests/test_jungle_grid_mcp_integration.py
+++ b/backend/tests/test_jungle_grid_mcp_integration.py
@@ -1,0 +1,105 @@
+import json
+import unittest
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.api.mcp import (
+    _connection_has_unresolved_credential_reference,
+    _redact_mcp_error,
+    _resolve_mcp_fetch_credentials,
+    get_credentials_context_for_user,
+)
+from app.db.models import CredentialType as DBCredentialType
+from app.models.schemas import CredentialType
+
+
+class JungleGridMCPIntegrationTests(unittest.TestCase):
+    def test_credential_type_is_registered(self) -> None:
+        self.assertEqual(DBCredentialType.jungle_grid.value, "jungle_grid")
+        self.assertEqual(CredentialType.jungle_grid.value, "jungle_grid")
+
+    def test_fetch_tool_connection_resolves_api_key_without_serializing_secret(self) -> None:
+        connection = {
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", "@jungle-grid/mcp"],
+            "env": {
+                "JUNGLE_GRID_API_KEY": "$credentials.jungle_grid",
+                "JUNGLE_GRID_API_URL": "https://orchestrator.example.com",
+            },
+        }
+
+        resolved = _resolve_mcp_fetch_credentials(
+            connection,
+            {"jungle_grid": "test-secret-value"},
+        )
+
+        self.assertEqual(resolved["env"]["JUNGLE_GRID_API_KEY"], "test-secret-value")
+        self.assertEqual(
+            resolved["env"]["JUNGLE_GRID_API_URL"],
+            "https://orchestrator.example.com",
+        )
+        self.assertNotIn("test-secret-value", json.dumps(connection))
+
+    def test_missing_credential_reference_is_detected(self) -> None:
+        resolved = _resolve_mcp_fetch_credentials(
+            {"env": {"JUNGLE_GRID_API_KEY": "$credentials.missing"}},
+            {},
+        )
+
+        self.assertTrue(_connection_has_unresolved_credential_reference(resolved))
+
+    def test_mcp_errors_redact_jungle_grid_api_key(self) -> None:
+        message = "server failed with JUNGLE_GRID_API_KEY=test-secret-value"
+        redacted = _redact_mcp_error(message, {"jungle_grid": "test-secret-value"})
+
+        self.assertEqual(redacted, "server failed with JUNGLE_GRID_API_KEY=[redacted]")
+
+    def test_example_workflow_contains_jungle_grid_mcp_without_secret(self) -> None:
+        example_path = (
+            Path(__file__).resolve().parents[2]
+            / "docs"
+            / "examples"
+            / "jungle-grid-mcp-workflow.json"
+        )
+        workflow = json.loads(example_path.read_text())
+        serialized = json.dumps(workflow)
+
+        self.assertIn("@jungle-grid/mcp", serialized)
+        self.assertIn("$credentials.jungle_grid", serialized)
+        self.assertNotIn("jg_", serialized)
+        self.assertEqual(workflow["nodes"][1]["type"], "agent")
+
+
+class JungleGridCredentialContextTests(unittest.IsolatedAsyncioTestCase):
+    async def test_credentials_context_includes_team_shared_jungle_grid_credentials(self) -> None:
+        user_id = uuid.uuid4()
+        team_credential = SimpleNamespace(
+            name="team_jungle_grid",
+            encrypted_config="encrypted",
+            type=DBCredentialType.jungle_grid,
+        )
+
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(
+                    scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+                ),
+                MagicMock(
+                    scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+                ),
+                MagicMock(
+                    scalars=MagicMock(
+                        return_value=MagicMock(all=MagicMock(return_value=[team_credential]))
+                    )
+                ),
+            ]
+        )
+
+        with patch("app.api.mcp.decrypt_config", return_value={"api_key": "team-secret-value"}):
+            context = await get_credentials_context_for_user(db, user_id)
+
+        self.assertEqual(context["team_jungle_grid"], "team-secret-value")

--- a/backend/tests/test_mcp_tool_executor.py
+++ b/backend/tests/test_mcp_tool_executor.py
@@ -68,6 +68,23 @@ class NormalizeConnectionTests(unittest.TestCase):
         _normalize_connection(original)
         self.assertEqual(original["args"], '["-y"]')
 
+    def test_jungle_grid_preset_args_and_env_are_preserved(self) -> None:
+        conn = _normalize_connection(
+            {
+                "transport": "stdio",
+                "command": "npx",
+                "args": '["-y", "@jungle-grid/mcp"]',
+                "env": (
+                    '{"JUNGLE_GRID_API_KEY":"$credentials.jungle_grid",'
+                    '"JUNGLE_GRID_API_URL":"https://orchestrator.example.com"}'
+                ),
+            }
+        )
+
+        self.assertEqual(conn["args"], ["-y", "@jungle-grid/mcp"])
+        self.assertEqual(conn["env"]["JUNGLE_GRID_API_KEY"], "$credentials.jungle_grid")
+        self.assertEqual(conn["env"]["JUNGLE_GRID_API_URL"], "https://orchestrator.example.com")
+
 
 class ExtractToolResultTests(unittest.TestCase):
     def _text_result(self, text: str, is_error: bool = False) -> types.CallToolResult:

--- a/docs/examples/jungle-grid-mcp-workflow.json
+++ b/docs/examples/jungle-grid-mcp-workflow.json
@@ -1,0 +1,73 @@
+{
+  "name": "Jungle Grid GPU Job With Approval",
+  "description": "Estimate, approve, submit, monitor, and retrieve artifacts from a Jungle Grid GPU workload through MCP.",
+  "nodes": [
+    {
+      "id": "input-user-request",
+      "type": "textInput",
+      "position": { "x": 80, "y": 180 },
+      "data": {
+        "label": "userRequest",
+        "value": "",
+        "inputFields": [{ "key": "text" }]
+      }
+    },
+    {
+      "id": "agent-jungle-grid",
+      "type": "agent",
+      "position": { "x": 420, "y": 160 },
+      "data": {
+        "label": "jungleGridAgent",
+        "credentialId": "",
+        "model": "",
+        "temperature": 0.2,
+        "systemInstruction": "You orchestrate GPU workloads through Jungle Grid MCP. Always call estimate_job first. Summarize estimated cost, likely GPU tier, queue/runtime range, and the exact workload payload. Ask for human approval before submit_job, cancel_job, or any action that spends credits or starts execution. After approval, call submit_job, monitor with stream_job_logs or get_job polling, retrieve logs and artifacts with list_job_artifacts and get_artifact_download_url, then return the final result or artifact URL. Never ask the user to paste API keys into chat.",
+        "userMessage": "$input.text",
+        "tools": [],
+        "mcpConnections": [
+          {
+            "id": "jungle-grid-mcp",
+            "transport": "stdio",
+            "label": "Jungle Grid",
+            "timeoutSeconds": 120,
+            "command": "npx",
+            "args": ["-y", "@jungle-grid/mcp"],
+            "env": {
+              "JUNGLE_GRID_API_KEY": "$credentials.jungle_grid"
+            }
+          }
+        ],
+        "toolTimeoutSeconds": 120,
+        "maxToolIterations": 30,
+        "isOrchestrator": false,
+        "subAgentLabels": [],
+        "hitlEnabled": true,
+        "hitlSummary": "Require approval before submit_job, cancel_job, or any Jungle Grid MCP tool call that starts execution or spends credits. estimate_job, get_job, list_jobs, get_job_logs, stream_job_logs, list_job_artifacts, and get_artifact_download_url may run without approval.",
+        "jsonOutputEnabled": false,
+        "jsonOutputSchema": ""
+      }
+    },
+    {
+      "id": "output-response",
+      "type": "output",
+      "position": { "x": 780, "y": 180 },
+      "data": {
+        "label": "response",
+        "message": "$input.text",
+        "allowDownstream": false
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-input-agent",
+      "source": "input-user-request",
+      "target": "agent-jungle-grid"
+    },
+    {
+      "id": "edge-agent-output",
+      "source": "agent-jungle-grid",
+      "target": "output-response"
+    }
+  ]
+}

--- a/frontend/src/components/Credentials/CredentialDialog.vue
+++ b/frontend/src/components/Credentials/CredentialDialog.vue
@@ -91,6 +91,7 @@ const typeOptions = [
   { value: "openai", label: CREDENTIAL_TYPE_LABELS.openai },
   { value: "google", label: CREDENTIAL_TYPE_LABELS.google },
   { value: "elevenlabs", label: CREDENTIAL_TYPE_LABELS.elevenlabs },
+  { value: "jungle_grid", label: CREDENTIAL_TYPE_LABELS.jungle_grid },
   { value: "custom", label: CREDENTIAL_TYPE_LABELS.custom },
   { value: "bearer", label: CREDENTIAL_TYPE_LABELS.bearer },
   { value: "header", label: CREDENTIAL_TYPE_LABELS.header },
@@ -218,7 +219,12 @@ watch(
 const isValid = computed(() => {
   if (!name.value.trim()) return false;
 
-  if (type.value === "openai" || type.value === "google" || type.value === "elevenlabs") {
+  if (
+    type.value === "openai" ||
+    type.value === "google" ||
+    type.value === "elevenlabs" ||
+    type.value === "jungle_grid"
+  ) {
     return !!apiKey.value.trim() || isEditing.value;
   } else if (type.value === "custom") {
     return (!!apiKey.value.trim() && !!baseUrl.value.trim()) || isEditing.value;
@@ -287,6 +293,8 @@ function buildConfig(): CredentialConfig {
   } else if (type.value === "google") {
     return { api_key: apiKey.value };
   } else if (type.value === "elevenlabs") {
+    return { api_key: apiKey.value };
+  } else if (type.value === "jungle_grid") {
     return { api_key: apiKey.value };
   } else if (type.value === "custom") {
     return { base_url: baseUrl.value, api_key: apiKey.value };
@@ -563,7 +571,8 @@ async function handleSave(): Promise<void> {
           rabbitmqPassword.value.trim() ||
           rabbitmqVhost.value.trim() ||
           cohereApiKey.value.trim() ||
-          flaresolverrUrl.value.trim());
+          flaresolverrUrl.value.trim() ||
+          (type.value === "jungle_grid" && apiKey.value.trim()));
 
       if (hasConfigChange) {
         updateData.config = buildConfig();
@@ -641,7 +650,7 @@ async function handleSave(): Promise<void> {
       </div>
 
       <div
-        v-if="type === 'openai' || type === 'google' || type === 'elevenlabs'"
+        v-if="type === 'openai' || type === 'google' || type === 'elevenlabs' || type === 'jungle_grid'"
         class="space-y-2"
       >
         <Label for="cred-api-key">API Key</Label>
@@ -650,7 +659,7 @@ async function handleSave(): Promise<void> {
             id="cred-api-key"
             v-model="apiKey"
             :type="showApiKey ? 'text' : 'password'"
-            :placeholder="isEditing ? '••••••• (re-enter to update)' : 'sk-...'"
+            :placeholder="isEditing ? '••••••• (re-enter to update)' : (type === 'jungle_grid' ? 'Jungle Grid API key' : 'sk-...')"
             :disabled="saving"
             class="pr-10"
           />
@@ -676,6 +685,13 @@ async function handleSave(): Promise<void> {
           Grant this API key the <strong>Text to Speech</strong>,
           <strong>Speech to Text</strong>, and <strong>Voices</strong> permissions in your
           ElevenLabs account.
+        </p>
+        <p
+          v-if="type === 'jungle_grid'"
+          class="text-xs text-muted-foreground"
+        >
+          Stored server-side and referenced from MCP env as
+          <code class="bg-muted px-1 rounded">${{ `credentials.${name || 'jungle_grid'}` }}</code>.
         </p>
       </div>
 

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -363,6 +363,7 @@ const bigqueryCredentials = ref<CredentialListItem[]>([]);
 const rabbitmqCredentials = ref<CredentialListItem[]>([]);
 const cohereCredentials = ref<CredentialListItem[]>([]);
 const crawlerCredentials = ref<CredentialListItem[]>([]);
+const jungleGridCredentials = ref<CredentialListItem[]>([]);
 const dataTables = ref<DataTableListItem[]>([]);
 const driveFiles = ref<GeneratedFile[]>([]);
 
@@ -592,6 +593,14 @@ watch(
             loadPlaywrightAiStepModels(step.credentialId);
           }
         }
+      }
+    }
+
+    if (type === "agent") {
+      try {
+        jungleGridCredentials.value = await credentialsApi.listByType("jungle_grid");
+      } catch {
+        jungleGridCredentials.value = [];
       }
     }
 
@@ -4297,6 +4306,74 @@ function addAgentMCPConnection(): void {
   ]);
 }
 
+function addJungleGridMCPConnection(): void {
+  if (!selectedNode.value) return;
+  const current = selectedNode.value.data.mcpConnections || [];
+  const credentialName = jungleGridCredentials.value[0]?.name || "jungle_grid";
+  const id = crypto.randomUUID();
+  updateNodeData("mcpConnections", [
+    ...current,
+    {
+      id,
+      transport: "stdio" as MCPTransportType,
+      label: "Jungle Grid",
+      timeoutSeconds: 120,
+      command: "npx",
+      args: ["-y", "@jungle-grid/mcp"],
+      env: {
+        JUNGLE_GRID_API_KEY: `$credentials.${credentialName}`,
+      },
+    },
+  ]);
+}
+
+function updateJungleGridMCPCredential(index: number, credentialName: string | undefined): void {
+  const env = {
+    ...jungleGridMCPEnv(index),
+    JUNGLE_GRID_API_KEY: credentialName ? `$credentials.${credentialName}` : "",
+  };
+  updateAgentMCPConnection(index, "env", env);
+}
+
+function updateJungleGridMCPApiUrl(index: number, apiUrl: string): void {
+  const env = { ...jungleGridMCPEnv(index) };
+  const trimmed = apiUrl.trim();
+  if (trimmed) {
+    env.JUNGLE_GRID_API_URL = trimmed;
+  } else {
+    delete env.JUNGLE_GRID_API_URL;
+  }
+  updateAgentMCPConnection(index, "env", env);
+}
+
+function jungleGridMCPEnv(index: number): Record<string, string> {
+  const conn = selectedNode.value?.data.mcpConnections?.[index];
+  const env = conn?.env;
+  if (env && typeof env === "object" && !Array.isArray(env)) {
+    return { ...env } as Record<string, string>;
+  }
+  return {};
+}
+
+function jungleGridMCPCredentialName(index: number): string {
+  const value = jungleGridMCPEnv(index).JUNGLE_GRID_API_KEY || "";
+  const prefix = "$credentials.";
+  return value.startsWith(prefix) ? value.slice(prefix.length) : "";
+}
+
+function jungleGridMCPApiUrl(index: number): string {
+  return jungleGridMCPEnv(index).JUNGLE_GRID_API_URL || "";
+}
+
+function isJungleGridMCPConnection(conn: AgentMCPConnection): boolean {
+  const args = Array.isArray(conn.args) ? conn.args : [];
+  return (
+    conn.transport === "stdio" &&
+    conn.command === "npx" &&
+    args.includes("@jungle-grid/mcp")
+  );
+}
+
 function removeAgentMCPConnection(index: number): void {
   if (!selectedNode.value) return;
   const current = [...(selectedNode.value.data.mcpConnections || [])];
@@ -6703,15 +6780,26 @@ onUnmounted(() => {
                   <Server class="w-3.5 h-3.5" />
                   MCP Connections
                 </Label>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  class="gap-1"
-                  @click="addAgentMCPConnection"
-                >
-                  <Plus class="w-3.5 h-3.5" />
-                  Add MCP
-                </Button>
+                <div class="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    class="gap-1"
+                    @click="addJungleGridMCPConnection"
+                  >
+                    <Zap class="w-3.5 h-3.5" />
+                    Jungle Grid
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    class="gap-1"
+                    @click="addAgentMCPConnection"
+                  >
+                    <Plus class="w-3.5 h-3.5" />
+                    Add MCP
+                  </Button>
+                </div>
               </div>
               <div
                 v-for="(conn, idx) in (selectedNode.data.mcpConnections || [])"
@@ -6765,6 +6853,46 @@ onUnmounted(() => {
                     />
                   </div>
                   <template v-if="conn.transport === 'stdio'">
+                    <div
+                      v-if="isJungleGridMCPConnection(conn)"
+                      class="rounded border border-primary/20 bg-primary/5 p-3 space-y-2"
+                    >
+                      <div class="flex items-center justify-between gap-2">
+                        <p class="text-xs font-medium text-foreground">
+                          Jungle Grid MCP preset
+                        </p>
+                        <a
+                          href="/docs/reference/jungle-grid"
+                          target="_blank"
+                          rel="noreferrer"
+                          class="text-xs text-primary hover:underline"
+                        >
+                          Setup guide
+                        </a>
+                      </div>
+                      <div>
+                        <Label class="text-xs">Jungle Grid credential</Label>
+                        <Select
+                          :model-value="jungleGridMCPCredentialName(idx)"
+                          :options="[
+                            { value: '', label: 'Select Jungle Grid credential...' },
+                            ...jungleGridCredentials.map((cred) => ({ value: cred.name, label: cred.name })),
+                          ]"
+                          @update:model-value="updateJungleGridMCPCredential(idx, $event)"
+                        />
+                        <p class="mt-1 text-xs text-muted-foreground">
+                          Stores only <code>$credentials.Name</code> in the workflow; the API key stays in encrypted credentials.
+                        </p>
+                      </div>
+                      <div>
+                        <Label class="text-xs">API URL override (optional)</Label>
+                        <Input
+                          :model-value="jungleGridMCPApiUrl(idx)"
+                          placeholder="https://api.junglegrid.dev"
+                          @update:model-value="updateJungleGridMCPApiUrl(idx, $event)"
+                        />
+                      </div>
+                    </div>
                     <div>
                       <Label class="text-xs">Command</Label>
                       <Input

--- a/frontend/src/docs/content/nodes/agent-node.md
+++ b/frontend/src/docs/content/nodes/agent-node.md
@@ -175,6 +175,8 @@ def count_characters(text: str) -> int:
 
 Connect to [Model Context Protocol](https://modelcontextprotocol.io/) servers to expose their tools to the agent.
 
+For GPU workloads, the **Jungle Grid** preset adds `npx -y @jungle-grid/mcp` and references a Heym credential as `$credentials.jungle_grid` so the API key is not stored in workflow JSON. See [Jungle Grid](../reference/jungle-grid.md) for the estimate -> approval -> submit -> monitor -> artifact pattern.
+
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `transport` | `"stdio"` \| `"sse"` \| `"streamable_http"` | Connection type |

--- a/frontend/src/docs/content/reference/integrations.md
+++ b/frontend/src/docs/content/reference/integrations.md
@@ -354,6 +354,16 @@ Both types can also be referenced via `$credentials.CredentialName` in the [Expr
 
 ---
 
+## Jungle Grid
+
+Use [Jungle Grid](./jungle-grid.md) when an AI workflow needs managed GPU execution for inference, training, image generation, or batch jobs. Heym connects through the Agent node's MCP preset using `@jungle-grid/mcp`; store the API key as a **Jungle Grid** credential and reference it as `$credentials.jungle_grid`.
+
+### Used By
+
+- [Agent node](../nodes/agent-node.md)
+
+---
+
 ## LLM Providers (OpenAI, Google, Custom, Cohere)
 
 These credentials power AI nodes.

--- a/frontend/src/docs/content/reference/jungle-grid.md
+++ b/frontend/src/docs/content/reference/jungle-grid.md
@@ -1,0 +1,122 @@
+# Jungle Grid
+
+Jungle Grid is a managed GPU execution layer for AI workloads and agents. In Heym, use it through the Agent node's MCP support: Heym handles workflow orchestration, approval, observability, and downstream steps while Jungle Grid handles GPU placement, execution, logs, retries, and artifacts.
+
+## When to use it
+
+Use Jungle Grid when a workflow needs GPU-backed inference, training, image generation, or batch execution without manually choosing or managing GPU infrastructure.
+
+The recommended pattern is:
+
+```text
+User Request -> AI Agent with Jungle Grid MCP tools -> estimate_job -> Human Approval -> submit_job -> monitor logs/status -> retrieve artifacts -> return response
+```
+
+## Create the credential
+
+1. In Jungle Grid, create an API key from the portal's API key settings.
+2. In Heym, open **Credentials** and create a **Jungle Grid** credential.
+3. Name it `jungle_grid` if you want to use the bundled example workflow unchanged.
+4. Paste the API key into the credential dialog. Do not paste it into prompts, node text fields, workflow JSON, screenshots, or docs.
+
+Heym stores the key encrypted and references it at runtime as `$credentials.jungle_grid`.
+
+## Add Jungle Grid MCP to an Agent
+
+1. Add or select an **Agent** node.
+2. Configure the agent's LLM credential and model.
+3. In **MCP Connections**, click **Jungle Grid**.
+4. Select the Jungle Grid credential.
+5. Optionally set an API URL override. Leave it blank for `https://api.junglegrid.dev`.
+6. Click **Fetch tools** to verify discovery.
+
+The preset config is:
+
+```json
+{
+  "transport": "stdio",
+  "label": "Jungle Grid",
+  "command": "npx",
+  "args": ["-y", "@jungle-grid/mcp"],
+  "env": {
+    "JUNGLE_GRID_API_KEY": "$credentials.jungle_grid"
+  }
+}
+```
+
+For alternate environments, add:
+
+```json
+{
+  "JUNGLE_GRID_API_URL": "https://your-orchestrator.example.com"
+}
+```
+
+## Available tools
+
+| Tool | Purpose |
+| --- | --- |
+| `estimate_job` | Estimate cost, GPU tier, route, queue wait, and runtime before starting work. |
+| `submit_job` | Submit a GPU workload and return a job ID immediately. |
+| `get_job` | Poll current job status and details. |
+| `list_jobs` | List recent jobs. |
+| `cancel_job` | Cancel a queued or running job. |
+| `get_job_logs` | Fetch stdout/stderr from a job. |
+| `stream_job_logs` | Stream logs while the job runs. |
+| `list_job_artifacts` | List files captured from `/workspace/artifacts`. |
+| `get_artifact_download_url` | Create a temporary download URL for an artifact. |
+
+## Agent instructions
+
+Use a system instruction like:
+
+```text
+You orchestrate GPU workloads through Jungle Grid MCP. Always call estimate_job first. Summarize estimated cost, likely GPU tier, queue/runtime range, and the exact workload payload. Ask for human approval before submit_job, cancel_job, or any action that spends credits or starts execution. After approval, call submit_job, monitor with stream_job_logs or get_job polling, retrieve logs and artifacts with list_job_artifacts and get_artifact_download_url, then return the final result or artifact URL. Never ask the user to paste API keys into chat.
+```
+
+Enable **Human-in-the-Loop** on the Agent node and use this approval summary:
+
+```text
+Require approval before submit_job, cancel_job, or any Jungle Grid MCP tool call that starts execution or spends credits. estimate_job, get_job, list_jobs, get_job_logs, stream_job_logs, list_job_artifacts, and get_artifact_download_url may run without approval.
+```
+
+## Example workflow
+
+An importable example is available at `docs/examples/jungle-grid-mcp-workflow.json`. Before running it:
+
+1. Create the `jungle_grid` credential.
+2. Select an LLM credential and model on the Agent node.
+3. Run a request such as:
+
+```text
+Estimate a small inference job using python:3.11-slim that writes output.json to /workspace/artifacts. Show me the estimate and ask before submitting.
+```
+
+Automated tests and examples must not submit real paid workloads. Manual verification should use `estimate_job` only unless you intentionally approve a real run.
+
+## Troubleshooting
+
+| Problem | Fix |
+| --- | --- |
+| Missing API key | Create a Jungle Grid credential and select it in the preset. Do not type the key directly into MCP env. |
+| Tools not discovered | Confirm Node.js 18+ is available, then retry **Fetch tools**. The preset runs `npx -y @jungle-grid/mcp`. |
+| `JUNGLE_GRID_API_KEY is required` | The env value did not resolve. Check the credential name and that the workflow owner can access it. |
+| Job failed | Use `get_job`, `get_job_logs`, and `stream_job_logs` to inspect status and logs. Return the failure reason through the workflow output. |
+| Long-running job | `submit_job` returns quickly. Poll with `get_job` or stream logs instead of blocking on one long tool call. |
+| Missing artifacts | Ensure the job writes files under `/workspace/artifacts`, then call `list_job_artifacts` after completion. |
+| Alternate API environment | Set `JUNGLE_GRID_API_URL` in the preset's optional API URL field. |
+
+## Security
+
+- Never put `JUNGLE_GRID_API_KEY` in prompts, public workflow values, screenshots, fixtures, logs, or committed files.
+- Store the API key only as a Heym Jungle Grid credential.
+- Prefer `estimate_job` before any `submit_job`.
+- Use Human-in-the-Loop approval for credit-spending or execution-starting tools.
+- Do not pass unrelated secrets through Jungle Grid job environment variables, callback metadata, command args, or artifacts.
+
+## Related
+
+- [Agent Node](/docs/nodes/agent-node)
+- [Human-in-the-Loop](/docs/reference/human-in-the-loop)
+- [Credentials](/docs/reference/credentials)
+- [Third-Party Integrations](/docs/reference/integrations)

--- a/frontend/src/docs/content/tabs/mcp-tab.md
+++ b/frontend/src/docs/content/tabs/mcp-tab.md
@@ -81,6 +81,7 @@ Both endpoints support the SSE transport (GET, MCP spec 2024-11-05) and Streamab
 
 - [Why Heym](../getting-started/why-heym.md) – MCP as a first-class primitive in Heym
 - [Agent Node](../nodes/agent-node.md) – Agent node with MCP tool support
+- [Jungle Grid](../reference/jungle-grid.md) – Run GPU workloads from Agent nodes through an MCP preset
 - [Agent Architecture](../reference/agent-architecture.md) – MCP client, tool dispatch, orchestrator
 - [Triggers](../reference/triggers.md) – MCP as a workflow entry point
 - [Workflows Tab](./workflows-tab.md) – Create and manage workflows

--- a/frontend/src/docs/manifest.ts
+++ b/frontend/src/docs/manifest.ts
@@ -104,6 +104,7 @@ export const DOCS_MANIFEST: Record<string, DocCategory> = {
       { slug: "drive", title: "Drive" },
       { slug: "security", title: "Security" },
       { slug: "integrations", title: "Third-Party Integrations" },
+      { slug: "jungle-grid", title: "Jungle Grid" },
       { slug: "guardrails", title: "Guardrails" },
       { slug: "enterprise", title: "Enterprise" },
     ],

--- a/frontend/src/types/credential.ts
+++ b/frontend/src/types/credential.ts
@@ -17,7 +17,8 @@ export type CredentialType =
   | "flaresolverr"
   | "google_sheets"
   | "bigquery"
-  | "elevenlabs";
+  | "elevenlabs"
+  | "jungle_grid";
 
 export interface Credential {
   id: string;
@@ -71,6 +72,10 @@ export interface CredentialConfigGoogle {
 }
 
 export interface CredentialConfigElevenLabs {
+  api_key: string;
+}
+
+export interface CredentialConfigJungleGrid {
   api_key: string;
 }
 
@@ -179,7 +184,8 @@ export type CredentialConfig =
   | CredentialConfigCohere
   | CredentialConfigFlaresolverr
   | CredentialConfigGoogleSheets
-  | CredentialConfigElevenLabs;
+  | CredentialConfigElevenLabs
+  | CredentialConfigJungleGrid;
 
 export interface CreateCredentialRequest {
   name: string;
@@ -212,6 +218,7 @@ export const CREDENTIAL_TYPE_LABELS: Record<CredentialType, string> = {
   google_sheets: "Google Sheets (OAuth2)",
   bigquery: "BigQuery (OAuth2)",
   elevenlabs: "ElevenLabs (Voice)",
+  jungle_grid: "Jungle Grid",
 };
 
 export const CREDENTIAL_TYPE_DESCRIPTIONS: Record<CredentialType, string> = {
@@ -234,4 +241,5 @@ export const CREDENTIAL_TYPE_DESCRIPTIONS: Record<CredentialType, string> = {
   google_sheets: "Connect to Google Sheets via OAuth2 — read, write, append, and query spreadsheets",
   bigquery: "Connect to Google BigQuery via OAuth2 — run SQL queries and insert rows",
   elevenlabs: "Text-to-speech and speech-to-text for chat voice features",
+  jungle_grid: "Run GPU inference, training, image generation, and batch workloads through Jungle Grid MCP",
 };


### PR DESCRIPTION
## Summary

This PR adds a Jungle Grid integration through Heym’s existing MCP workflow architecture.

Jungle Grid provides managed execution for GPU-backed AI workloads, while Heym continues to handle workflow composition, agents, approvals and orchestration. With this integration, Heym workflows can securely access Jungle Grid MCP tools for estimating workloads, submitting jobs, monitoring execution, retrieving logs and accessing generated artifacts.

## What changed

* Added Jungle Grid MCP integration support following Heym’s existing MCP patterns.
* Added secure Jungle Grid credential configuration using Heym’s credential resolution model.
* Added support for team-shared Jungle Grid credentials in addition to user-owned/shared credentials.
* Added regression coverage for Jungle Grid MCP execution and shared credential resolution.
* Added documentation and an example workflow for configuring Jungle Grid in Heym workflows.

## Workflow enabled

A Heym workflow can now follow this execution path:

`User request → Agent with Jungle Grid MCP tools → estimate_job → optional human approval → submit_job → monitor logs/status → retrieve artifacts/result`

This allows expensive or long-running GPU-backed work to be estimated and approved before execution, while keeping orchestration inside Heym.

## Security considerations

* Jungle Grid credentials are resolved through Heym’s existing credential system.
* Team-shared credential access is covered by regression tests.
* No real Jungle Grid API keys are included in source code, fixtures, examples or documentation.
* Automated tests do not submit paid or live GPU workloads.
* Secrets are not intended to be serialized into public workflow data or exposed in logs/errors.

## Testing

Verified:

* `ENCRYPTION_KEY=... UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_jungle_grid_mcp_integration.py tests/test_mcp_tool_executor.py` — 38 passed
* `ENCRYPTION_KEY=... UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .` — passed
* `ENCRYPTION_KEY=... UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .` — passed
* `git diff --check` — passed
* Full backend test suite — 882 passed; one WebSocket test initially failed because sandbox socket creation was blocked and passed when rerun with local socket permission
* `ENCRYPTION_KEY=... UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_websocket_node.py::TestWebSocketSendIntegration::test_send_websocket_message_delivers_payload_before_close` with local socket permission — 1 passed


## Notes for reviewers

This integration is intentionally aligned with Heym’s existing MCP architecture rather than introducing redundant provider-specific workflow execution logic. Jungle Grid remains responsible for GPU workload execution, status, logs and artifacts; Heym remains responsible for agent/workflow orchestration and approvals.