### PR TITLE
fix/cross-worker-execution-state-and-sse-heartbeats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Read and follow this `AGENTS.md` at the start of every session. Repository conve
 ./run.sh                    # Start all services (postgres, backend, frontend)
 ./run.sh --no-debug         # Start with INFO logging instead of DEBUG
 ./check.sh                  # Run frontend lint/typecheck, backend Ruff checks, and backend tests
+SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh  # Use when no SECRET_KEY is exported locally
 ```
 
 ### Frontend (Vue.js + Bun)
@@ -24,6 +25,7 @@ bun run build && bun run preview  # Build && test production build
 ```bash
 cd backend && uv sync && uv run alembic upgrade head && uv run uvicorn app.main:app --reload --port 10105
 ./run_tests.sh               # Run all backend unit tests in parallel (required before git push)
+SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./run_tests.sh  # Full backend tests when no SECRET_KEY is exported
 uv run pytest tests/test_file.py::ClassName::test_method  # Run specific test
 uv run ruff check .           # Linting (fix with --fix) - must pass before commits
 uv run ruff format .          # Auto-format code
@@ -72,6 +74,7 @@ SQLAlchemy 2.0 async, UUID primary keys only, Alembic for migrations, index freq
 Backend: pytest with unittest.TestCase/IsolatedAsyncioTestCase, AsyncMock for DB mocking
 Frontend: No tests yet (add when needed)
 **New features must include backend tests** - run `./check.sh` before git push (includes backend tests via `./run_tests.sh`)
+If the local environment does not export `SECRET_KEY`, prefix full-suite commands with `SECRET_KEY=test-secret-key-for-tests-only-32-bytes` (test-only value; never use it for runtime/prod).
 
 ### Expression evaluation (avoid executor vs dialog drift)
 The canvas **expression evaluate** dialog (`/expressions/evaluate`, `ExpressionEvaluatorService`) and **workflow execution** (`WorkflowExecutor`) must agree on the same semantics for `$…` templates.

