### PR TITLE
feat: add generic webhook trigger node

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ cp .env.example .env
 
 | Category | Nodes |
 |----------|-------|
-| **Triggers** | Input (Webhook), Cron, RabbitMQ Receive, Error Handler |
+| **Triggers** | Input, Webhook Trigger, Cron, RabbitMQ Receive, Error Handler |
 | **AI** | LLM, AI Agent, Qdrant RAG |
 | **Logic** | Condition, Switch, Loop, Merge |
 | **Data** | Set, Variable, DataTable, Execute (sub-workflow) |

--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -1,0 +1,66 @@
+"""Generic HTTP webhook trigger endpoint."""
+
+import json
+import uuid
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user_optional
+from app.api.workflows import execute_workflow_request
+from app.db.models import User, Workflow
+from app.db.session import get_db
+
+router = APIRouter()
+
+
+async def _find_workflow_by_node_id(db: AsyncSession, node_id: str) -> Workflow | None:
+    """Use JSONB containment to find the workflow containing this node_id."""
+    result = await db.execute(
+        select(Workflow).where(
+            text("nodes::jsonb @> (:node_filter)::jsonb").bindparams(
+                node_filter=json.dumps([{"id": node_id}])
+            )
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+def _find_webhook_trigger_node(workflow: Workflow, node_id: str) -> dict | None:
+    """Return the matching webhookTrigger node, if it exists in this workflow."""
+    for node in workflow.nodes or []:
+        if node.get("id") != node_id:
+            continue
+        if node.get("type") != "webhookTrigger":
+            return None
+        if node.get("data", {}).get("active", True) is False:
+            return None
+        return node
+    return None
+
+
+@router.api_route("/{node_id}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+async def webhook_trigger(
+    node_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: User | None = Depends(get_current_user_optional),
+    db: AsyncSession = Depends(get_db),
+) -> object:
+    """Receive generic HTTP webhook requests and execute the owning workflow."""
+    workflow = await _find_workflow_by_node_id(db, node_id)
+    if workflow is None or _find_webhook_trigger_node(workflow, node_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No webhook trigger found for this URL",
+        )
+
+    return await execute_workflow_request(
+        workflow_id=uuid.UUID(str(workflow.id)),
+        request=request,
+        background_tasks=background_tasks,
+        current_user=current_user,
+        db=db,
+        default_trigger_source="webhook",
+    )

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -2081,7 +2081,10 @@ async def get_grist_columns(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-async def parse_execute_body(request: Request) -> tuple[object, bool, str | None, bool]:
+async def parse_execute_body(
+    request: Request,
+    default_trigger_source: str = "API",
+) -> tuple[object, bool, str | None, bool]:
     raw_body: object = {}
     test_run = _coerce_bool(request.query_params.get("test_run"))
     trigger_source = str(request.query_params.get("trigger_source") or "").strip() or None
@@ -2101,7 +2104,7 @@ async def parse_execute_body(request: Request) -> tuple[object, bool, str | None
                     raw_body = raw_body.get("inputs", {})
     except (json.JSONDecodeError, UnicodeDecodeError):
         pass
-    return raw_body, test_run, trigger_source or "API", simple_response
+    return raw_body, test_run, trigger_source or default_trigger_source, simple_response
 
 
 @router.post("/{workflow_id}/execute", response_model=WorkflowExecuteResponse)
@@ -2112,7 +2115,27 @@ async def execute_workflow_endpoint(
     current_user: User | None = Depends(get_current_user_optional),
     db: AsyncSession = Depends(get_db),
 ) -> WorkflowExecuteResponse:
-    raw_body, test_run, trigger_source, simple_response = await parse_execute_body(request)
+    return await execute_workflow_request(
+        workflow_id=workflow_id,
+        request=request,
+        background_tasks=background_tasks,
+        current_user=current_user,
+        db=db,
+    )
+
+
+async def execute_workflow_request(
+    workflow_id: uuid.UUID,
+    request: Request,
+    background_tasks: BackgroundTasks | None,
+    current_user: User | None,
+    db: AsyncSession,
+    default_trigger_source: str = "API",
+) -> WorkflowExecuteResponse:
+    raw_body, test_run, trigger_source, simple_response = await parse_execute_body(
+        request,
+        default_trigger_source=default_trigger_source,
+    )
 
     result = await db.execute(select(Workflow).where(Workflow.id == workflow_id))
     workflow = result.scalar_one_or_none()
@@ -2129,6 +2152,8 @@ async def execute_workflow_endpoint(
         "headers": _sanitize_headers(dict(request.headers)),
         "query": dict(request.query_params),
         "body": raw_body,
+        "method": request.method,
+        "triggered_at": datetime.now(timezone.utc).isoformat(),
     }
 
     client_ip = get_client_ip(request)
@@ -2678,6 +2703,8 @@ async def execute_workflow_stream(
         "headers": _sanitize_headers(dict(request.headers)),
         "query": dict(request.query_params),
         "body": raw_body,
+        "method": request.method,
+        "triggered_at": datetime.now(timezone.utc).isoformat(),
     }
 
     client_ip = get_client_ip(request)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,7 @@ from app.api import (
     traces,
     vector_stores,
     voice,
+    webhooks,
     workflows,
 )
 from app.api.deps import get_client_ip
@@ -240,6 +241,7 @@ app.include_router(expressions.router, prefix="/api/expressions", tags=["Express
 app.include_router(templates.router, prefix="/api/templates", tags=["Templates"])
 app.include_router(teams.router, prefix="/api/teams", tags=["Teams"])
 app.include_router(data_tables.router, prefix="/api/data-tables", tags=["Data Tables"])
+app.include_router(webhooks.router, prefix="/api/webhooks", tags=["Webhooks"])
 app.include_router(slack.router, prefix="/api/slack", tags=["Slack"])
 app.include_router(telegram.router, prefix="/api/telegram", tags=["Telegram"])
 app.include_router(schedules.router, prefix="/api/schedules", tags=["Schedules"])

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -202,6 +202,28 @@ In workflow expressions:
 - `$userInput.query.source` → query parameter value
 - `$userInput.headers.authorization` → header value
 
+### 1b. webhookTrigger (Generic HTTP Webhook Trigger)
+- **Purpose**: Receive generic HTTP webhook requests at a node-specific URL and trigger the workflow
+- **Inputs**: 0 | **Outputs**: 1
+- **WHEN TO USE**: When an external app should call a dedicated webhook URL to start the workflow, similar to n8n/Make webhook triggers
+- **Data fields**:
+  - `label`: Node identifier (e.g., "webhook")
+- **Output fields available downstream**:
+  - `$<label>.body` — request JSON body
+  - `$<label>.headers` — sanitized request headers
+  - `$<label>.query` — query parameters
+  - `$<label>.method` — HTTP method
+  - `$<label>.triggered_at` — ISO timestamp
+
+**Example node JSON:**
+```json
+{"id": "n1", "type": "webhookTrigger", "position": {"x": 100, "y": 100}, "data": {"label": "webhook"}}
+```
+
+**Example downstream expressions:**
+- Condition: `$webhook.body.event == "created"`
+- LLM user message: `"Process this payload: $webhook.body"`
+
 ### 2. cron (Scheduled Trigger)
 - **Purpose**: Trigger workflow on a schedule
 - **Inputs**: 0 | **Outputs**: 1

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -6224,6 +6224,15 @@ class WorkflowExecutor:
                     "event": trigger_inputs.get("event", {}),
                     "headers": trigger_inputs.get("headers", {}),
                 }
+            elif node_type == "webhookTrigger":
+                trigger_inputs = node_data.get("_initial_inputs", {})
+                output = {
+                    "body": trigger_inputs.get("body", {}),
+                    "headers": trigger_inputs.get("headers", {}),
+                    "query": trigger_inputs.get("query", {}),
+                    "method": trigger_inputs.get("method"),
+                    "triggered_at": trigger_inputs.get("triggered_at"),
+                }
             elif node_type == "telegramTrigger":
                 trigger_inputs = node_data.get("_initial_inputs", {})
                 output = {
@@ -9515,6 +9524,9 @@ class WorkflowExecutor:
             elif node.get("type") == "slackTrigger":
                 node["data"] = node.get("data", {})
                 node["data"]["_initial_inputs"] = initial_inputs
+            elif node.get("type") == "webhookTrigger":
+                node["data"] = node.get("data", {})
+                node["data"]["_initial_inputs"] = initial_inputs
             elif node.get("type") == "telegramTrigger":
                 node["data"] = node.get("data", {})
                 node["data"]["_initial_inputs"] = initial_inputs
@@ -10955,6 +10967,9 @@ def execute_workflow_streaming(
             node["data"] = node.get("data", {})
             node["data"]["_initial_inputs"] = inputs
         elif node.get("type") == "slackTrigger":
+            node["data"] = node.get("data", {})
+            node["data"]["_initial_inputs"] = inputs
+        elif node.get("type") == "webhookTrigger":
             node["data"] = node.get("data", {})
             node["data"]["_initial_inputs"] = inputs
         elif node.get("type") == "telegramTrigger":

--- a/backend/tests/test_webhook_trigger.py
+++ b/backend/tests/test_webhook_trigger.py
@@ -1,0 +1,155 @@
+"""Unit tests for the generic webhook trigger endpoint."""
+
+import json
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException
+from starlette.datastructures import Headers
+from starlette.requests import Request
+
+from app.services.workflow_executor import WorkflowExecutor
+
+
+def _make_request(
+    body_bytes: bytes = b"",
+    headers: dict[str, str] | None = None,
+    query_string: bytes = b"",
+    method: str = "POST",
+) -> Request:
+    """Build a minimal Starlette request."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": "/api/webhooks/test",
+        "headers": Headers(headers or {}).raw,
+        "query_string": query_string,
+    }
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": body_bytes, "more_body": False}
+
+    return Request(scope, receive)
+
+
+class TestWebhookTriggerEndpoint(unittest.IsolatedAsyncioTestCase):
+    async def test_known_webhook_node_delegates_to_workflow_execution(self) -> None:
+        from app.api.webhooks import webhook_trigger
+
+        node_id = str(uuid.uuid4())
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            nodes=[{"id": node_id, "type": "webhookTrigger", "data": {"label": "webhook"}}],
+        )
+        db = AsyncMock()
+
+        request = _make_request(
+            json.dumps({"event": "created"}).encode(),
+            {"content-type": "application/json"},
+            b"source=test",
+        )
+        expected_response = {"ok": True}
+
+        with (
+            patch(
+                "app.api.webhooks._find_workflow_by_node_id",
+                new=AsyncMock(return_value=workflow),
+            ),
+            patch(
+                "app.api.webhooks.execute_workflow_request",
+                new=AsyncMock(return_value=expected_response),
+            ) as execute_request,
+        ):
+            response = await webhook_trigger(
+                node_id=node_id,
+                request=request,
+                background_tasks=MagicMock(),
+                current_user=None,
+                db=db,
+            )
+
+        self.assertEqual(response, expected_response)
+        execute_request.assert_awaited_once()
+        call_kwargs = execute_request.await_args.kwargs
+        self.assertEqual(call_kwargs["workflow_id"], workflow_id)
+        self.assertEqual(call_kwargs["request"], request)
+        self.assertEqual(call_kwargs["current_user"], None)
+        self.assertEqual(call_kwargs["db"], db)
+        self.assertEqual(call_kwargs["default_trigger_source"], "webhook")
+
+    async def test_unknown_node_returns_404(self) -> None:
+        from app.api.webhooks import webhook_trigger
+
+        with patch(
+            "app.api.webhooks._find_workflow_by_node_id",
+            new=AsyncMock(return_value=None),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await webhook_trigger(
+                    node_id="missing",
+                    request=_make_request(),
+                    background_tasks=MagicMock(),
+                    current_user=None,
+                    db=AsyncMock(),
+                )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    async def test_non_webhook_node_returns_404(self) -> None:
+        from app.api.webhooks import webhook_trigger
+
+        node_id = str(uuid.uuid4())
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            nodes=[{"id": node_id, "type": "textInput", "data": {"label": "start"}}],
+        )
+
+        with patch(
+            "app.api.webhooks._find_workflow_by_node_id",
+            new=AsyncMock(return_value=workflow),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await webhook_trigger(
+                    node_id=node_id,
+                    request=_make_request(),
+                    background_tasks=MagicMock(),
+                    current_user=None,
+                    db=AsyncMock(),
+                )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class TestWebhookTriggerExecutor(unittest.TestCase):
+    def test_webhook_trigger_outputs_request_metadata(self) -> None:
+        node = {
+            "id": "webhook-1",
+            "type": "webhookTrigger",
+            "data": {"label": "webhook"},
+        }
+        executor = WorkflowExecutor(nodes=[node], edges=[])
+        result = executor.execute(
+            uuid.uuid4(),
+            {
+                "body": {"event": "created"},
+                "headers": {"content-type": "application/json"},
+                "query": {"source": "test"},
+                "method": "POST",
+                "triggered_at": "2026-06-05T12:00:00+00:00",
+            },
+        )
+
+        self.assertEqual(result.status, "success")
+        output = result.node_results[0]["output"]
+        self.assertEqual(output["body"], {"event": "created"})
+        self.assertEqual(output["headers"], {"content-type": "application/json"})
+        self.assertEqual(output["query"], {"source": "test"})
+        self.assertEqual(output["method"], "POST")
+        self.assertEqual(output["triggered_at"], "2026-06-05T12:00:00+00:00")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/Canvas/WorkflowCanvas.vue
+++ b/frontend/src/components/Canvas/WorkflowCanvas.vue
@@ -819,6 +819,7 @@ function handleDragLeave(event: DragEvent): void {
 function getDefaultNodeData(type: NodeType): WorkflowNode["data"] {
   const defaults: Record<NodeType, WorkflowNode["data"]> = {
     textInput: { label: "start", value: "", inputFields: [{ key: "text" }] },
+    webhookTrigger: { label: "webhook" },
     cron: { label: "cron", cronExpression: "0 * * * *" },
     websocketTrigger: {
       label: "websocketTrigger",

--- a/frontend/src/components/Docs/DocContent.vue
+++ b/frontend/src/components/Docs/DocContent.vue
@@ -22,6 +22,7 @@ const prevNext = computed(() => getPrevNextDoc(props.path));
 
 const NODE_TYPES_FOR_PREVIEW: NodeType[] = [
   "textInput",
+  "webhookTrigger",
   "cron",
   "telegramTrigger",
   "websocketTrigger",

--- a/frontend/src/components/Nodes/BaseNode.vue
+++ b/frontend/src/components/Nodes/BaseNode.vue
@@ -23,6 +23,7 @@ const emit = defineEmits<{
 
 const icons = {
   textInput: Type,
+  webhookTrigger: Globe,
   cron: CalendarClock,
   telegramTrigger: MessageSquare,
   websocketTrigger: Radio,
@@ -65,6 +66,7 @@ const icons = {
 
 const nodeColorMap = {
   textInput: "node-input",
+  webhookTrigger: "node-http",
   cron: "node-cron",
   telegramTrigger: "node-telegram",
   websocketTrigger: "node-websocket",
@@ -118,6 +120,7 @@ const hasInput = computed(
   () => !isToolNode.value
     && !isSubAgentNode.value
     && props.type !== "textInput"
+    && props.type !== "webhookTrigger"
     && props.type !== "cron"
     && props.type !== "sticky"
     && props.type !== "merge"
@@ -157,6 +160,7 @@ const hasErrorOutput = computed(() => {
   if (isSubAgentNode.value) return false;
   const excludedTypes = [
     "textInput",
+    "webhookTrigger",
     "cron",
     "sticky",
     "errorHandler",

--- a/frontend/src/components/Panels/NodePanel.vue
+++ b/frontend/src/components/Panels/NodePanel.vue
@@ -144,6 +144,7 @@ function scrollToSelectedNode(): void {
 
 const icons = {
   textInput: Type,
+  webhookTrigger: Globe,
   cron: CalendarClock,
   telegramTrigger: MessageSquare,
   websocketTrigger: Radio,

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -63,6 +63,7 @@ import type { WebSocketTriggerEventName } from "@/types/workflow";
 
 const nodeIcons: Record<NodeType, ReturnType<typeof Type>> = {
   textInput: Type,
+  webhookTrigger: Globe,
   cron: CalendarClock,
   websocketTrigger: Radio,
   llm: Brain,
@@ -105,6 +106,7 @@ const nodeIcons: Record<NodeType, ReturnType<typeof Type>> = {
 
 const nodeColorMap: Record<NodeType, string> = {
   textInput: "node-input",
+  webhookTrigger: "node-http",
   cron: "node-cron",
   websocketTrigger: "node-websocket",
   llm: "node-llm",
@@ -147,6 +149,7 @@ const nodeColorMap: Record<NodeType, string> = {
 
 const nodeDocSlugMap: Record<NodeType, string> = {
   textInput: "input-node",
+  webhookTrigger: "webhook-trigger-node",
   cron: "cron-node",
   websocketTrigger: "websocket-trigger-node",
   llm: "llm-node",
@@ -207,6 +210,14 @@ const runInputValues = computed(() => workflowStore.runInputValues);
 const runInputJson = computed(() => workflowStore.runInputJson);
 const allInputFields = computed(() => workflowStore.allInputFields);
 const isGenericWebhookBodyMode = computed(() => workflowStore.webhookBodyMode === "generic");
+const apiBaseUrl = computed((): string => {
+  return (import.meta.env.VITE_API_URL || window.location.origin).replace(/\/$/, "");
+});
+
+const webhookTriggerUrl = computed((): string => {
+  if (!selectedNode.value || selectedNode.value.type !== "webhookTrigger") return "";
+  return `${apiBaseUrl.value}/api/webhooks/${selectedNode.value.id}`;
+});
 
 const slackTriggerWebhookUrl = computed((): string => {
   if (!selectedNode.value || selectedNode.value.type !== "slackTrigger") return "";
@@ -220,6 +231,10 @@ const telegramTriggerWebhookUrl = computed((): string => {
 
 function copySlackWebhookUrl(): void {
   navigator.clipboard.writeText(slackTriggerWebhookUrl.value);
+}
+
+function copyWebhookTriggerUrl(): void {
+  navigator.clipboard.writeText(webhookTriggerUrl.value);
 }
 
 function copyTelegramWebhookUrl(): void {
@@ -5525,6 +5540,42 @@ onUnmounted(() => {
               <p class="text-xs text-muted-foreground">
                 Use standard cron format to define the schedule.
               </p>
+            </div>
+          </template>
+
+          <template v-if="selectedNode.type === 'webhookTrigger'">
+            <div class="space-y-4">
+              <div class="space-y-2">
+                <Label>Webhook URL</Label>
+                <div class="flex gap-2">
+                  <Input
+                    :model-value="webhookTriggerUrl"
+                    readonly
+                    class="font-mono text-xs"
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    @click="copyWebhookTriggerUrl"
+                  >
+                    Copy
+                  </Button>
+                </div>
+                <p class="text-xs text-muted-foreground">
+                  Send HTTP requests to this URL to start the workflow. The workflow authentication settings still apply.
+                </p>
+              </div>
+
+              <div class="space-y-2 pt-2 border-t">
+                <Label class="text-xs text-muted-foreground">Available output fields</Label>
+                <div class="text-xs text-muted-foreground space-y-1 font-mono">
+                  <div>${{ selectedNode.data.label }}.body — request JSON body</div>
+                  <div>${{ selectedNode.data.label }}.headers — sanitized request headers</div>
+                  <div>${{ selectedNode.data.label }}.query — query parameters</div>
+                  <div>${{ selectedNode.data.label }}.method — HTTP method</div>
+                  <div>${{ selectedNode.data.label }}.triggered_at — ISO timestamp</div>
+                </div>
+              </div>
             </div>
           </template>
 
@@ -11545,7 +11596,7 @@ onUnmounted(() => {
           </template>
 
           <div
-            v-if="!['textInput', 'cron', 'sticky', 'errorHandler', 'output', 'throwError', 'telegramTrigger', 'websocketTrigger', 'slackTrigger', 'imapTrigger'].includes(selectedNode.type) && !(selectedNode.type === 'rabbitmq' && selectedNode.data.rabbitmqOperation === 'receive')"
+            v-if="!['textInput', 'webhookTrigger', 'cron', 'sticky', 'errorHandler', 'output', 'throwError', 'telegramTrigger', 'websocketTrigger', 'slackTrigger', 'imapTrigger'].includes(selectedNode.type) && !(selectedNode.type === 'rabbitmq' && selectedNode.data.rabbitmqOperation === 'receive')"
             class="space-y-4 pt-4 border-t"
           >
             <Label class="text-muted-foreground">Error Handling</Label>

--- a/frontend/src/docs/content/nodes/webhook-trigger-node.md
+++ b/frontend/src/docs/content/nodes/webhook-trigger-node.md
@@ -1,0 +1,65 @@
+# Webhook Trigger
+
+The **Webhook Trigger** node starts a workflow from a node-specific HTTP webhook URL. Use it when an external system should call a dedicated trigger URL, similar to n8n or Make webhook modules.
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Inputs | 0 |
+| Outputs | 1 |
+| Endpoint | `/api/webhooks/{node_id}` |
+| Output | `$nodeLabel.body`, `$nodeLabel.headers`, `$nodeLabel.query`, `$nodeLabel.method`, `$nodeLabel.triggered_at` |
+
+## Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `label` | string | Node identifier used in expressions |
+
+The node panel shows a read-only **Webhook URL** with a copy button. Send HTTP requests to that URL to execute the workflow.
+
+## Authentication
+
+Webhook Trigger uses the workflow's existing authentication settings:
+
+| Workflow auth | Behavior |
+|---------------|----------|
+| `anonymous` | Anyone with the webhook URL can trigger the workflow |
+| `jwt` | Requires a user session bearer token or scoped execution token |
+| `header_auth` | Requires the configured custom header and value |
+
+## Accessing Request Data
+
+```text
+$webhook.body
+$webhook.body.event
+$webhook.headers
+$webhook.query
+$webhook.method
+$webhook.triggered_at
+```
+
+Header keys are lowercased and sensitive headers are removed before they are exposed to the workflow.
+
+## Example
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  "https://app.heym.ai/api/webhooks/{node_id}?source=crm" \
+  -d '{"event":"created","user":{"id":"123"}}'
+```
+
+Downstream expressions:
+
+- `$webhook.body.event`
+- `$webhook.body.user.id`
+- `$webhook.query.source`
+
+## Related
+
+- [Webhooks](../reference/webhooks.md) – Generic workflow execution webhooks
+- [Triggers](../reference/triggers.md) – All workflow entry points
+- [Expression DSL](../reference/expression-dsl.md) – Referencing `$nodeLabel.field`
+- [Execution Tokens](../reference/execution-tokens.md) – Scoped JWTs for external callers

--- a/frontend/src/docs/content/reference/features.md
+++ b/frontend/src/docs/content/reference/features.md
@@ -48,6 +48,12 @@ The Input node is the entry point for workflows that receive data from the user 
 
 Pairs naturally with [Condition](../nodes/condition-node.md), [LLM](../nodes/llm-node.md), and [Output](../nodes/output-node.md). For payload references and field access, see [Expression DSL](./expression-dsl.md) and [Webhooks](./webhooks.md).
 
+#### [Webhook Trigger](../nodes/webhook-trigger-node.md)
+
+The Webhook Trigger node receives generic HTTP webhook requests at a node-specific URL and starts the workflow immediately. It exposes the request body, sanitized headers, query parameters, HTTP method, and trigger timestamp for downstream routing and processing.
+
+Pairs naturally with [Condition](../nodes/condition-node.md), [Set](../nodes/set-node.md), [LLM](../nodes/llm-node.md), and [JSON output mapper](../nodes/json-output-mapper-node.md) for event-driven API workflows.
+
 #### [Cron](../nodes/cron-node.md)
 
 The Cron node triggers a workflow on a schedule using a standard five-field cron expression. No user input is required—the workflow runs automatically at the specified times (e.g. hourly, daily, every 15 minutes). Output is a trigger event with no payload.

--- a/frontend/src/docs/content/reference/node-types.md
+++ b/frontend/src/docs/content/reference/node-types.md
@@ -7,6 +7,7 @@ Heym provides a variety of node types for building workflows. Use [expressions](
 | Node | Description | Outputs |
 |------|-------------|---------|
 | [Input](../nodes/input-node.md) | Text entry point for the workflow (HTTP/[webhook](./webhooks.md)) | 1 |
+| [Webhook Trigger](../nodes/webhook-trigger-node.md) | Trigger from a node-specific HTTP webhook URL | 1 |
 | [Cron](../nodes/cron-node.md) | Trigger on a schedule (cron expression) | 1 |
 | [Telegram Trigger](../nodes/telegram-trigger-node.md) | Trigger when a Telegram bot webhook update arrives | 1 |
 | [IMAP Trigger](../nodes/imap-trigger-node.md) | Trigger when a new email arrives in an IMAP mailbox | 1 |

--- a/frontend/src/docs/content/reference/triggers.md
+++ b/frontend/src/docs/content/reference/triggers.md
@@ -9,6 +9,7 @@ Start nodes (no incoming edges) that initiate execution:
 | Node Type | Description |
 |-----------|-------------|
 | [Input](../nodes/input-node.md) (textInput) | HTTP entry point. Receives `body`, `headers`, `query` from requests. |
+| [Webhook Trigger](../nodes/webhook-trigger-node.md) | Node-specific HTTP webhook URL. Receives `body`, `headers`, `query`, `method`, and `triggered_at`. |
 | [Cron](../nodes/cron-node.md) | Runs on a schedule (cron expression, e.g. `0 * * * *` for hourly). |
 | [Telegram Trigger](../nodes/telegram-trigger-node.md) | Starts when Telegram sends a bot webhook update to the node-specific webhook URL. |
 | [IMAP Trigger](../nodes/imap-trigger-node.md) | Polls an IMAP mailbox and starts once for each newly detected email. |
@@ -21,6 +22,7 @@ Start nodes (no incoming edges) that initiate execution:
 | Trigger | Endpoint / Source | Auth |
 |---------|-------------------|------|
 | **Webhook/API** | `POST /api/workflows/{id}/execute` | `anonymous` / `jwt` / `header_auth` |
+| **Webhook Trigger** | `/api/webhooks/{node_id}` | Workflow auth (`anonymous` / `jwt` / `header_auth`) |
 | **MCP** | `POST /api/mcp/tools/call`, `/message`, `/sse` | `X-MCP-Key` header or Bearer token |
 | **Portal** | `POST /api/portal/{slug}/execute` | Portal session token |
 | **Cron** | Cron scheduler (runs every 60s, evaluates cron expressions) | N/A |
@@ -39,6 +41,10 @@ Start nodes (no incoming edges) that initiate execution:
 - **Auth**: Configured per workflow (`auth_type`, `allow_anonymous`)
 
 See [Webhooks](./webhooks.md) for details on TTL, cache, rate limiting, and auth.
+
+### Webhook Trigger
+
+Webhook Trigger nodes expose a dedicated URL at `/api/webhooks/{node_id}`. Requests run the owning workflow and pass `body`, sanitized `headers`, `query`, HTTP `method`, and `triggered_at` to the trigger node. Workflow authentication, response caching, rate limiting, execution history, and output response behavior match the standard Webhook/API endpoint.
 
 ### MCP
 
@@ -75,6 +81,7 @@ Execution history records `trigger_source` for every entry point:
 | Value | When |
 |-------|------|
 | `"API"` | Webhook / API call with no explicit header (default) |
+| `"webhook"` | Webhook Trigger call with no explicit header (default) |
 | `"Canvas"` | Run from the workflow editor canvas |
 | `"Quick Drawer"` | Run from the editor quick-drawer panel |
 | `"cron"` | Cron scheduler |
@@ -92,6 +99,7 @@ Execution history records `trigger_source` for every entry point:
 ## Inputs by Trigger
 
 - **HTTP/Webhook**: `body`, `headers`, `query` from the request
+- **Webhook Trigger**: `body`, `headers`, `query`, `method`, `triggered_at` from the request
 - **Cron**: `{"triggered_by": "cron"}`
 - **Telegram**: `update` + `message` + optional `callback_query` + sanitized `headers` + `triggered_by: "telegram"`
 - **IMAP**: `email` + `triggered_by: "imap"` + `triggered_at`

--- a/frontend/src/docs/content/reference/webhooks.md
+++ b/frontend/src/docs/content/reference/webhooks.md
@@ -8,6 +8,14 @@ Workflows can be triggered via HTTP webhooks. The standard execute endpoint retu
 
 Replace `{workflow_id}` with the workflow UUID. The base URL is your Heym instance (e.g. `https://app.heym.ai`).
 
+## Webhook Trigger Endpoint
+
+Webhook Trigger nodes also expose a node-specific URL:
+
+`/api/webhooks/{node_id}`
+
+Use this when an external system should call a dedicated trigger URL from the canvas. The request still runs the owning workflow and uses the same workflow authentication, rate limiting, response caching, execution history, and response behavior as `/execute`. The trigger node exposes `body`, sanitized `headers`, `query`, `method`, and `triggered_at`.
+
 ## Streaming Endpoint
 
 `POST /api/workflows/{workflow_id}/execute/stream`
@@ -183,7 +191,7 @@ curl -X POST \
 
 The **Copy cURL** button in the editor dialog includes `X-Trigger-Source: API` automatically. You can replace `API` with anything meaningful — `scheduler`, `rabbitmq`, `github-actions`, etc.
 
-If the header is not sent, `trigger_source` defaults to `"API"` and the run is labelled **API** in history. Override it with any value meaningful to your system — `scheduler`, `github-actions`, `rabbitmq`, etc.
+If the header is not sent, `trigger_source` defaults to `"API"` for `/execute` and `"webhook"` for Webhook Trigger URLs. Override it with any value meaningful to your system — `scheduler`, `github-actions`, `rabbitmq`, etc.
 
 ## Related
 

--- a/frontend/src/docs/manifest.ts
+++ b/frontend/src/docs/manifest.ts
@@ -28,6 +28,7 @@ export const DOCS_MANIFEST: Record<string, DocCategory> = {
       { slug: "agent-node", title: "Agent Node" },
       { slug: "mcp-call-node", title: "MCP Call Node" },
       { slug: "input-node", title: "Input" },
+      { slug: "webhook-trigger-node", title: "Webhook Trigger" },
       { slug: "cron-node", title: "Cron" },
       { slug: "telegram-trigger-node", title: "Telegram Trigger" },
       { slug: "imap-trigger-node", title: "IMAP Trigger" },

--- a/frontend/src/lib/canvasConnectionRules.ts
+++ b/frontend/src/lib/canvasConnectionRules.ts
@@ -18,6 +18,7 @@ export const BLOCKED_AS_TOOL_NODE_TYPES: ReadonlySet<NodeType> = new Set<NodeTyp
   "errorHandler",
   "cron",
   "textInput",
+  "webhookTrigger",
   "telegramTrigger",
   "websocketTrigger",
   "slackTrigger",
@@ -27,6 +28,7 @@ export const BLOCKED_AS_TOOL_NODE_TYPES: ReadonlySet<NodeType> = new Set<NodeTyp
 
 export const NO_REGULAR_INPUT_NODE_TYPES: ReadonlySet<NodeType> = new Set<NodeType>([
   "textInput",
+  "webhookTrigger",
   "cron",
   "sticky",
   "merge",

--- a/frontend/src/lib/nodeIcons.ts
+++ b/frontend/src/lib/nodeIcons.ts
@@ -39,6 +39,7 @@ import type { NodeType } from "@/types/workflow";
 
 export const nodeIcons: Record<NodeType, ReturnType<typeof Type>> = {
   textInput: Type,
+  webhookTrigger: Globe,
   cron: CalendarClock,
   telegramTrigger: MessageSquare,
   websocketTrigger: Radio,
@@ -82,6 +83,7 @@ export const nodeIcons: Record<NodeType, ReturnType<typeof Type>> = {
 /** Tailwind text-* classes aligned with canvas node header tints (BaseNode). */
 export const nodeIconColorClass: Record<NodeType, string> = {
   textInput: "text-node-input",
+  webhookTrigger: "text-node-http",
   cron: "text-node-cron",
   telegramTrigger: "text-node-telegram",
   websocketTrigger: "text-node-websocket",

--- a/frontend/src/types/node.ts
+++ b/frontend/src/types/node.ts
@@ -30,6 +30,18 @@ export const NODE_DEFINITIONS: Record<NodeType, NodeDefinition> = {
       inputFields: [{ key: "text" }],
     },
   },
+  webhookTrigger: {
+    type: "webhookTrigger",
+    label: "Webhook Trigger",
+    description: "Receive generic HTTP webhook requests",
+    color: "node-http",
+    icon: "Globe",
+    inputs: 0,
+    outputs: 1,
+    defaultData: {
+      label: "webhook",
+    },
+  },
   cron: {
     type: "cron",
     label: "Cron",

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -124,6 +124,7 @@ export interface AgentSkill {
 
 export type NodeType =
   | "textInput"
+  | "webhookTrigger"
   | "cron"
   | "telegramTrigger"
   | "websocketTrigger"


### PR DESCRIPTION
  ## Summary
  - Add a generic Webhook Trigger node with a node-specific `/api/webhooks/{node_id}` endpoint
  - Reuse existing workflow auth, rate limiting, caching, execution history, and response behavior
  - Expose request body, headers, query, method, and timestamp to downstream nodes
  - Add docs and backend tests

  ## Validation
  - Ran `./check.sh` with test `SECRET_KEY` and `ENCRYPTION_KEY`
  - 901 tests passed