### PR TITLE
Use non-mutating lint in PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Frontend lint
         working-directory: frontend
-        run: bun run lint
+        run: bun run lint:check
 
       - name: Frontend typecheck
         working-directory: frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",
+    "lint:check": "eslint .",
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

This keeps PR checks read-only.

The existing frontend `lint` script still runs ESLint with `--fix` for local cleanup, but CI now uses a new `lint:check` script that runs `eslint .` without modifying files. That makes lint failures explicit in pull requests instead of letting the workflow rewrite the checkout.

## Verification

- `BUN_INSTALL_CACHE_DIR=/tmp/heym-bun-cache bun run lint:check`
