### PR TITLE
[codex] Fix runbook console log output preview

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -8554,6 +8554,8 @@ class WorkflowExecutor:
                 )
                 first_input = next(iter(inputs.values()), {})
                 output = first_input if isinstance(first_input, dict) else {"value": first_input}
+                output = dict(output)
+                output["logMessage"] = self._unwrap_value(resolved)
 
             elif node_type == "playwright":
                 output = self._execute_playwright_node(node_data, inputs, node_id, node_label)

--- a/backend/tests/test_runbook_demo.py
+++ b/backend/tests/test_runbook_demo.py
@@ -53,6 +53,7 @@ class RunbookDemoExecutionTest(unittest.TestCase):
         # The consoleLog node logs the resolved $input.text.upper() to the heym.workflow logger.
         joined = "\n".join(captured.output)
         self.assertIn(RUNBOOK_EXPECTED_LOG, joined)
+        self.assertEqual(results["consoleLog"]["output"]["logMessage"], RUNBOOK_EXPECTED_LOG)
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -548,11 +548,39 @@ function getOutputText(output: unknown): string | null {
   return typeof t === "string" ? t : null;
 }
 
+function stringifyCompact(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function getConsoleLogOutputText(output: unknown): string | null {
+  const o = output as Record<string, unknown> | undefined;
+  if (!o || !Object.prototype.hasOwnProperty.call(o, "logMessage")) {
+    return null;
+  }
+  return stringifyCompact(o.logMessage);
+}
+
 function getMarkdownDisplayText(output: unknown): string | null {
   if (typeof output === "string") {
     return output;
   }
   return getOutputText(output);
+}
+
+interface ResultOutputDisplayTarget {
+  node_type: string;
+  output: unknown;
+}
+
+function getMarkdownDisplayTextForResult(result: ResultOutputDisplayTarget): string | null {
+  if (result.node_type === "consoleLog") {
+    const logged = getConsoleLogOutputText(result.output);
+    if (logged !== null) return logged;
+  }
+  return getMarkdownDisplayText(result.output);
 }
 
 function getGenericResultOutputText(output: unknown): string {
@@ -561,6 +589,14 @@ function getGenericResultOutputText(output: unknown): string {
     return text;
   }
   return JSON.stringify(output);
+}
+
+function getGenericResultOutputTextForResult(result: ResultOutputDisplayTarget): string {
+  if (result.node_type === "consoleLog") {
+    const logged = getConsoleLogOutputText(result.output);
+    if (logged !== null) return logged;
+  }
+  return getGenericResultOutputText(result.output);
 }
 
 function renderExecutionMarkdown(content: string): string {
@@ -2760,13 +2796,13 @@ function renderContent(content: string): string {
                 class="text-muted-foreground text-xs mt-1 min-w-0 max-w-full"
               >
                 <div
-                  v-if="showMarkdownInExecutionLog && getMarkdownDisplayText(result.output) !== null"
+                  v-if="showMarkdownInExecutionLog && getMarkdownDisplayTextForResult(result) !== null"
                   class="execution-markdown-output break-words font-sans min-w-0 max-w-full"
                 >
                   <!-- eslint-disable vue/no-v-html -->
                   <div
                     class="execution-markdown-output-inner min-w-0 max-w-full"
-                    v-html="renderExecutionMarkdown(getMarkdownDisplayText(result.output)!)"
+                    v-html="renderExecutionMarkdown(getMarkdownDisplayTextForResult(result)!)"
                   />
                   <!-- eslint-enable vue/no-v-html -->
                 </div>
@@ -2774,7 +2810,7 @@ function renderContent(content: string): string {
                   v-else
                   class="break-all whitespace-pre-wrap"
                 >
-                  {{ getGenericResultOutputText(result.output) }}
+                  {{ getGenericResultOutputTextForResult(result) }}
                 </div>
               </div>
             </template>


### PR DESCRIPTION
## What changed

- Store the resolved Console Log expression in node output as `logMessage` while preserving pass-through input output.
- Prefer `logMessage` for Console Log rows in the Execution Log preview.
- Add a focused runbook assertion that the resolved log output is available to the canvas.

## Why

The backend was resolving and logging the uppercase runbook expression, but the canvas Execution Log preview displayed the pass-through `text` field instead. This made the runbook look like the expression had not run.

## Validation

- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh`
- Frontend lint/typecheck passed
- Backend Ruff passed
- Backend tests passed: 948 tests