--- a/backend/alembic/versions/074_active_workflow_executions.py
+++ b/backend/alembic/versions/074_active_workflow_executions.py
@@ -1,0 +1,79 @@
+"""add active workflow executions registry
+
+Revision ID: 074
+Revises: 073
+Create Date: 2026-06-04
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "074"
+down_revision: str | None = "073"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "active_workflow_executions",
+        sa.Column("execution_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "workflow_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workflows.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("worker_id", sa.String(length=128), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("cancel_requested_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_active_workflow_executions_workflow_id",
+        "active_workflow_executions",
+        ["workflow_id"],
+    )
+    op.create_index(
+        "ix_active_workflow_executions_worker_id",
+        "active_workflow_executions",
+        ["worker_id"],
+    )
+    op.create_index(
+        "ix_active_workflow_executions_heartbeat_at",
+        "active_workflow_executions",
+        ["heartbeat_at"],
+    )
+    op.create_index(
+        "ix_active_workflow_executions_cancel_requested_at",
+        "active_workflow_executions",
+        ["cancel_requested_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_active_workflow_executions_cancel_requested_at",
+        table_name="active_workflow_executions",
+    )
+    op.drop_index(
+        "ix_active_workflow_executions_heartbeat_at",
+        table_name="active_workflow_executions",
+    )
+    op.drop_index(
+        "ix_active_workflow_executions_worker_id",
+        table_name="active_workflow_executions",
+    )
+    op.drop_index(
+        "ix_active_workflow_executions_workflow_id",
+        table_name="active_workflow_executions",
+    )
+    op.drop_table("active_workflow_executions")

--- a/backend/app/api/ai_assistant.py
+++ b/backend/app/api/ai_assistant.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from threading import Event
+from threading import Event, Thread
 from typing import Any, AsyncGenerator, Literal
 from urllib.parse import urlparse
 
@@ -123,6 +123,7 @@ class FixTranscriptionResponse(BaseModel):
 MAX_DASHBOARD_CHAT_HISTORY = 25
 DASHBOARD_CHAT_TEMPERATURE = 0.1
 WORKFLOW_BUILDER_TEMPERATURE = 0.0
+WORKFLOW_ASSISTANT_SSE_HEARTBEAT_SECONDS = 10.0
 
 
 def _get_dashboard_chat_node_label(
@@ -3359,6 +3360,43 @@ async def stream_llm_response(
         yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
 
 
+async def _stream_sse_with_heartbeat(
+    source: AsyncGenerator[str, None],
+    *,
+    heartbeat_seconds: float,
+) -> AsyncGenerator[str, None]:
+    """Forward SSE chunks from a sync-backed generator while sending idle keepalives."""
+    queue: asyncio.Queue[str | Exception | None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    async def consume_source() -> None:
+        try:
+            async for chunk in source:
+                loop.call_soon_threadsafe(queue.put_nowait, chunk)
+        except Exception as exc:
+            loop.call_soon_threadsafe(queue.put_nowait, exc)
+        finally:
+            loop.call_soon_threadsafe(queue.put_nowait, None)
+
+    def run_source() -> None:
+        asyncio.run(consume_source())
+
+    Thread(target=run_source, daemon=True).start()
+
+    while True:
+        try:
+            item = await asyncio.wait_for(queue.get(), timeout=heartbeat_seconds)
+        except TimeoutError:
+            yield ": heartbeat\n\n"
+            continue
+
+        if item is None:
+            break
+        if isinstance(item, Exception):
+            raise item
+        yield item
+
+
 @router.post("/workflow-assistant")
 async def workflow_assistant_stream(
     request: AIAssistantRequest,
@@ -3446,15 +3484,20 @@ async def workflow_assistant_stream(
         source="assistant",
     )
 
+    assistant_stream = stream_llm_response(
+        client,
+        request.model,
+        system_prompt,
+        messages,
+        provider,
+        trace_context,
+        run_type="workflow_assistant",
+    )
+
     return StreamingResponse(
-        stream_llm_response(
-            client,
-            request.model,
-            system_prompt,
-            messages,
-            provider,
-            trace_context,
-            run_type="workflow_assistant",
+        _stream_sse_with_heartbeat(
+            assistant_stream,
+            heartbeat_seconds=WORKFLOW_ASSISTANT_SSE_HEARTBEAT_SECONDS,
         ),
         media_type="text/event-stream",
         headers={

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -41,6 +41,7 @@ from app.services.execution_cancellation import (
 )
 from app.services.execution_cancellation import (
     register_execution,
+    request_persisted_execution_cancel,
 )
 from app.services.global_variables_service import get_global_variables_context
 from app.services.hitl_service import build_public_base_url, persist_pending_hitl_execution
@@ -56,6 +57,7 @@ from app.services.workflow_executor import (
 router = APIRouter()
 
 _session_ttl_hours = 168
+PORTAL_SSE_HEARTBEAT_SECONDS = 10.0
 
 
 def _generate_session_token() -> str:
@@ -446,6 +448,7 @@ async def portal_execute_stream(
         loop = asyncio.get_event_loop()
         with ThreadPoolExecutor(max_workers=1) as pool:
             future = loop.run_in_executor(pool, run_executor)
+            last_heartbeat_at = loop.time()
             yield (
                 "data: "
                 + json.dumps(
@@ -466,6 +469,7 @@ async def portal_execute_stream(
                     if event is None:
                         break
                     event = progress_tracker.observe_event(event)
+                    last_heartbeat_at = loop.time()
                     if (
                         event.get("type") == "execution_complete"
                         and event.get("status") == "pending"
@@ -502,12 +506,18 @@ async def portal_execute_stream(
                     if await request.is_disconnected():
                         cancel_event.set()
                         break
+                    now = loop.time()
+                    if now - last_heartbeat_at >= PORTAL_SSE_HEARTBEAT_SECONDS:
+                        last_heartbeat_at = now
+                        yield ": heartbeat\n\n"
+                        continue
                     if future.done():
                         while not event_queue.empty():
                             event = event_queue.get_nowait()
                             if event is None:
                                 break
                             event = progress_tracker.observe_event(event)
+                            last_heartbeat_at = loop.time()
                             if (
                                 event.get("type") == "execution_complete"
                                 and event.get("status") == "pending"
@@ -648,8 +658,13 @@ async def portal_cancel_execution(
                 detail="Invalid or expired session",
             )
 
-    cancelled = cancel_active_execution(workflow_id=workflow.id, execution_id=execution_id)
-    if not cancelled:
+    cancelled_local = cancel_active_execution(workflow_id=workflow.id, execution_id=execution_id)
+    cancelled_persisted = await request_persisted_execution_cancel(
+        db,
+        workflow_id=workflow.id,
+        execution_id=execution_id,
+    )
+    if not cancelled_local and not cancelled_persisted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Execution not found or already finished",

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -64,7 +64,9 @@ from app.services.execution_cancellation import (
 )
 from app.services.execution_cancellation import (
     list_active_executions,
+    list_persisted_active_executions_for_user,
     register_execution,
+    request_persisted_execution_cancel,
 )
 from app.services.global_variables_service import (
     get_global_variables_context,
@@ -953,36 +955,53 @@ async def list_active_workflow_executions(
     db: AsyncSession = Depends(get_db),
 ) -> list[ActiveExecutionItem]:
     """Return all currently running executions belonging to the authenticated user."""
-    handles = list_active_executions()
-    if not handles:
-        return []
-
-    workflow_ids = list({h.workflow_id for h in handles})
-    result = await db.execute(
-        select(Workflow).where(
-            Workflow.id.in_(workflow_ids),
-            or_(
-                Workflow.owner_id == current_user.id,
-                Workflow.id.in_(
-                    select(WorkflowShare.workflow_id).where(
-                        WorkflowShare.user_id == current_user.id
-                    )
-                ),
-            ),
+    persisted = await list_persisted_active_executions_for_user(db, current_user.id)
+    items_by_execution_id = {
+        record.execution_id: ActiveExecutionItem(
+            execution_id=str(record.execution_id),
+            workflow_id=str(record.workflow_id),
+            workflow_name=record.workflow_name,
+            started_at=record.started_at,
         )
-    )
-    accessible: dict[uuid.UUID, str] = {w.id: w.name for w in result.scalars().all()}
+        for record in persisted
+    }
 
-    return [
-        ActiveExecutionItem(
-            execution_id=str(h.execution_id),
-            workflow_id=str(h.workflow_id),
-            workflow_name=accessible[h.workflow_id],
-            started_at=h.started_at,
-        )
-        for h in handles
-        if h.workflow_id in accessible
+    local_handles = [
+        handle
+        for handle in list_active_executions()
+        if handle.execution_id not in items_by_execution_id and not handle.event.is_set()
     ]
+    if local_handles:
+        workflow_ids = list({h.workflow_id for h in local_handles})
+        result = await db.execute(
+            select(Workflow).where(
+                Workflow.id.in_(workflow_ids),
+                or_(
+                    Workflow.owner_id == current_user.id,
+                    Workflow.id.in_(
+                        select(WorkflowShare.workflow_id).where(
+                            WorkflowShare.user_id == current_user.id
+                        )
+                    ),
+                ),
+            )
+        )
+        accessible: dict[uuid.UUID, str] = {w.id: w.name for w in result.scalars().all()}
+        for handle in local_handles:
+            if handle.workflow_id not in accessible:
+                continue
+            items_by_execution_id[handle.execution_id] = ActiveExecutionItem(
+                execution_id=str(handle.execution_id),
+                workflow_id=str(handle.workflow_id),
+                workflow_name=accessible[handle.workflow_id],
+                started_at=handle.started_at,
+            )
+
+    return sorted(
+        items_by_execution_id.values(),
+        key=lambda item: item.started_at,
+        reverse=True,
+    )
 
 
 @router.post("", response_model=WorkflowResponse, status_code=status.HTTP_201_CREATED)
@@ -3067,8 +3086,13 @@ async def cancel_workflow_execution(
             detail="Workflow not found",
         )
 
-    cancelled = cancel_active_execution(workflow_id=workflow_id, execution_id=execution_id)
-    if not cancelled:
+    cancelled_local = cancel_active_execution(workflow_id=workflow_id, execution_id=execution_id)
+    cancelled_persisted = await request_persisted_execution_cancel(
+        db,
+        workflow_id=workflow_id,
+        execution_id=execution_id,
+    )
+    if not cancelled_local and not cancelled_persisted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Execution not found or already finished",

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -425,6 +425,31 @@ class ExecutionHistory(Base):
     )
 
 
+class ActiveWorkflowExecution(Base):
+    """Cross-worker registry of executions that are currently running."""
+
+    __tablename__ = "active_workflow_executions"
+
+    execution_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    workflow_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workflows.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    worker_id: Mapped[str] = mapped_column(String(128), nullable=False, index=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    heartbeat_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    cancel_requested_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
 class WorkflowAnalyticsSnapshot(Base):
     __tablename__ = "workflow_analytics_snapshots"
     __table_args__ = (

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,6 +53,7 @@ from app.http_identity import HEYM_SERVER_AGENT
 from app.models.schemas import AppVersionResponse
 from app.services.cron_scheduler import cron_scheduler
 from app.services.distributed_lock import lock_service
+from app.services.execution_cancellation import active_execution_registry
 from app.services.grist_pool import close_all_clients as close_grist_clients
 from app.services.grist_pool import warm_up_pools as warm_up_grist_pools
 from app.services.hitl_service import build_public_base_url, build_review_url
@@ -122,6 +123,7 @@ async def lifespan(app: FastAPI):
     if qdrant_count > 0:
         logger.info("Qdrant pools warmed up: %d", qdrant_count)
 
+    await active_execution_registry.start()
     await cron_scheduler.start()
     await imap_trigger_manager.start()
     await rabbitmq_consumer_manager.start()
@@ -132,6 +134,7 @@ async def lifespan(app: FastAPI):
     await imap_trigger_manager.stop()
     await RabbitMQPool.close_all()
     await cron_scheduler.stop()
+    await active_execution_registry.stop()
     await lock_service.stop()
     close_redis_pools()
     close_grist_clients()

--- a/backend/app/services/execution_cancellation.py
+++ b/backend/app/services/execution_cancellation.py
@@ -1,7 +1,30 @@
+import asyncio
+import contextlib
+import logging
+import os
+import queue
+import socket
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+ACTIVE_EXECUTION_STALE_AFTER_SECONDS = 300
+_REGISTRY_POLL_SECONDS = 0.5
+_REGISTRY_CLEANUP_SECONDS = 30.0
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+_WORKER_ID = f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
 
 
 @dataclass
@@ -9,7 +32,25 @@ class ExecutionCancellationHandle:
     workflow_id: uuid.UUID
     execution_id: uuid.UUID
     event: threading.Event
-    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    started_at: datetime = field(default_factory=_utcnow)
+
+
+@dataclass(frozen=True)
+class ActiveExecutionRecord:
+    """Persisted active execution visible across API workers."""
+
+    execution_id: uuid.UUID
+    workflow_id: uuid.UUID
+    workflow_name: str
+    started_at: datetime
+
+
+@dataclass(frozen=True)
+class _RegistryCommand:
+    action: Literal["start", "finish"]
+    execution_id: uuid.UUID
+    workflow_id: uuid.UUID | None = None
+    started_at: datetime | None = None
 
 
 _ACTIVE_EXECUTIONS: dict[uuid.UUID, ExecutionCancellationHandle] = {}
@@ -21,16 +62,20 @@ def register_execution(
     workflow_id: uuid.UUID,
     execution_id: uuid.UUID,
     event: threading.Event | None = None,
+    started_at: datetime | None = None,
 ) -> threading.Event:
     if event is None:
         event = threading.Event()
+    started_at = started_at or _utcnow()
     handle = ExecutionCancellationHandle(
         workflow_id=workflow_id,
         execution_id=execution_id,
         event=event,
+        started_at=started_at,
     )
     with _LOCK:
         _ACTIVE_EXECUTIONS[execution_id] = handle
+    active_execution_registry.record_started(handle)
     return event
 
 
@@ -46,9 +91,259 @@ def cancel_execution(*, workflow_id: uuid.UUID, execution_id: uuid.UUID) -> bool
 def clear_execution(execution_id: uuid.UUID) -> None:
     with _LOCK:
         _ACTIVE_EXECUTIONS.pop(execution_id, None)
+    active_execution_registry.record_finished(execution_id)
 
 
 def list_active_executions() -> list[ExecutionCancellationHandle]:
     """Return a snapshot of all currently active executions."""
     with _LOCK:
         return list(_ACTIVE_EXECUTIONS.values())
+
+
+class ActiveExecutionRegistry:
+    """Persist local active execution state into Postgres for multi-worker visibility."""
+
+    def __init__(self) -> None:
+        self._commands: queue.Queue[_RegistryCommand] = queue.Queue()
+        self._task: asyncio.Task[None] | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._wakeup: asyncio.Event | None = None
+        self._running = False
+        self._next_cleanup_at = 0.0
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._running = True
+        self._loop = asyncio.get_running_loop()
+        self._wakeup = asyncio.Event()
+        self._next_cleanup_at = time.monotonic()
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("Active execution registry started (worker_id=%s)", _WORKER_ID)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        self._loop = None
+        self._wakeup = None
+        with contextlib.suppress(Exception):
+            await self._drain_commands()
+        logger.info("Active execution registry stopped")
+
+    def record_started(self, handle: ExecutionCancellationHandle) -> None:
+        if not self._running:
+            return
+        self._commands.put(
+            _RegistryCommand(
+                action="start",
+                execution_id=handle.execution_id,
+                workflow_id=handle.workflow_id,
+                started_at=handle.started_at,
+            )
+        )
+        self._wake()
+
+    def record_finished(self, execution_id: uuid.UUID) -> None:
+        if not self._running:
+            return
+        self._commands.put(_RegistryCommand(action="finish", execution_id=execution_id))
+        self._wake()
+
+    def _wake(self) -> None:
+        if self._loop is None or self._wakeup is None:
+            return
+        self._loop.call_soon_threadsafe(self._wakeup.set)
+
+    async def _run_loop(self) -> None:
+        while self._running:
+            try:
+                await self._drain_commands()
+                await self._sync_local_handles()
+                if time.monotonic() >= self._next_cleanup_at:
+                    await cleanup_stale_persisted_executions()
+                    self._next_cleanup_at = time.monotonic() + _REGISTRY_CLEANUP_SECONDS
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Active execution registry sync failed")
+            if self._wakeup is None:
+                await asyncio.sleep(_REGISTRY_POLL_SECONDS)
+                continue
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(self._wakeup.wait(), timeout=_REGISTRY_POLL_SECONDS)
+            self._wakeup.clear()
+
+    async def _drain_commands(self) -> None:
+        commands: list[_RegistryCommand] = []
+        while True:
+            try:
+                commands.append(self._commands.get_nowait())
+            except queue.Empty:
+                break
+        if not commands:
+            return
+
+        from sqlalchemy import delete
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+        from app.db.models import ActiveWorkflowExecution
+        from app.db.session import async_session_maker
+
+        now = _utcnow()
+        async with async_session_maker() as session:
+            for command in commands:
+                if command.action == "finish":
+                    await session.execute(
+                        delete(ActiveWorkflowExecution).where(
+                            ActiveWorkflowExecution.execution_id == command.execution_id
+                        )
+                    )
+                    continue
+
+                if command.workflow_id is None:
+                    continue
+                started_at = command.started_at or now
+                stmt = (
+                    pg_insert(ActiveWorkflowExecution)
+                    .values(
+                        execution_id=command.execution_id,
+                        workflow_id=command.workflow_id,
+                        worker_id=_WORKER_ID,
+                        started_at=started_at,
+                        heartbeat_at=now,
+                        cancel_requested_at=None,
+                    )
+                    .on_conflict_do_update(
+                        index_elements=["execution_id"],
+                        set_={
+                            "workflow_id": command.workflow_id,
+                            "worker_id": _WORKER_ID,
+                            "started_at": started_at,
+                            "heartbeat_at": now,
+                            "cancel_requested_at": None,
+                        },
+                    )
+                )
+                await session.execute(stmt)
+            await session.commit()
+
+    async def _sync_local_handles(self) -> None:
+        handles = list_active_executions()
+        if not handles:
+            return
+
+        from sqlalchemy import select, update
+
+        from app.db.models import ActiveWorkflowExecution
+        from app.db.session import async_session_maker
+
+        handles_by_id = {handle.execution_id: handle for handle in handles}
+        execution_ids = list(handles_by_id)
+        now = _utcnow()
+        async with async_session_maker() as session:
+            cancel_result = await session.execute(
+                select(ActiveWorkflowExecution.execution_id).where(
+                    ActiveWorkflowExecution.execution_id.in_(execution_ids),
+                    ActiveWorkflowExecution.cancel_requested_at.is_not(None),
+                )
+            )
+            cancelled_ids = list(cancel_result.scalars().all())
+            await session.execute(
+                update(ActiveWorkflowExecution)
+                .where(ActiveWorkflowExecution.execution_id.in_(execution_ids))
+                .values(heartbeat_at=now, worker_id=_WORKER_ID)
+            )
+            await session.commit()
+
+        for execution_id in cancelled_ids:
+            handle = handles_by_id.get(execution_id)
+            if handle is not None:
+                handle.event.set()
+
+
+async def request_persisted_execution_cancel(
+    db: AsyncSession,
+    *,
+    workflow_id: uuid.UUID,
+    execution_id: uuid.UUID,
+) -> bool:
+    """Mark a running execution as cancelled so its owning worker can stop it."""
+    from sqlalchemy import update
+
+    from app.db.models import ActiveWorkflowExecution
+
+    result = await db.execute(
+        update(ActiveWorkflowExecution)
+        .where(
+            ActiveWorkflowExecution.workflow_id == workflow_id,
+            ActiveWorkflowExecution.execution_id == execution_id,
+        )
+        .values(cancel_requested_at=_utcnow())
+    )
+    await db.commit()
+    return bool(result.rowcount or 0)
+
+
+async def cleanup_stale_persisted_executions() -> int:
+    """Remove active rows whose worker has stopped heartbeating."""
+    from sqlalchemy import delete
+
+    from app.db.models import ActiveWorkflowExecution
+    from app.db.session import async_session_maker
+
+    cutoff = _utcnow() - timedelta(seconds=ACTIVE_EXECUTION_STALE_AFTER_SECONDS)
+    async with async_session_maker() as session:
+        result = await session.execute(
+            delete(ActiveWorkflowExecution).where(ActiveWorkflowExecution.heartbeat_at < cutoff)
+        )
+        await session.commit()
+    return result.rowcount or 0
+
+
+async def list_persisted_active_executions_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[ActiveExecutionRecord]:
+    """Return active execution rows for workflows accessible to the user."""
+    from sqlalchemy import or_, select
+
+    from app.db.models import ActiveWorkflowExecution, Workflow, WorkflowShare
+
+    cutoff = _utcnow() - timedelta(seconds=ACTIVE_EXECUTION_STALE_AFTER_SECONDS)
+    result = await db.execute(
+        select(
+            ActiveWorkflowExecution.execution_id,
+            ActiveWorkflowExecution.workflow_id,
+            ActiveWorkflowExecution.started_at,
+            Workflow.name,
+        )
+        .join(Workflow, Workflow.id == ActiveWorkflowExecution.workflow_id)
+        .where(
+            ActiveWorkflowExecution.heartbeat_at >= cutoff,
+            ActiveWorkflowExecution.cancel_requested_at.is_(None),
+            or_(
+                Workflow.owner_id == user_id,
+                Workflow.id.in_(
+                    select(WorkflowShare.workflow_id).where(WorkflowShare.user_id == user_id)
+                ),
+            ),
+        )
+        .order_by(ActiveWorkflowExecution.started_at.desc())
+    )
+
+    return [
+        ActiveExecutionRecord(
+            execution_id=row.execution_id,
+            workflow_id=row.workflow_id,
+            workflow_name=row.name,
+            started_at=row.started_at,
+        )
+        for row in result.all()
+    ]
+
+
+active_execution_registry = ActiveExecutionRegistry()

--- a/backend/tests/test_active_executions_api.py
+++ b/backend/tests/test_active_executions_api.py
@@ -7,8 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from app.api.workflows import list_active_workflow_executions
 from app.models.schemas import ActiveExecutionItem
 from app.services.execution_cancellation import (
+    ActiveExecutionRecord,
     ExecutionCancellationHandle,
     list_active_executions,
+    list_persisted_active_executions_for_user,
 )
 from app.services.workflow_executor import ExecutionResult, WorkflowExecutor
 
@@ -22,19 +24,58 @@ def _make_handle(workflow_id: uuid.UUID, execution_id: uuid.UUID) -> ExecutionCa
     )
 
 
+def _make_record(workflow_id: uuid.UUID, execution_id: uuid.UUID) -> ActiveExecutionRecord:
+    return ActiveExecutionRecord(
+        workflow_id=workflow_id,
+        execution_id=execution_id,
+        workflow_name="My Workflow",
+        started_at=datetime.datetime(2025, 1, 1, 12, 0, 0),
+    )
+
+
 class ListActiveWorkflowExecutionsTests(unittest.IsolatedAsyncioTestCase):
     async def test_returns_empty_when_no_active_executions(self) -> None:
         user = MagicMock()
         user.id = uuid.uuid4()
         db = AsyncMock()
 
-        with patch("app.api.workflows.list_active_executions", return_value=[]):
+        with (
+            patch(
+                "app.api.workflows.list_persisted_active_executions_for_user",
+                AsyncMock(return_value=[]),
+            ),
+            patch("app.api.workflows.list_active_executions", return_value=[]),
+        ):
             result = await list_active_workflow_executions(current_user=user, db=db)
 
         self.assertEqual(result, [])
         db.execute.assert_not_called()
 
-    async def test_filters_to_accessible_workflows(self) -> None:
+    async def test_returns_persisted_active_executions(self) -> None:
+        user = MagicMock()
+        user.id = uuid.uuid4()
+
+        wf_id = uuid.uuid4()
+        ex_id = uuid.uuid4()
+        db = AsyncMock()
+
+        with (
+            patch(
+                "app.api.workflows.list_persisted_active_executions_for_user",
+                AsyncMock(return_value=[_make_record(wf_id, ex_id)]),
+            ),
+            patch("app.api.workflows.list_active_executions", return_value=[]),
+        ):
+            result = await list_active_workflow_executions(current_user=user, db=db)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].execution_id, str(ex_id))
+        self.assertEqual(result[0].workflow_id, str(wf_id))
+        self.assertEqual(result[0].workflow_name, "My Workflow")
+        self.assertIsInstance(result[0], ActiveExecutionItem)
+        db.execute.assert_not_called()
+
+    async def test_filters_local_fallback_to_accessible_workflows(self) -> None:
         user = MagicMock()
         user.id = uuid.uuid4()
 
@@ -57,7 +98,13 @@ class ListActiveWorkflowExecutionsTests(unittest.IsolatedAsyncioTestCase):
         db_result.scalars.return_value.all.return_value = [owned_workflow]
         db.execute.return_value = db_result
 
-        with patch("app.api.workflows.list_active_executions", return_value=handles):
+        with (
+            patch(
+                "app.api.workflows.list_persisted_active_executions_for_user",
+                AsyncMock(return_value=[]),
+            ),
+            patch("app.api.workflows.list_active_executions", return_value=handles),
+        ):
             result = await list_active_workflow_executions(current_user=user, db=db)
 
         self.assertEqual(len(result), 1)
@@ -83,10 +130,53 @@ class ListActiveWorkflowExecutionsTests(unittest.IsolatedAsyncioTestCase):
         db_result.scalars.return_value.all.return_value = [workflow]
         db.execute.return_value = db_result
 
-        with patch("app.api.workflows.list_active_executions", return_value=[handle]):
+        with (
+            patch(
+                "app.api.workflows.list_persisted_active_executions_for_user",
+                AsyncMock(return_value=[]),
+            ),
+            patch("app.api.workflows.list_active_executions", return_value=[handle]),
+        ):
             result = await list_active_workflow_executions(current_user=user, db=db)
 
         self.assertEqual(result[0].started_at, datetime.datetime(2025, 1, 1, 12, 0, 0))
+
+    async def test_excludes_cancelled_local_fallback_handles(self) -> None:
+        user = MagicMock()
+        user.id = uuid.uuid4()
+
+        wf_id = uuid.uuid4()
+        ex_id = uuid.uuid4()
+        handle = _make_handle(wf_id, ex_id)
+        handle.event.set()
+
+        db = AsyncMock()
+
+        with (
+            patch(
+                "app.api.workflows.list_persisted_active_executions_for_user",
+                AsyncMock(return_value=[]),
+            ),
+            patch("app.api.workflows.list_active_executions", return_value=[handle]),
+        ):
+            result = await list_active_workflow_executions(current_user=user, db=db)
+
+        self.assertEqual(result, [])
+        db.execute.assert_not_called()
+
+
+class ListPersistedActiveExecutionsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_filters_out_cancel_requested_rows(self) -> None:
+        db = AsyncMock()
+        db_result = MagicMock()
+        db_result.all.return_value = []
+        db.execute.return_value = db_result
+
+        await list_persisted_active_executions_for_user(db, uuid.uuid4())
+
+        stmt = db.execute.call_args.args[0]
+        compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+        self.assertIn("active_workflow_executions.cancel_requested_at IS NULL", compiled)
 
 
 class SubWorkflowActiveTrackingTests(unittest.TestCase):

--- a/backend/tests/test_workflow_assistant_stream.py
+++ b/backend/tests/test_workflow_assistant_stream.py
@@ -1,0 +1,58 @@
+import asyncio
+import unittest
+import uuid
+from threading import Event
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from app.api.ai_assistant import AIAssistantRequest, workflow_assistant_stream
+from app.db.models import CredentialType
+
+
+class WorkflowAssistantStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
+    async def test_emits_hidden_heartbeat_while_waiting_for_model_stream(self) -> None:
+        release_stream = Event()
+        credential_id = uuid.uuid4()
+        user = SimpleNamespace(id=uuid.uuid4())
+        credential = SimpleNamespace(
+            id=credential_id,
+            type=CredentialType.openai,
+            encrypted_config={},
+        )
+
+        async def fake_stream_llm_response(*_args: object, **_kwargs: object):
+            await asyncio.to_thread(release_stream.wait)
+            yield 'data: {"type": "done"}\n\n'
+
+        with (
+            patch(
+                "app.api.ai_assistant.get_credential_for_user",
+                AsyncMock(return_value=credential),
+            ),
+            patch("app.api.ai_assistant.decrypt_config", return_value={"api_key": "test"}),
+            patch("app.api.ai_assistant.get_openai_client", return_value=(object(), "openai")),
+            patch(
+                "app.api.ai_assistant.template_service.list_node_templates",
+                AsyncMock(return_value=[]),
+            ),
+            patch("app.api.ai_assistant.stream_llm_response", fake_stream_llm_response),
+            patch("app.api.ai_assistant.WORKFLOW_ASSISTANT_SSE_HEARTBEAT_SECONDS", 0.001),
+        ):
+            response = await workflow_assistant_stream(
+                request=AIAssistantRequest(
+                    credential_id=credential_id,
+                    model="gpt-test",
+                    message="hello",
+                    ask_mode=True,
+                ),
+                current_user=user,
+                db=AsyncMock(),
+            )
+
+            stream = response.body_iterator
+            self.assertEqual(await stream.__anext__(), ": heartbeat\n\n")
+
+            release_stream.set()
+            self.assertEqual(await stream.__anext__(), 'data: {"type": "done"}\n\n')
+            with self.assertRaises(StopAsyncIteration):
+                await stream.__anext__()

--- a/backend/tests/test_workflow_assistant_stream.py
+++ b/backend/tests/test_workflow_assistant_stream.py
@@ -53,6 +53,11 @@ class WorkflowAssistantStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(await stream.__anext__(), ": heartbeat\n\n")
 
             release_stream.set()
-            self.assertEqual(await stream.__anext__(), 'data: {"type": "done"}\n\n')
+            while True:
+                chunk = await stream.__anext__()
+                if chunk == 'data: {"type": "done"}\n\n':
+                    break
+                self.assertEqual(chunk, ": heartbeat\n\n")
+
             with self.assertRaises(StopAsyncIteration):
                 await stream.__anext__()

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import HTTPException, Request
 
 from app.api.ai_assistant import run_execute_workflow_tool
-from app.api.portal import portal_cancel_execution
+from app.api.portal import portal_cancel_execution, portal_execute_stream
 from app.api.workflows import (
     collect_referenced_workflows,
     execute_workflow_endpoint,
@@ -19,6 +19,7 @@ from app.api.workflows import (
     parse_execute_body,
 )
 from app.db.models import DataTable, DataTableRow
+from app.models.schemas import PortalExecuteRequest
 from app.services.workflow_executor import (
     ExecutionResult,
     SubWorkflowExecution,
@@ -270,7 +271,13 @@ class PortalCancelExecutionTests(unittest.IsolatedAsyncioTestCase):
             ]
         )
 
-        with patch("app.api.portal.cancel_active_execution", return_value=True) as cancel_mock:
+        with (
+            patch("app.api.portal.cancel_active_execution", return_value=True) as cancel_mock,
+            patch(
+                "app.api.portal.request_persisted_execution_cancel",
+                AsyncMock(return_value=True),
+            ) as persisted_cancel_mock,
+        ):
             result = await portal_cancel_execution(
                 slug="portal-test",
                 execution_id=execution_id,
@@ -280,6 +287,38 @@ class PortalCancelExecutionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, {"status": "cancel_requested"})
         cancel_mock.assert_called_once_with(workflow_id=workflow_id, execution_id=execution_id)
+        persisted_cancel_mock.assert_awaited_once_with(
+            db,
+            workflow_id=workflow_id,
+            execution_id=execution_id,
+        )
+
+    async def test_returns_cancel_requested_when_execution_is_on_another_worker(self) -> None:
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _ScalarResult(SimpleNamespace(id=workflow_id)),
+                _ScalarResult(None),
+            ]
+        )
+
+        with (
+            patch("app.api.portal.cancel_active_execution", return_value=False),
+            patch(
+                "app.api.portal.request_persisted_execution_cancel",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            result = await portal_cancel_execution(
+                slug="portal-test",
+                execution_id=execution_id,
+                request=make_request(),
+                db=db,
+            )
+
+        self.assertEqual(result, {"status": "cancel_requested"})
 
     async def test_raises_not_found_when_execution_is_missing(self) -> None:
         workflow_id = uuid.uuid4()
@@ -292,7 +331,13 @@ class PortalCancelExecutionTests(unittest.IsolatedAsyncioTestCase):
             ]
         )
 
-        with patch("app.api.portal.cancel_active_execution", return_value=False):
+        with (
+            patch("app.api.portal.cancel_active_execution", return_value=False),
+            patch(
+                "app.api.portal.request_persisted_execution_cancel",
+                AsyncMock(return_value=False),
+            ),
+        ):
             with self.assertRaises(HTTPException) as context:
                 await portal_cancel_execution(
                     slug="portal-test",
@@ -303,6 +348,67 @@ class PortalCancelExecutionTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(context.exception.status_code, 404)
         self.assertEqual(context.exception.detail, "Execution not found or already finished")
+
+
+class PortalExecuteStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
+    async def test_emits_hidden_heartbeat_while_waiting_for_workflow_events(self) -> None:
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Portal Workflow",
+            nodes=[{"id": "n1", "type": "textInput", "data": {"label": "Input"}}],
+            edges=[],
+        )
+        release_executor = Event()
+
+        def fake_streaming_executor(**_kwargs: object):
+            release_executor.wait(timeout=2)
+            yield {
+                "type": "execution_complete",
+                "workflow_id": str(workflow.id),
+                "status": "success",
+                "outputs": {},
+                "node_results": [],
+                "sub_workflow_executions": [],
+                "execution_time_ms": 0,
+            }
+
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _ScalarResult(workflow),
+                _ScalarResult(None),
+            ]
+        )
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+
+        with (
+            patch("app.api.portal.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.portal.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.portal.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.portal.register_execution", return_value=Event()),
+            patch("app.api.portal.clear_active_execution"),
+            patch("app.api.portal.execute_workflow_streaming", fake_streaming_executor),
+            patch("app.api.portal._persist_global_variables_from_execution", AsyncMock()),
+            patch("app.api.portal.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch("app.api.portal.PORTAL_SSE_HEARTBEAT_SECONDS", 0.001),
+        ):
+            response = await portal_execute_stream(
+                slug="portal-test",
+                execute_data=PortalExecuteRequest(inputs={}),
+                request=make_request(),
+                db=db,
+            )
+
+            stream = response.body_iterator
+            self.assertIn('"type": "execution_started"', await stream.__anext__())
+            self.assertEqual(await stream.__anext__(), ": heartbeat\n\n")
+
+            release_executor.set()
+            self.assertIn('"type": "execution_complete"', await stream.__anext__())
+            with self.assertRaises(StopAsyncIteration):
+                await stream.__anext__()
 
 
 class ExecuteWorkflowStreamAvailabilityTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
- Persist active workflow executions in Postgres for multi-worker visibility
- Propagate cancel requests across workers while preserving local process kill behavior
- Hide cancel-requested executions from active history lists
- Add invisible SSE heartbeats for portal and workflow assistant streams
- Document test SECRET_KEY usage for local full-suite runs