### PR TITLE
Restrict workflow share management to owners

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1565,6 +1565,11 @@ async def list_workflow_shares(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow not found",
         )
+    if workflow.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only owner can list shares",
+        )
 
     result = await db.execute(
         select(WorkflowShare, User)
@@ -1600,6 +1605,11 @@ async def create_workflow_share(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow not found",
+        )
+    if workflow.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only owner can add shares",
         )
 
     result = await db.execute(select(User).where(User.email == share_data.email))
@@ -1650,6 +1660,11 @@ async def remove_workflow_share(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow not found",
+        )
+    if workflow.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only owner can remove shares",
         )
 
     result = await db.execute(

--- a/backend/tests/test_workflow_share_permissions.py
+++ b/backend/tests/test_workflow_share_permissions.py
@@ -1,0 +1,77 @@
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException, status
+
+from app.api.workflows import (
+    create_workflow_share,
+    list_workflow_shares,
+    remove_workflow_share,
+)
+from app.models.schemas import WorkflowShareRequest
+
+
+def _db_returning_workflow(workflow: SimpleNamespace) -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=workflow))
+    )
+    db.add = MagicMock()
+    db.delete = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+class WorkflowSharePermissionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_shared_user_cannot_list_user_shares(self) -> None:
+        owner_id = uuid.uuid4()
+        shared_user = SimpleNamespace(id=uuid.uuid4())
+        workflow = SimpleNamespace(id=uuid.uuid4(), owner_id=owner_id)
+        db = _db_returning_workflow(workflow)
+
+        with self.assertRaises(HTTPException) as ctx:
+            await list_workflow_shares(workflow.id, current_user=shared_user, db=db)
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(ctx.exception.detail, "Only owner can list shares")
+        self.assertEqual(db.execute.await_count, 1)
+
+    async def test_shared_user_cannot_create_user_share(self) -> None:
+        owner_id = uuid.uuid4()
+        shared_user = SimpleNamespace(id=uuid.uuid4())
+        workflow = SimpleNamespace(id=uuid.uuid4(), owner_id=owner_id)
+        db = _db_returning_workflow(workflow)
+
+        with self.assertRaises(HTTPException) as ctx:
+            await create_workflow_share(
+                workflow.id,
+                WorkflowShareRequest(email="target@example.com"),
+                current_user=shared_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(ctx.exception.detail, "Only owner can add shares")
+        self.assertEqual(db.execute.await_count, 1)
+        db.add.assert_not_called()
+
+    async def test_shared_user_cannot_remove_user_share(self) -> None:
+        owner_id = uuid.uuid4()
+        shared_user = SimpleNamespace(id=uuid.uuid4())
+        workflow = SimpleNamespace(id=uuid.uuid4(), owner_id=owner_id)
+        db = _db_returning_workflow(workflow)
+
+        with self.assertRaises(HTTPException) as ctx:
+            await remove_workflow_share(
+                workflow.id,
+                user_id=uuid.uuid4(),
+                current_user=shared_user,
+                db=db,
+            )
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(ctx.exception.detail, "Only owner can remove shares")
+        self.assertEqual(db.execute.await_count, 1)
+        db.delete.assert_not_called()


### PR DESCRIPTION
## Summary

This closes a workflow sharing permission gap from the audit.

User-level workflow share endpoints now match the existing team-share behavior: only the workflow owner can list, add, or remove user shares. A user who only has shared access to a workflow can still access the workflow itself, but they can no longer inspect or change the share list for someone else's workflow.

## Verification

- `SECRET_KEY=test-secret-key-that-is-long-enough-for-share-tests ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 UV_CACHE_DIR=/tmp/heym-uv-cache uv run pytest tests/test_workflow_share_permissions.py tests/test_workflow_execution_api.py tests/test_workflow_update_websocket_sync.py -q`
- `SECRET_KEY=test-secret-key-that-is-long-enough-for-share-tests ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 UV_CACHE_DIR=/tmp/heym-uv-cache ./run_tests.sh`
