### PR TITLE
fix: derive auth cookie security from public origin

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,7 +32,28 @@ from app.services.credential_access import get_accessible_credential
 
 router = APIRouter()
 
-_COOKIE_SECURE = not settings.cors_origins.startswith("http://localhost")
+
+def _is_local_http_origin(origin: str) -> bool:
+    """Return True when an origin is plain HTTP for a local development host."""
+    parsed = urlparse(origin.strip())
+    hostname = parsed.hostname or ""
+    return parsed.scheme == "http" and hostname in {"localhost", "127.0.0.1", "::1"}
+
+
+def _should_use_secure_auth_cookies(frontend_url: str, cors_origins: list[str]) -> bool:
+    """Use insecure cookies only for explicit local HTTP development origins."""
+    frontend = frontend_url.strip()
+    if frontend and not _is_local_http_origin(frontend):
+        return True
+
+    origins = [origin.strip() for origin in cors_origins if origin.strip()]
+    if not origins:
+        return not frontend or not _is_local_http_origin(frontend)
+
+    return not all(_is_local_http_origin(origin) for origin in origins)
+
+
+_COOKIE_SECURE = _should_use_secure_auth_cookies(settings.frontend_url, settings.cors_origins_list)
 _ACCESS_COOKIE_MAX_AGE = settings.jwt_access_token_expire_minutes * 60
 _REFRESH_COOKIE_MAX_AGE = settings.jwt_refresh_token_expire_days * 86400
 

--- a/backend/tests/test_auth_cookie_security.py
+++ b/backend/tests/test_auth_cookie_security.py
@@ -1,0 +1,47 @@
+"""Tests for auth cookie Secure flag environment decisions."""
+
+import unittest
+
+from app.api.auth import _should_use_secure_auth_cookies
+
+
+class AuthCookieSecurityTests(unittest.TestCase):
+    def test_local_frontend_url_allows_insecure_dev_cookie(self) -> None:
+        self.assertFalse(
+            _should_use_secure_auth_cookies("http://localhost:4017", ["http://localhost:4017"])
+        )
+
+    def test_https_frontend_url_uses_secure_cookie_even_with_local_cors_first(self) -> None:
+        self.assertTrue(
+            _should_use_secure_auth_cookies(
+                "https://heym.example.com",
+                ["http://localhost:4017", "https://heym.example.com"],
+            )
+        )
+
+    def test_local_frontend_url_uses_secure_cookie_with_https_cors_origin(self) -> None:
+        self.assertTrue(
+            _should_use_secure_auth_cookies(
+                "http://localhost:4017",
+                ["https://heym.example.com"],
+            )
+        )
+
+    def test_blank_frontend_uses_secure_cookie_when_any_cors_origin_is_not_local_http(self) -> None:
+        self.assertTrue(
+            _should_use_secure_auth_cookies(
+                "",
+                ["http://localhost:4017", "https://heym.example.com"],
+            )
+        )
+
+    def test_blank_frontend_allows_insecure_cookie_for_local_http_cors_only(self) -> None:
+        self.assertFalse(
+            _should_use_secure_auth_cookies(
+                "",
+                ["http://localhost:4017", "http://127.0.0.1:4017"],
+            )
+        )
+
+    def test_blank_origin_configuration_fails_secure(self) -> None:
+        self.assertTrue(_should_use_secure_auth_cookies("", []))


### PR DESCRIPTION
## Summary
- derive auth cookie Secure behavior from FRONTEND_URL before falling back to CORS origins
- allow insecure auth cookies only for explicit local HTTP development origins
- add coverage for HTTPS deployments where localhost appears first in CORS_ORIGINS

## Why
The previous check used `settings.cors_origins.startswith("http://localhost")`. In a deployment with `CORS_ORIGINS=http://localhost:4017,https://heym.example.com` and `FRONTEND_URL=https://heym.example.com`, auth cookies would be issued without the Secure flag even though the public app is HTTPS.

## Verification
- `cd frontend && bun run lint && bun run typecheck && bun run build`
- `cd backend && uv run ruff format --check . && uv run ruff check .`
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1 ./check.sh`