### PR TITLE
Harden Drive URL downloads

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -61,7 +61,6 @@ class Settings(BaseSettings):
     docs_dir: str = ""  # Path to docs content. Empty = use frontend/src/docs/content
     file_storage_dir: str = "./data/files"
     file_max_size_mb: int = 99
-    drive_download_allow_private_ips: bool = False
     mcp_protocol_max_concurrency: int = 20
     mcp_sse_max_sessions: int = 100
     app_version: str = ""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
     docs_dir: str = ""  # Path to docs content. Empty = use frontend/src/docs/content
     file_storage_dir: str = "./data/files"
     file_max_size_mb: int = 99
+    drive_download_allow_private_ips: bool = False
     mcp_protocol_max_concurrency: int = 20
     mcp_sse_max_sessions: int = 100
     app_version: str = ""

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -3,6 +3,7 @@ import asyncio
 import copy
 import gc
 import hashlib
+import ipaddress
 import json
 import logging
 import os
@@ -11,6 +12,7 @@ import random
 import re
 import shlex
 import signal
+import socket
 import time
 import uuid
 from collections import deque
@@ -21,7 +23,7 @@ from datetime import datetime, timedelta, timezone, tzinfo
 from functools import lru_cache
 from threading import Event, Lock, Thread, local
 from typing import Any
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urljoin, urlparse
 
 import httpx
 from simpleeval import DEFAULT_FUNCTIONS, EvalWithCompoundTypes, SimpleEval
@@ -43,6 +45,8 @@ from app.services.timezone_utils import get_configured_timezone, normalize_datet
 from app.services.websocket_utils import send_websocket_message
 
 logger = logging.getLogger(__name__)
+
+_DRIVE_DOWNLOAD_MAX_REDIRECTS = 5
 
 
 # Dict methods that commonly collide with JSON keys when using dot access (e.g. `$data.items`).
@@ -107,6 +111,70 @@ def run_async(coro):
             return loop.run_until_complete(coro)
     except RuntimeError:
         return asyncio.run(coro)
