### PR TITLE
Limit upload reads before buffering

### DIFF
--- a/backend/app/api/data_tables.py
+++ b/backend/app/api/data_tables.py
@@ -34,6 +34,7 @@ from app.models.schemas import (
     DataTableTeamShareResponse,
     DataTableUpdate,
 )
+from app.services.upload_limits import read_upload_file_limited
 
 router = APIRouter()
 
@@ -659,7 +660,7 @@ async def import_csv(
     columns = table.columns or []
     col_names = {col["name"] for col in columns}
 
-    content = await file.read()
+    content = await read_upload_file_limited(file)
     try:
         text = content.decode("utf-8-sig")
     except UnicodeDecodeError:

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -28,6 +28,7 @@ from app.services.file_storage import (
     validate_basic_auth,
 )
 from app.services.hitl_service import build_public_base_url
+from app.services.upload_limits import read_upload_file_limited
 
 router = APIRouter()
 
@@ -177,7 +178,7 @@ async def upload_file(
 ) -> GeneratedFileResponse:
     """Upload a file manually to Drive."""
     base_url = build_public_base_url(request)
-    file_bytes = await file.read()
+    file_bytes = await read_upload_file_limited(file)
     try:
         row = await store_file(
             db,

--- a/backend/app/api/vector_stores.py
+++ b/backend/app/api/vector_stores.py
@@ -38,6 +38,7 @@ from app.models.schemas import (
 )
 from app.services.encryption import decrypt_config
 from app.services.file_processor import create_file_processor
+from app.services.upload_limits import read_upload_file_limited
 from app.services.vector_store import create_vector_store_service
 
 router = APIRouter()
@@ -536,7 +537,7 @@ async def upload_file_to_vector_store(
             detail=f"File type not allowed. Allowed: {', '.join(allowed_extensions)}",
         )
 
-    file_content = await file.read()
+    file_content = await read_upload_file_limited(file)
     file_size = len(file_content)
 
     cred_result = await db.execute(select(Credential).where(Credential.id == store.credential_id))

--- a/backend/app/api/voice.py
+++ b/backend/app/api/voice.py
@@ -17,6 +17,7 @@ from app.services.elevenlabs_service import (
     text_to_speech,
 )
 from app.services.encryption import decrypt_config
+from app.services.upload_limits import read_upload_file_limited
 
 router = APIRouter()
 
@@ -127,7 +128,7 @@ async def transcribe(
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, str]:
     api_key, _ = await _resolve_credential(db, current_user, credential_id)
-    audio = await file.read()
+    audio = await read_upload_file_limited(file)
     try:
         return await speech_to_text(
             api_key, audio, file.filename or "audio.webm", file.content_type or "audio/webm"

--- a/backend/app/services/upload_limits.py
+++ b/backend/app/services/upload_limits.py
@@ -1,0 +1,30 @@
+from fastapi import HTTPException, UploadFile, status
+
+from app.config import settings
+
+_BYTES_PER_MB = 1024 * 1024
+
+
+def configured_upload_limit_bytes() -> int:
+    return settings.file_max_size_mb * _BYTES_PER_MB
+
+
+def _format_size(size_bytes: int) -> str:
+    if size_bytes % _BYTES_PER_MB == 0:
+        return f"{size_bytes // _BYTES_PER_MB} MB"
+    return f"{size_bytes} bytes"
+
+
+async def read_upload_file_limited(
+    file: UploadFile,
+    *,
+    max_bytes: int | None = None,
+) -> bytes:
+    limit = configured_upload_limit_bytes() if max_bytes is None else max_bytes
+    payload = await file.read(limit + 1)
+    if len(payload) > limit:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail=f"File size exceeds limit ({_format_size(limit)})",
+        )
+    return payload

--- a/backend/tests/test_upload_limits.py
+++ b/backend/tests/test_upload_limits.py
@@ -1,0 +1,26 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from fastapi import HTTPException, status
+
+from app.services.upload_limits import read_upload_file_limited
+
+
+class UploadLimitTests(unittest.IsolatedAsyncioTestCase):
+    async def test_read_upload_file_limited_reads_only_limit_plus_one_bytes(self) -> None:
+        upload = SimpleNamespace(read=AsyncMock(return_value=b"abc"))
+
+        payload = await read_upload_file_limited(upload, max_bytes=3)
+
+        self.assertEqual(payload, b"abc")
+        upload.read.assert_awaited_once_with(4)
+
+    async def test_read_upload_file_limited_rejects_oversized_upload(self) -> None:
+        upload = SimpleNamespace(read=AsyncMock(return_value=b"abcd"))
+
+        with self.assertRaises(HTTPException) as ctx:
+            await read_upload_file_limited(upload, max_bytes=3)
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_413_CONTENT_TOO_LARGE)
+        self.assertEqual(ctx.exception.detail, "File size exceeds limit (3 bytes)")

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -406,7 +406,15 @@ class PortalExecuteStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(await stream.__anext__(), ": heartbeat\n\n")
 
             release_executor.set()
-            self.assertIn('"type": "execution_complete"', await stream.__anext__())
+            complete_chunk = ""
+            for _ in range(100):
+                chunk = await stream.__anext__()
+                if '"type": "execution_complete"' in chunk:
+                    complete_chunk = chunk
+                    break
+                self.assertEqual(chunk, ": heartbeat\n\n")
+
+            self.assertIn('"type": "execution_complete"', complete_chunk)
             with self.assertRaises(StopAsyncIteration):
                 await stream.__anext__()
 


### PR DESCRIPTION
## Summary

This adds a shared bounded-read helper for uploaded files and uses it in the upload paths that were reading the entire request body into memory:

- manual generated-file uploads
- vector-store document uploads
- data-table CSV imports
- voice transcription uploads

The helper reads only `file_max_size_mb + 1 byte` worth of data, returns a `413` when the configured limit is exceeded, and keeps the existing downstream storage/processing behavior for valid files.

## Verification

- `SECRET_KEY=test-secret-key-that-is-long-enough-for-upload-tests ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 UV_CACHE_DIR=/tmp/heym-uv-cache uv run pytest tests/test_upload_limits.py tests/test_file_storage.py tests/test_voice_api.py -q`
- `SECRET_KEY=test-secret-key-that-is-long-enough-for-upload-tests ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 UV_CACHE_DIR=/tmp/heym-uv-cache ./run_tests.sh`
