### PR TITLE
Harden OAuth token handling

### DIFF
--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -55,6 +55,7 @@ from app.services.execution_cancellation import (
 )
 from app.services.global_variables_service import get_global_variables_context
 from app.services.mcp_session import mcp_session_store, mcp_sse_channels
+from app.services.oauth_tokens import oauth_token_lookup_values
 from app.services.workflow_executor import execute_workflow
 
 router = APIRouter()
@@ -144,7 +145,7 @@ async def get_mcp_user(
         now = datetime.now(timezone.utc)
         result = await db.execute(
             select(OAuthAccessToken).where(
-                OAuthAccessToken.access_token == bearer_token,
+                OAuthAccessToken.access_token.in_(oauth_token_lookup_values(bearer_token)),
                 OAuthAccessToken.revoked.is_(False),
                 OAuthAccessToken.expires_at > now,
             )

--- a/backend/app/api/mcp_servers.py
+++ b/backend/app/api/mcp_servers.py
@@ -44,6 +44,7 @@ from app.services.execution_cancellation import clear_execution as clear_active_
 from app.services.execution_cancellation import register_execution
 from app.services.global_variables_service import get_global_variables_context
 from app.services.mcp_session import mcp_session_store, mcp_sse_channels
+from app.services.oauth_tokens import oauth_token_lookup_values
 from app.services.workflow_executor import execute_workflow
 
 router = APIRouter()
@@ -138,7 +139,7 @@ async def _get_named_server_context(
         now = datetime.now(timezone.utc)
         token_res = await db.execute(
             select(OAuthAccessToken).where(
-                OAuthAccessToken.access_token == bearer_token,
+                OAuthAccessToken.access_token.in_(oauth_token_lookup_values(bearer_token)),
                 OAuthAccessToken.revoked.is_(False),
                 OAuthAccessToken.expires_at > now,
             )

--- a/backend/app/api/oauth.py
+++ b/backend/app/api/oauth.py
@@ -200,7 +200,7 @@ def _validate_pkce_request(
     client: OAuthClient,
     code_challenge: str,
     code_challenge_method: str,
-) -> None:
+) -> tuple[str, str]:
     challenge = code_challenge.strip()
     method = code_challenge_method.strip()
 
@@ -230,6 +230,8 @@ def _validate_pkce_request(
                 "error_description": "Public OAuth clients must use PKCE with S256",
             },
         )
+
+    return challenge, method
 
 
 async def _issue_tokens(db: AsyncSession, client_id: str, user_id, scope: str) -> dict:
@@ -381,7 +383,9 @@ async def authorize_get(
     if client is None or redirect_uri not in client.redirect_uris:
         raise HTTPException(400, detail="Invalid client_id or redirect_uri")
 
-    _validate_pkce_request(client, code_challenge, code_challenge_method)
+    code_challenge, code_challenge_method = _validate_pkce_request(
+        client, code_challenge, code_challenge_method
+    )
 
     csrf_token = _generate_csrf_token(client_id)
     return HTMLResponse(
@@ -421,7 +425,9 @@ async def authorize_post(
     if client is None or redirect_uri not in client.redirect_uris:
         raise HTTPException(400, detail="Invalid client")
 
-    _validate_pkce_request(client, code_challenge, code_challenge_method)
+    code_challenge, code_challenge_method = _validate_pkce_request(
+        client, code_challenge, code_challenge_method
+    )
 
     # Verify CSRF token
     if not _verify_csrf_token(client_id, csrf_token):

--- a/backend/app/api/oauth.py
+++ b/backend/app/api/oauth.py
@@ -511,10 +511,12 @@ async def _handle_auth_code_grant(request: Request, form: dict, db: AsyncSession
     client = await _authenticate_client(form, request, db)
 
     result = await db.execute(
-        select(OAuthAuthorizationCode).where(
+        select(OAuthAuthorizationCode)
+        .where(
             OAuthAuthorizationCode.code == code_str,
             OAuthAuthorizationCode.used.is_(False),
-        ).with_for_update()
+        )
+        .with_for_update()
     )
     auth_code = result.scalar_one_or_none()
 
@@ -578,12 +580,12 @@ async def _handle_refresh_token_grant(request: Request, form: dict, db: AsyncSes
     client = await _authenticate_client(form, request, db)
 
     result = await db.execute(
-        select(OAuthAccessToken).where(
-            OAuthAccessToken.refresh_token.in_(
-                oauth_token_lookup_values(str(refresh_token_str))
-            ),
+        select(OAuthAccessToken)
+        .where(
+            OAuthAccessToken.refresh_token.in_(oauth_token_lookup_values(str(refresh_token_str))),
             OAuthAccessToken.revoked.is_(False),
-        ).with_for_update()
+        )
+        .with_for_update()
     )
     token_record = result.scalar_one_or_none()
 

--- a/backend/app/api/oauth.py
+++ b/backend/app/api/oauth.py
@@ -18,10 +18,13 @@ from app.db.models import OAuthAccessToken, OAuthAuthorizationCode, OAuthClient,
 from app.db.session import get_db
 from app.services.auth import verify_password
 from app.services.auth_rate_limiter import oauth_register_limiter
+from app.services.oauth_tokens import hash_oauth_token, oauth_token_lookup_values
 
 router = APIRouter()
 
 _CSRF_MAX_AGE_SECONDS = 600  # 10-minute window
+_SUPPORTED_TOKEN_AUTH_METHODS = {"client_secret_post", "client_secret_basic", "none"}
+_SUPPORTED_PKCE_METHOD = "S256"
 
 
 def _generate_csrf_token(client_id: str) -> str:
@@ -190,7 +193,43 @@ async def _authenticate_client(form: dict, request: Request, db: AsyncSession) -
 def _verify_pkce(code_challenge: str, code_verifier: str) -> bool:
     digest = hashlib.sha256(code_verifier.encode()).digest()
     computed = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
-    return computed == code_challenge
+    return secrets.compare_digest(computed, code_challenge)
+
+
+def _validate_pkce_request(
+    client: OAuthClient,
+    code_challenge: str,
+    code_challenge_method: str,
+) -> None:
+    challenge = code_challenge.strip()
+    method = code_challenge_method.strip()
+
+    if challenge or method:
+        if not challenge:
+            raise HTTPException(
+                400,
+                detail={
+                    "error": "invalid_request",
+                    "error_description": "code_challenge is required when using PKCE",
+                },
+            )
+        if method != _SUPPORTED_PKCE_METHOD:
+            raise HTTPException(
+                400,
+                detail={
+                    "error": "invalid_request",
+                    "error_description": "Only S256 PKCE is supported",
+                },
+            )
+
+    if not client.is_confidential and (not challenge or method != _SUPPORTED_PKCE_METHOD):
+        raise HTTPException(
+            400,
+            detail={
+                "error": "invalid_request",
+                "error_description": "Public OAuth clients must use PKCE with S256",
+            },
+        )
 
 
 async def _issue_tokens(db: AsyncSession, client_id: str, user_id, scope: str) -> dict:
@@ -204,8 +243,8 @@ async def _issue_tokens(db: AsyncSession, client_id: str, user_id, scope: str) -
     )
 
     token = OAuthAccessToken(
-        access_token=access_token,
-        refresh_token=refresh_token,
+        access_token=hash_oauth_token(access_token),
+        refresh_token=hash_oauth_token(refresh_token),
         client_id=client_id,
         user_id=user_id,
         scope=scope,
@@ -278,6 +317,18 @@ async def register_client(
     is_confidential = False
 
     token_auth_method = body.get("token_endpoint_auth_method", "none")
+    if (
+        not isinstance(token_auth_method, str)
+        or token_auth_method not in _SUPPORTED_TOKEN_AUTH_METHODS
+    ):
+        raise HTTPException(
+            400,
+            detail={
+                "error": "invalid_client_metadata",
+                "error_description": "Unsupported token_endpoint_auth_method",
+            },
+        )
+
     if token_auth_method in ("client_secret_post", "client_secret_basic"):
         client_secret = secrets.token_urlsafe(32)
         client_secret_hash = bcrypt.hashpw(client_secret.encode(), bcrypt.gensalt()).decode()
@@ -330,6 +381,8 @@ async def authorize_get(
     if client is None or redirect_uri not in client.redirect_uris:
         raise HTTPException(400, detail="Invalid client_id or redirect_uri")
 
+    _validate_pkce_request(client, code_challenge, code_challenge_method)
+
     csrf_token = _generate_csrf_token(client_id)
     return HTMLResponse(
         _render_consent_page(
@@ -367,6 +420,8 @@ async def authorize_post(
     client = await _get_client(db, client_id)
     if client is None or redirect_uri not in client.redirect_uris:
         raise HTTPException(400, detail="Invalid client")
+
+    _validate_pkce_request(client, code_challenge, code_challenge_method)
 
     # Verify CSRF token
     if not _verify_csrf_token(client_id, csrf_token):
@@ -453,7 +508,7 @@ async def _handle_auth_code_grant(request: Request, form: dict, db: AsyncSession
         select(OAuthAuthorizationCode).where(
             OAuthAuthorizationCode.code == code_str,
             OAuthAuthorizationCode.used.is_(False),
-        )
+        ).with_for_update()
     )
     auth_code = result.scalar_one_or_none()
 
@@ -469,7 +524,24 @@ async def _handle_auth_code_grant(request: Request, form: dict, db: AsyncSession
         raise HTTPException(400, detail={"error": "invalid_grant"})
 
     # PKCE verification
+    if not client.is_confidential and not auth_code.code_challenge:
+        raise HTTPException(
+            400,
+            detail={
+                "error": "invalid_grant",
+                "error_description": "PKCE is required for public clients",
+            },
+        )
+
     if auth_code.code_challenge:
+        if auth_code.code_challenge_method != _SUPPORTED_PKCE_METHOD:
+            raise HTTPException(
+                400,
+                detail={
+                    "error": "invalid_grant",
+                    "error_description": "Unsupported PKCE method",
+                },
+            )
         if not code_verifier:
             raise HTTPException(
                 400,
@@ -501,9 +573,11 @@ async def _handle_refresh_token_grant(request: Request, form: dict, db: AsyncSes
 
     result = await db.execute(
         select(OAuthAccessToken).where(
-            OAuthAccessToken.refresh_token == refresh_token_str,
+            OAuthAccessToken.refresh_token.in_(
+                oauth_token_lookup_values(str(refresh_token_str))
+            ),
             OAuthAccessToken.revoked.is_(False),
-        )
+        ).with_for_update()
     )
     token_record = result.scalar_one_or_none()
 

--- a/backend/app/services/oauth_tokens.py
+++ b/backend/app/services/oauth_tokens.py
@@ -1,0 +1,14 @@
+import hashlib
+
+
+def hash_oauth_token(token: str) -> str:
+    """Return the database-safe hash for an OAuth access or refresh token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def oauth_token_lookup_values(token: str) -> tuple[str, ...]:
+    """Accept new hashed-token rows and legacy plaintext rows during rotation."""
+    hashed = hash_oauth_token(token)
+    if hashed == token:
+        return (hashed,)
+    return (hashed, token)

--- a/backend/tests/test_oauth_api.py
+++ b/backend/tests/test_oauth_api.py
@@ -1,25 +1,78 @@
 import base64
 import hashlib
+import json
 import unittest
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlencode, urlparse
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
+from app.api.mcp import get_mcp_user
+from app.api.mcp_servers import _get_named_server_context
 from app.api.oauth import (
+    _generate_csrf_token,
     _issue_tokens,
     _validate_pkce_request,
     _verify_pkce,
+    authorize_get,
+    authorize_post,
     register_client,
+    token_endpoint,
 )
-from app.db.models import OAuthAccessToken
+from app.db.models import OAuthAccessToken, OAuthAuthorizationCode
 from app.services.oauth_tokens import hash_oauth_token, oauth_token_lookup_values
 
 
 def _pkce_challenge(verifier: str) -> str:
     digest = hashlib.sha256(verifier.encode()).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def _query_result(value: object) -> MagicMock:
+    return MagicMock(scalar_one_or_none=MagicMock(return_value=value))
+
+
+def _request(
+    *,
+    method: str = "POST",
+    path: str = "/",
+    data: dict[str, str] | None = None,
+    query_string: bytes = b"",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> Request:
+    body = urlencode(data or {}).encode()
+    request_headers = headers or []
+    if data is not None:
+        request_headers = [
+            *request_headers,
+            (b"content-type", b"application/x-www-form-urlencoded"),
+        ]
+
+    async def receive() -> dict[str, object]:
+        return {
+            "type": "http.request",
+            "body": body,
+            "more_body": False,
+        }
+
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": request_headers,
+            "query_string": query_string,
+        },
+        receive,
+    )
+
+
+def _compiled_in_values(statement: object, param_name: str) -> list[str]:
+    compiled = statement.compile()
+    values = compiled.params[param_name]
+    return list(values)
 
 
 class OAuthPKCETests(unittest.TestCase):
@@ -39,7 +92,7 @@ class OAuthPKCETests(unittest.TestCase):
     def test_confidential_client_may_skip_pkce(self) -> None:
         client = SimpleNamespace(is_confidential=True)
 
-        _validate_pkce_request(client, "", "")
+        self.assertEqual(_validate_pkce_request(client, "", ""), ("", ""))
 
     def test_unsupported_pkce_method_is_rejected(self) -> None:
         client = SimpleNamespace(is_confidential=True)
@@ -49,6 +102,113 @@ class OAuthPKCETests(unittest.TestCase):
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertEqual(ctx.exception.detail["error"], "invalid_request")
+
+    def test_pkce_values_are_normalized_for_storage(self) -> None:
+        client = SimpleNamespace(is_confidential=False)
+        challenge = _pkce_challenge("verifier")
+
+        self.assertEqual(
+            _validate_pkce_request(client, f" {challenge} ", " S256 "),
+            (challenge, "S256"),
+        )
+
+
+class OAuthEndpointFlowTests(unittest.IsolatedAsyncioTestCase):
+    async def test_authorize_endpoint_rejects_public_client_without_pkce(self) -> None:
+        client = SimpleNamespace(
+            client_id="public-client",
+            client_name="Public Client",
+            redirect_uris=["https://client.example/callback"],
+            is_confidential=False,
+        )
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_query_result(client))
+
+        with self.assertRaises(HTTPException) as ctx:
+            await authorize_get(
+                request=_request(method="GET", path="/authorize"),
+                client_id=client.client_id,
+                redirect_uri=client.redirect_uris[0],
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail["error"], "invalid_request")
+
+    async def test_authorize_and_token_endpoints_exchange_public_pkce_code(self) -> None:
+        client = SimpleNamespace(
+            client_id="public-client",
+            client_name="Public Client",
+            redirect_uris=["https://client.example/callback"],
+            is_confidential=False,
+        )
+        user = SimpleNamespace(id=uuid.uuid4(), email="user@example.com", hashed_password="hash")
+        verifier = "correct-horse-battery-staple"
+        challenge = _pkce_challenge(verifier)
+
+        added: list[object] = []
+        db = AsyncMock()
+        db.add = MagicMock(side_effect=added.append)
+        db.flush = AsyncMock()
+        db.execute = AsyncMock(side_effect=[
+            _query_result(client),
+            _query_result(user),
+        ])
+
+        authorize_response = None
+        with patch("app.api.oauth.verify_password", return_value=True):
+            authorize_response = await authorize_post(
+                request=_request(
+                    path="/authorize",
+                    data={
+                        "client_id": client.client_id,
+                        "redirect_uri": client.redirect_uris[0],
+                        "scope": "mcp",
+                        "state": "state-123",
+                        "code_challenge": f" {challenge} ",
+                        "code_challenge_method": " S256 ",
+                        "csrf_token": _generate_csrf_token(client.client_id),
+                        "email": user.email,
+                        "password": "secret",
+                    },
+                ),
+                db=db,
+            )
+
+        self.assertEqual(authorize_response.status_code, 302)
+        auth_code = next(obj for obj in added if isinstance(obj, OAuthAuthorizationCode))
+        self.assertEqual(auth_code.code_challenge, challenge)
+        self.assertEqual(auth_code.code_challenge_method, "S256")
+
+        redirect_params = parse_qs(urlparse(authorize_response.headers["location"]).query)
+        self.assertEqual(redirect_params["code"], [auth_code.code])
+        self.assertEqual(redirect_params["state"], ["state-123"])
+
+        db.execute = AsyncMock(side_effect=[
+            _query_result(client),
+            _query_result(auth_code),
+        ])
+        token_response = await token_endpoint(
+            request=_request(
+                path="/token",
+                data={
+                    "grant_type": "authorization_code",
+                    "client_id": client.client_id,
+                    "code": auth_code.code,
+                    "redirect_uri": client.redirect_uris[0],
+                    "code_verifier": verifier,
+                },
+            ),
+            db=db,
+        )
+
+        self.assertTrue(auth_code.used)
+        self.assertEqual(token_response.status_code, 200)
+        token_body = json.loads(token_response.body.decode())
+        self.assertEqual(token_body["token_type"], "bearer")
+        token_record = next(obj for obj in added if isinstance(obj, OAuthAccessToken))
+        self.assertEqual(token_record.access_token, hash_oauth_token(token_body["access_token"]))
+        self.assertEqual(token_record.refresh_token, hash_oauth_token(token_body["refresh_token"]))
 
 
 class OAuthTokenStorageTests(unittest.IsolatedAsyncioTestCase):
@@ -96,3 +256,64 @@ class OAuthRegistrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertEqual(ctx.exception.detail["error"], "invalid_client_metadata")
         db.add.assert_not_called()
+
+
+class MCPBearerTokenLookupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_default_mcp_auth_queries_hash_and_legacy_plaintext_token(self) -> None:
+        raw_token = "legacy-access-token"
+        user = SimpleNamespace(id=uuid.uuid4())
+        token_record = SimpleNamespace(user_id=user.id)
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=[
+            _query_result(token_record),
+            _query_result(user),
+        ])
+
+        result = await get_mcp_user(
+            request=_request(
+                method="GET",
+                path="/api/mcp/tools",
+                headers=[(b"authorization", f"Bearer {raw_token}".encode())],
+            ),
+            x_mcp_key=None,
+            db=db,
+        )
+
+        self.assertIs(result, user)
+        token_query = db.execute.call_args_list[0].args[0]
+        self.assertEqual(
+            _compiled_in_values(token_query, "access_token_1"),
+            list(oauth_token_lookup_values(raw_token)),
+        )
+
+    async def test_named_mcp_server_auth_queries_hash_and_legacy_plaintext_token(self) -> None:
+        raw_token = "legacy-server-token"
+        server_id = uuid.uuid4()
+        user = SimpleNamespace(id=uuid.uuid4())
+        server = SimpleNamespace(id=server_id, user_id=user.id)
+        token_record = SimpleNamespace(user_id=user.id)
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=[
+            _query_result(token_record),
+            _query_result(user),
+            _query_result(server),
+        ])
+
+        result_user, result_server = await _get_named_server_context(
+            server_id=server_id,
+            request=_request(
+                method="GET",
+                path=f"/api/mcp/servers/{server_id}/tools",
+                headers=[(b"authorization", f"Bearer {raw_token}".encode())],
+            ),
+            x_mcp_key=None,
+            db=db,
+        )
+
+        self.assertIs(result_user, user)
+        self.assertIs(result_server, server)
+        token_query = db.execute.call_args_list[0].args[0]
+        self.assertEqual(
+            _compiled_in_values(token_query, "access_token_1"),
+            list(oauth_token_lookup_values(raw_token)),
+        )

--- a/backend/tests/test_oauth_api.py
+++ b/backend/tests/test_oauth_api.py
@@ -150,10 +150,12 @@ class OAuthEndpointFlowTests(unittest.IsolatedAsyncioTestCase):
         db = AsyncMock()
         db.add = MagicMock(side_effect=added.append)
         db.flush = AsyncMock()
-        db.execute = AsyncMock(side_effect=[
-            _query_result(client),
-            _query_result(user),
-        ])
+        db.execute = AsyncMock(
+            side_effect=[
+                _query_result(client),
+                _query_result(user),
+            ]
+        )
 
         authorize_response = None
         with patch("app.api.oauth.verify_password", return_value=True):
@@ -184,10 +186,12 @@ class OAuthEndpointFlowTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(redirect_params["code"], [auth_code.code])
         self.assertEqual(redirect_params["state"], ["state-123"])
 
-        db.execute = AsyncMock(side_effect=[
-            _query_result(client),
-            _query_result(auth_code),
-        ])
+        db.execute = AsyncMock(
+            side_effect=[
+                _query_result(client),
+                _query_result(auth_code),
+            ]
+        )
         token_response = await token_endpoint(
             request=_request(
                 path="/token",
@@ -264,10 +268,12 @@ class MCPBearerTokenLookupTests(unittest.IsolatedAsyncioTestCase):
         user = SimpleNamespace(id=uuid.uuid4())
         token_record = SimpleNamespace(user_id=user.id)
         db = AsyncMock()
-        db.execute = AsyncMock(side_effect=[
-            _query_result(token_record),
-            _query_result(user),
-        ])
+        db.execute = AsyncMock(
+            side_effect=[
+                _query_result(token_record),
+                _query_result(user),
+            ]
+        )
 
         result = await get_mcp_user(
             request=_request(
@@ -293,11 +299,13 @@ class MCPBearerTokenLookupTests(unittest.IsolatedAsyncioTestCase):
         server = SimpleNamespace(id=server_id, user_id=user.id)
         token_record = SimpleNamespace(user_id=user.id)
         db = AsyncMock()
-        db.execute = AsyncMock(side_effect=[
-            _query_result(token_record),
-            _query_result(user),
-            _query_result(server),
-        ])
+        db.execute = AsyncMock(
+            side_effect=[
+                _query_result(token_record),
+                _query_result(user),
+                _query_result(server),
+            ]
+        )
 
         result_user, result_server = await _get_named_server_context(
             server_id=server_id,

--- a/backend/tests/test_oauth_api.py
+++ b/backend/tests/test_oauth_api.py
@@ -1,0 +1,98 @@
+import base64
+import hashlib
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import HTTPException
+
+from app.api.oauth import (
+    _issue_tokens,
+    _validate_pkce_request,
+    _verify_pkce,
+    register_client,
+)
+from app.db.models import OAuthAccessToken
+from app.services.oauth_tokens import hash_oauth_token, oauth_token_lookup_values
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+class OAuthPKCETests(unittest.TestCase):
+    def test_verify_pkce_accepts_s256_challenge(self) -> None:
+        verifier = "correct-horse-battery-staple"
+        self.assertTrue(_verify_pkce(_pkce_challenge(verifier), verifier))
+
+    def test_public_client_requires_s256_pkce(self) -> None:
+        client = SimpleNamespace(is_confidential=False)
+
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_pkce_request(client, "", "")
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail["error"], "invalid_request")
+
+    def test_confidential_client_may_skip_pkce(self) -> None:
+        client = SimpleNamespace(is_confidential=True)
+
+        _validate_pkce_request(client, "", "")
+
+    def test_unsupported_pkce_method_is_rejected(self) -> None:
+        client = SimpleNamespace(is_confidential=True)
+
+        with self.assertRaises(HTTPException) as ctx:
+            _validate_pkce_request(client, "challenge", "plain")
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail["error"], "invalid_request")
+
+
+class OAuthTokenStorageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_issue_tokens_stores_hashes_not_returned_token_values(self) -> None:
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+
+        result = await _issue_tokens(db, "client-id", uuid.uuid4(), "mcp")
+
+        token_record = db.add.call_args.args[0]
+        self.assertIsInstance(token_record, OAuthAccessToken)
+        self.assertEqual(token_record.access_token, hash_oauth_token(result["access_token"]))
+        self.assertEqual(token_record.refresh_token, hash_oauth_token(result["refresh_token"]))
+        self.assertNotEqual(token_record.access_token, result["access_token"])
+        self.assertNotEqual(token_record.refresh_token, result["refresh_token"])
+
+    def test_lookup_values_include_hash_and_legacy_plaintext_token(self) -> None:
+        values = oauth_token_lookup_values("legacy-token")
+
+        self.assertEqual(values[0], hash_oauth_token("legacy-token"))
+        self.assertEqual(values[1], "legacy-token")
+
+
+class OAuthRegistrationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_register_rejects_unsupported_token_auth_method(self) -> None:
+        request = SimpleNamespace(
+            headers={},
+            client=SimpleNamespace(host="127.0.0.1"),
+            json=AsyncMock(
+                return_value={
+                    "client_name": "Bad Client",
+                    "redirect_uris": ["https://example.com/callback"],
+                    "token_endpoint_auth_method": "client_secret_jwt",
+                }
+            ),
+        )
+        db = AsyncMock()
+        db.add = MagicMock()
+
+        with patch("app.api.oauth.oauth_register_limiter.is_allowed", return_value=(True, None)):
+            with self.assertRaises(HTTPException) as ctx:
+                await register_client(request, db)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail["error"], "invalid_client_metadata")
+        db.add.assert_not_called()


### PR DESCRIPTION
Public OAuth clients could start an authorization flow without PKCE, and issued access and refresh tokens were stored in plaintext. This change requires S256 PKCE for public clients at both authorization and token exchange, rejects unsupported client authentication methods, and uses a timing-safe comparison for the PKCE challenge.

New tokens are stored as SHA-256 hashes. Both MCP authentication paths can look up the new hashed rows as well as legacy plaintext rows, so existing sessions keep working during the transition. This PR does not migrate or revoke existing plaintext tokens; they remain usable until expiry or rotation.

Authorization-code and refresh-token grants also acquire row locks where the database supports them, to serialize the replay-sensitive lookups.

## Verification

The tests cover the authorization and token endpoints, public-client PKCE requirements, hashed token storage, and both MCP lookup paths, including legacy compatibility. Checks recorded for this change:

- `SECRET_KEY=test-secret-key-that-is-long-enough-for-oauth-tests ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 UV_CACHE_DIR=/tmp/heym-uv-cache uv run pytest tests/test_oauth_api.py tests/test_mcp_servers.py -q`
- `SECRET_KEY=test-secret-key-that-is-long-enough-for-oauth-tests ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 UV_CACHE_DIR=/tmp/heym-uv-cache ./run_tests.sh`