+
+
+def _host_has_private_address(hostname: str) -> bool:
+    host = hostname.strip("[]")
+    if "%" in host:
+        host = host.split("%", 1)[0]
+    try:
+        addresses = [ipaddress.ip_address(host)]
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(hostname, None)
+        except socket.gaierror as exc:
+            raise ValueError(
+                f"Drive Node: failed to resolve download URL host: {hostname}"
+            ) from exc
+        addresses = []
+        for family, _, _, _, sockaddr in resolved:
+            if family not in (socket.AF_INET, socket.AF_INET6):
+                continue
+            addresses.append(ipaddress.ip_address(sockaddr[0].split("%", 1)[0]))
+
+    if not addresses:
+        raise ValueError(f"Drive Node: failed to resolve download URL host: {hostname}")
+
+    return any(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+        for address in addresses
+    )
+
+
+def _validate_drive_download_url(raw_url: str) -> str:
+    from app.config import settings
+
+    parsed = urlparse(raw_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Drive Node: source URL must use http or https")
+    if not parsed.hostname:
+        raise ValueError("Drive Node: source URL must include a host")
+    if not settings.drive_download_allow_private_ips and _host_has_private_address(parsed.hostname):
+        raise ValueError("Drive Node: source URL resolves to a private or reserved address")
+    return raw_url
+
+
+def _fetch_drive_download_url(source_url: str) -> httpx.Response:
+    current_url = _validate_drive_download_url(source_url)
+    with httpx.Client(timeout=30, follow_redirects=False) as client:
+        for _ in range(_DRIVE_DOWNLOAD_MAX_REDIRECTS + 1):
+            response = client.get(current_url)
+            if response.status_code not in {301, 302, 303, 307, 308}:
+                response.raise_for_status()
+                return response
+
+            location = response.headers.get("location")
+            if not location:
+                response.raise_for_status()
+                return response
+            current_url = _validate_drive_download_url(urljoin(current_url, location))
+
+    raise ValueError("Drive Node: too many redirects while downloading URL")
 
 
 def _ensure_additional_properties(schema: dict) -> dict:
@@ -8734,7 +8802,12 @@ class WorkflowExecutor:
 
                 from app.db.models import FileAccessToken, GeneratedFile
                 from app.db.session import SessionLocal
-                from app.services.file_storage import _storage_root, build_download_url
+                from app.services.file_storage import (
+                    _normalize_storage_filename,
+                    _safe_storage_path,
+                    _storage_root,
+                    build_download_url,
+                )
 
                 operation = node_data.get("driveOperation", "")
                 if not operation:
@@ -8769,9 +8842,7 @@ class WorkflowExecutor:
                         raise ValueError("Drive Node: source URL is required for downloadUrl")
 
                     try:
-                        with httpx.Client(timeout=30, follow_redirects=True) as _client:
-                            _resp = _client.get(source_url)
-                            _resp.raise_for_status()
+                        _resp = _fetch_drive_download_url(source_url)
                         file_bytes = _resp.content
                         content_type = _resp.headers.get("content-type", "application/octet-stream")
                         mime_type = content_type.split(";")[0].strip()
@@ -8789,6 +8860,7 @@ class WorkflowExecutor:
                             filename = _url_path.split("/")[-1] if _url_path else ""
                         if not filename:
                             filename = "downloaded_file"
+                        filename = _normalize_storage_filename(filename)
                         if not mime_type or mime_type == "application/octet-stream":
                             _guessed = _mimetypes.guess_type(filename)[0]
                             if _guessed:
@@ -8809,7 +8881,7 @@ class WorkflowExecutor:
                     with SessionLocal() as db:
                         _file_uuid = uuid.uuid4()
                         _rel_path = f"{owner_id}/{_file_uuid}/{filename}"
-                        _abs_path = _storage_root() / _rel_path
+                        _abs_path = _safe_storage_path(_rel_path)
                         _abs_path.parent.mkdir(parents=True, exist_ok=True)
                         _abs_path.write_bytes(file_bytes)
 
@@ -9266,9 +9338,10 @@ class WorkflowExecutor:
 
                             import secrets as _secrets
 
+                            out_filename = _normalize_storage_filename(out_filename)
                             new_uuid = uuid.uuid4()
                             rel_path = f"{owner_id}/{new_uuid}/{out_filename}"
-                            abs_path = _storage_root() / rel_path
+                            abs_path = _safe_storage_path(rel_path)
                             abs_path.parent.mkdir(parents=True, exist_ok=True)
                             abs_path.write_bytes(out_bytes)
 

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -47,6 +47,7 @@ from app.services.websocket_utils import send_websocket_message
 logger = logging.getLogger(__name__)
 
 _DRIVE_DOWNLOAD_MAX_REDIRECTS = 5
+_DRIVE_DOWNLOAD_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 
 
 # Dict methods that commonly collide with JSON keys when using dot access (e.g. `$data.items`).
@@ -113,58 +114,104 @@ def run_async(coro):
         return asyncio.run(coro)
 
 
-def _host_has_private_address(hostname: str) -> bool:
+@dataclass(frozen=True)
+class _DriveDownloadTarget:
+    original_url: str
+    request_url: str
+    host_header: str
+    sni_hostname: str | None
+
+
+def _format_host_for_url(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+    if isinstance(address, ipaddress.IPv6Address):
+        return f"[{address.compressed}]"
+    return address.compressed
+
+
+def _format_host_header(hostname: str, scheme: str, port: int | None) -> str:
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    if port is not None and port != (443 if scheme == "https" else 80):
+        return f"{hostname}:{port}"
+    return hostname
+
+
+def _resolve_drive_download_addresses(
+    hostname: str,
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
     host = hostname.strip("[]")
     if "%" in host:
         host = host.split("%", 1)[0]
+
     try:
-        addresses = [ipaddress.ip_address(host)]
+        return [ipaddress.ip_address(host)]
     except ValueError:
-        try:
-            resolved = socket.getaddrinfo(hostname, None)
-        except socket.gaierror as exc:
-            raise ValueError(
-                f"Drive Node: failed to resolve download URL host: {hostname}"
-            ) from exc
-        addresses = []
-        for family, _, _, _, sockaddr in resolved:
-            if family not in (socket.AF_INET, socket.AF_INET6):
-                continue
-            addresses.append(ipaddress.ip_address(sockaddr[0].split("%", 1)[0]))
+        pass
+
+    try:
+        resolved = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"Drive Node: failed to resolve download URL host: {hostname}") from exc
+
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    seen: set[str] = set()
+    for family, _, _, _, sockaddr in resolved:
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            continue
+        address = ipaddress.ip_address(sockaddr[0].split("%", 1)[0])
+        address_key = address.compressed
+        if address_key in seen:
+            continue
+        seen.add(address_key)
+        addresses.append(address)
 
     if not addresses:
         raise ValueError(f"Drive Node: failed to resolve download URL host: {hostname}")
-
-    return any(
-        address.is_private
-        or address.is_loopback
-        or address.is_link_local
-        or address.is_multicast
-        or address.is_reserved
-        or address.is_unspecified
-        for address in addresses
-    )
+    return addresses
 
 
-def _validate_drive_download_url(raw_url: str) -> str:
-    from app.config import settings
-
+def _resolve_drive_download_target(raw_url: str) -> _DriveDownloadTarget:
     parsed = urlparse(raw_url)
     if parsed.scheme not in {"http", "https"}:
         raise ValueError("Drive Node: source URL must use http or https")
     if not parsed.hostname:
         raise ValueError("Drive Node: source URL must include a host")
-    if not settings.drive_download_allow_private_ips and _host_has_private_address(parsed.hostname):
-        raise ValueError("Drive Node: source URL resolves to a private or reserved address")
-    return raw_url
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("Drive Node: source URL includes an invalid port") from exc
+
+    addresses = _resolve_drive_download_addresses(parsed.hostname)
+    global_addresses = [address for address in addresses if address.is_global]
+    if not global_addresses:
+        raise ValueError("Drive Node: source URL must resolve to a globally routable address")
+
+    address = global_addresses[0]
+    request_netloc = _format_host_for_url(address)
+    if port is not None:
+        request_netloc = f"{request_netloc}:{port}"
+    request_url = parsed._replace(netloc=request_netloc).geturl()
+
+    hostname = parsed.hostname
+    sni_hostname = hostname.encode("idna").decode("ascii") if parsed.scheme == "https" else None
+    return _DriveDownloadTarget(
+        original_url=raw_url,
+        request_url=request_url,
+        host_header=_format_host_header(hostname, parsed.scheme, port),
+        sni_hostname=sni_hostname,
+    )
 
 
 def _fetch_drive_download_url(source_url: str) -> httpx.Response:
-    current_url = _validate_drive_download_url(source_url)
-    with httpx.Client(timeout=30, follow_redirects=False) as client:
-        for _ in range(_DRIVE_DOWNLOAD_MAX_REDIRECTS + 1):
-            response = client.get(current_url)
-            if response.status_code not in {301, 302, 303, 307, 308}:
+    current_url = source_url
+    for _ in range(_DRIVE_DOWNLOAD_MAX_REDIRECTS + 1):
+        target = _resolve_drive_download_target(current_url)
+        headers = {"Host": target.host_header}
+        extensions = {"sni_hostname": target.sni_hostname} if target.sni_hostname else None
+
+        with httpx.Client(timeout=30, follow_redirects=False, trust_env=False) as client:
+            response = client.get(target.request_url, headers=headers, extensions=extensions)
+            if response.status_code not in _DRIVE_DOWNLOAD_REDIRECT_STATUS_CODES:
                 response.raise_for_status()
                 return response
 
@@ -172,7 +219,7 @@ def _fetch_drive_download_url(source_url: str) -> httpx.Response:
             if not location:
                 response.raise_for_status()
                 return response
-            current_url = _validate_drive_download_url(urljoin(current_url, location))
+            current_url = urljoin(target.original_url, location)
 
     raise ValueError("Drive Node: too many redirects while downloading URL")
 

--- a/backend/tests/test_drive_node.py
+++ b/backend/tests/test_drive_node.py
@@ -929,16 +929,19 @@ class DriveNodeDownloadUrlTests(unittest.TestCase):
 
         with (
             patch("app.db.session.SessionLocal", return_value=db_mock),
-            patch("app.services.file_storage._storage_root") as mock_root,
+            patch("app.services.file_storage._safe_storage_path", return_value=storage_path_mock),
             patch(
                 "app.services.file_storage.build_download_url",
                 return_value="https://heym.run/api/files/dl/dltoken",
+            ),
+            patch(
+                "app.services.workflow_executor.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
             ),
             patch("httpx.Client") as mock_client_cls,
             patch("secrets.token_urlsafe", return_value="dltoken"),
         ):
             mock_client_cls.return_value.__enter__.return_value.get.return_value = http_response
-            mock_root.return_value.__truediv__ = MagicMock(return_value=storage_path_mock)
 
             result = executor.execute(
                 workflow_id=uuid.uuid4(),
@@ -958,6 +961,7 @@ class DriveNodeDownloadUrlTests(unittest.TestCase):
     ) -> MagicMock:
         resp = MagicMock()
         resp.content = content
+        resp.status_code = 200
         resp.headers = {
             "content-type": content_type,
             "content-disposition": content_disposition,
@@ -1038,6 +1042,87 @@ class DriveNodeDownloadUrlTests(unittest.TestCase):
         self.assertEqual(nr["status"], "success")
         self.assertEqual(nr["output"]["filename"], "data.csv")
 
+    def test_download_url_rejects_unsafe_content_disposition_filename(self) -> None:
+        """Remote filenames cannot escape the generated-file directory."""
+        owner_id = uuid.uuid4()
+        file_bytes = b"evil"
+        db = MagicMock()
+        db.__enter__ = MagicMock(return_value=db)
+        db.__exit__ = MagicMock(return_value=False)
+        db.flush = MagicMock()
+        db.commit = MagicMock()
+        db.add = MagicMock()
+
+        http_resp = self._make_http_response(
+            file_bytes,
+            content_type="text/plain",
+            content_disposition='attachment; filename="../evil.txt"',
+        )
+        storage_path = self._make_storage_path()
+
+        nr = self._run_download_workflow(
+            {
+                "label": "dl",
+                "driveOperation": "downloadUrl",
+                "driveSourceUrl": "https://example.com/file.txt",
+            },
+            owner_id,
+            db,
+            http_resp,
+            storage_path,
+        )
+
+        self.assertEqual(nr["status"], "error")
+        self.assertIn("Filename cannot contain path components", nr["error"])
+        storage_path.write_bytes.assert_not_called()
+
+    def test_download_url_rejects_private_ip_before_fetch(self) -> None:
+        """Private/internal targets are blocked before httpx connects."""
+        from app.services.workflow_executor import WorkflowExecutor
+
+        owner_id = uuid.uuid4()
+        nodes, edges = _make_workflow(
+            {
+                "label": "dl",
+                "driveOperation": "downloadUrl",
+                "driveSourceUrl": "http://127.0.0.1/metadata",
+            }
+        )
+        executor = WorkflowExecutor(nodes=nodes, edges=edges)
+        executor.trace_user_id = owner_id
+
+        with patch("httpx.Client") as mock_client_cls:
+            result = executor.execute(
+                workflow_id=uuid.uuid4(),
+                initial_inputs={"headers": {}, "query": {}, "body": {"text": "hi"}},
+            )
+
+        nr = next((r for r in result.node_results if r["node_type"] == "drive"), None)
+        self.assertIsNotNone(nr)
+        self.assertEqual(nr["status"], "error")
+        self.assertIn("private or reserved", nr["error"])
+        mock_client_cls.assert_not_called()
+
+    def test_download_url_rejects_redirect_to_private_ip_before_following(self) -> None:
+        """Redirect targets are validated before a follow-up request is made."""
+        from app.services.workflow_executor import _fetch_drive_download_url
+
+        redirect_resp = MagicMock()
+        redirect_resp.status_code = 302
+        redirect_resp.headers = {"location": "http://127.0.0.1/metadata"}
+        redirect_resp.raise_for_status = MagicMock()
+
+        client = MagicMock()
+        client.get.return_value = redirect_resp
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+
+        with patch("httpx.Client", return_value=client):
+            with self.assertRaisesRegex(ValueError, "private or reserved"):
+                _fetch_drive_download_url("http://93.184.216.34/start")
+
+        client.get.assert_called_once_with("http://93.184.216.34/start")
+
     def test_download_url_missing_url_raises(self) -> None:
         """Empty driveSourceUrl results in an error."""
         owner_id = uuid.uuid4()
@@ -1100,6 +1185,10 @@ class DriveNodeDownloadUrlTests(unittest.TestCase):
             patch("app.db.session.SessionLocal", return_value=db),
             patch("app.services.file_storage._storage_root"),
             patch("app.services.file_storage.build_download_url", return_value=""),
+            patch(
+                "app.services.workflow_executor.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+            ),
             patch("httpx.Client") as mock_client_cls,
         ):
             mock_client_cls.return_value.__enter__.return_value.get.side_effect = raise_http_error

--- a/backend/tests/test_drive_node.py
+++ b/backend/tests/test_drive_node.py
@@ -1100,8 +1100,68 @@ class DriveNodeDownloadUrlTests(unittest.TestCase):
         nr = next((r for r in result.node_results if r["node_type"] == "drive"), None)
         self.assertIsNotNone(nr)
         self.assertEqual(nr["status"], "error")
-        self.assertIn("private or reserved", nr["error"])
+        self.assertIn("globally routable", nr["error"])
         mock_client_cls.assert_not_called()
+
+    def test_download_url_rejects_non_global_resolved_address_before_fetch(self) -> None:
+        """Non-global DNS answers such as carrier-grade NAT are blocked."""
+        from app.services.workflow_executor import WorkflowExecutor
+
+        owner_id = uuid.uuid4()
+        nodes, edges = _make_workflow(
+            {
+                "label": "dl",
+                "driveOperation": "downloadUrl",
+                "driveSourceUrl": "https://example.com/metadata",
+            }
+        )
+        executor = WorkflowExecutor(nodes=nodes, edges=edges)
+        executor.trace_user_id = owner_id
+
+        with (
+            patch(
+                "app.services.workflow_executor.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("100.64.0.1", 0))],
+            ),
+            patch("httpx.Client") as mock_client_cls,
+        ):
+            result = executor.execute(
+                workflow_id=uuid.uuid4(),
+                initial_inputs={"headers": {}, "query": {}, "body": {"text": "hi"}},
+            )
+
+        nr = next((r for r in result.node_results if r["node_type"] == "drive"), None)
+        self.assertIsNotNone(nr)
+        self.assertEqual(nr["status"], "error")
+        self.assertIn("globally routable", nr["error"])
+        mock_client_cls.assert_not_called()
+
+    def test_download_url_connects_to_validated_address_with_original_host(self) -> None:
+        """The validated address is pinned for the HTTP request."""
+        from app.services.workflow_executor import _fetch_drive_download_url
+
+        response = self._make_http_response(b"ok", content_type="text/plain")
+        client = MagicMock()
+        client.get.return_value = response
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(
+                "app.services.workflow_executor.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+            ) as mock_getaddrinfo,
+            patch("httpx.Client", return_value=client),
+        ):
+            result = _fetch_drive_download_url("https://example.com/downloads/file.txt")
+
+        self.assertIs(result, response)
+        mock_getaddrinfo.assert_called_once()
+        client.get.assert_called_once_with(
+            "https://93.184.216.34/downloads/file.txt",
+            headers={"Host": "example.com"},
+            extensions={"sni_hostname": "example.com"},
+        )
 
     def test_download_url_rejects_redirect_to_private_ip_before_following(self) -> None:
         """Redirect targets are validated before a follow-up request is made."""
@@ -1118,10 +1178,14 @@ class DriveNodeDownloadUrlTests(unittest.TestCase):
         client.__exit__ = MagicMock(return_value=False)
 
         with patch("httpx.Client", return_value=client):
-            with self.assertRaisesRegex(ValueError, "private or reserved"):
+            with self.assertRaisesRegex(ValueError, "globally routable"):
                 _fetch_drive_download_url("http://93.184.216.34/start")
 
-        client.get.assert_called_once_with("http://93.184.216.34/start")
+        client.get.assert_called_once_with(
+            "http://93.184.216.34/start",
+            headers={"Host": "93.184.216.34"},
+            extensions=None,
+        )
 
     def test_download_url_missing_url_raises(self) -> None:
         """Empty driveSourceUrl results in an error."""

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -406,7 +406,15 @@ class PortalExecuteStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(await stream.__anext__(), ": heartbeat\n\n")
 
             release_executor.set()
-            self.assertIn('"type": "execution_complete"', await stream.__anext__())
+            complete_chunk = ""
+            for _ in range(100):
+                chunk = await stream.__anext__()
+                if '"type": "execution_complete"' in chunk:
+                    complete_chunk = chunk
+                    break
+                self.assertEqual(chunk, ": heartbeat\n\n")
+
+            self.assertIn('"type": "execution_complete"', complete_chunk)
             with self.assertRaises(StopAsyncIteration):
                 await stream.__anext__()
 


### PR DESCRIPTION
The Drive `downloadUrl` operation followed user-supplied URLs and used remote filenames to build storage paths. A download could reach an internal service, and a filename such as `../evil.txt` could escape the intended directory.

Downloads now require an HTTP or HTTPS URL that resolves to a globally routable address. The request connects to that validated address while preserving the original Host header and TLS server name. Checking DNS and then letting the HTTP client resolve the hostname again would leave a rebinding gap, so the connection uses the checked IP directly. Redirects are followed manually, with the same check before each new connection.

Downloaded and converted files also go through the existing filename and safe-storage-path helpers instead of constructing paths directly.

## Verification

The added tests cover unsafe remote filenames, non-public destinations, connecting to the validated address, and redirects to private addresses. Checks recorded for this change:

- `uv run pytest -q tests/test_drive_node.py tests/test_file_storage.py`
- `uv run ruff format --check app/services/workflow_executor.py app/config.py tests/test_drive_node.py`
- `uv run ruff check app/services/workflow_executor.py app/config.py tests/test_drive_node.py`
- `./run_tests.sh`
