### PR TITLE
fix/agent-mcp-tool-timeout

### DIFF
--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -2240,7 +2240,11 @@ def _unified_tool_executor(
         from app.services.mcp_tool_executor import execute_mcp_tool
 
         connection = tool_def.get("_connection") or {}
-        return execute_mcp_tool(connection, name, args, timeout_seconds)
+        # The MCP connection's own "Timeout (s)" governs tool execution, mirroring
+        # the tool-listing path (workflow_executor._list_mcp_tools). Fall back to
+        # the agent-level toolTimeoutSeconds only when the connection has none.
+        mcp_timeout = float(connection.get("timeoutSeconds") or timeout_seconds)
+        return execute_mcp_tool(connection, name, args, mcp_timeout)
     if tool_def.get("_source") == "skill":
         from app.services.skill_python_executor import SkillExecutionResult, execute_skill_python
 

--- a/backend/tests/test_agent_mcp_tool_timeout.py
+++ b/backend/tests/test_agent_mcp_tool_timeout.py
@@ -1,0 +1,69 @@
+"""Unit tests for MCP tool execution timeout resolution in the agent path.
+
+An agent's MCP connection has its own ``timeoutSeconds`` (the "Timeout (s)" field
+in the UI). That per-connection timeout must govern the actual ``call_tool``
+execution, not just tool discovery/listing. Previously the agent-level
+``toolTimeoutSeconds`` was passed to every MCP call, so long-running MCP tools
+timed out regardless of the connection's configured timeout.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from app.services.llm_service import _unified_tool_executor
+
+
+class UnifiedToolExecutorMcpTimeoutTest(unittest.TestCase):
+    """MCP tool execution must honor the connection's own timeoutSeconds."""
+
+    def test_mcp_execution_uses_connection_timeout_over_agent_timeout(self) -> None:
+        captured: dict = {}
+
+        def fake_execute_mcp_tool(connection, name, args, timeout_seconds):
+            captured["timeout"] = timeout_seconds
+            return {"ok": True}
+
+        tool_def = {
+            "_source": "mcp",
+            "_connection": {
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com",
+                "timeoutSeconds": 1800,
+            },
+        }
+
+        with patch(
+            "app.services.mcp_tool_executor.execute_mcp_tool",
+            side_effect=fake_execute_mcp_tool,
+        ):
+            result = _unified_tool_executor(tool_def, "long_tool", {}, 300.0)
+
+        self.assertEqual(captured["timeout"], 1800.0)
+        self.assertEqual(result, {"ok": True})
+
+    def test_mcp_execution_falls_back_to_agent_timeout_when_connection_unset(self) -> None:
+        captured: dict = {}
+
+        def fake_execute_mcp_tool(connection, name, args, timeout_seconds):
+            captured["timeout"] = timeout_seconds
+            return {"ok": True}
+
+        tool_def = {
+            "_source": "mcp",
+            "_connection": {
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com",
+            },
+        }
+
+        with patch(
+            "app.services.mcp_tool_executor.execute_mcp_tool",
+            side_effect=fake_execute_mcp_tool,
+        ):
+            _unified_tool_executor(tool_def, "tool", {}, 45.0)
+
+        self.assertEqual(captured["timeout"], 45.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -6656,7 +6656,7 @@ onUnmounted(() => {
                 type="number"
                 :model-value="String(selectedNode.data.toolTimeoutSeconds ?? 30)"
                 min="1"
-                max="300"
+                max="3600"
                 placeholder="30"
                 @update:model-value="updateNodeData('toolTimeoutSeconds', parseInt($event, 10) || 30)"
               />
@@ -6783,7 +6783,7 @@ onUnmounted(() => {
                         type="number"
                         :model-value="String(conn.timeoutSeconds ?? 30)"
                         min="1"
-                        max="300"
+                        max="3600"
                         placeholder="30"
                         @update:model-value="updateAgentMCPConnection(idx, 'timeoutSeconds', parseInt($event, 10) || 30)"
                       />
@@ -7052,7 +7052,7 @@ onUnmounted(() => {
                       type="number"
                       :model-value="String(skill.timeoutSeconds ?? 30)"
                       min="1"
-                      max="300"
+                      max="3600"
                       placeholder="30"
                       @update:model-value="updateAgentSkill(idx, 'timeoutSeconds', parseInt($event, 10) || 30)"
                     />
@@ -11376,7 +11376,7 @@ onUnmounted(() => {
                         type="number"
                         :model-value="String(selectedNode.data.connection?.timeoutSeconds ?? 30)"
                         min="1"
-                        max="300"
+                        max="3600"
                         placeholder="30"
                         @update:model-value="updateMCPCallConnectionField('timeoutSeconds', parseInt($event, 10) || 30)"
                       />


### PR DESCRIPTION
Fix: Agent MCP tool calls now honor the MCP connection's own Timeout(s) : https://github.com/heymrun/heym/issues/173

The Agent node used the MCP connection's timeoutSeconds only for tool discovery (_list_mcp_tools), but the actual call_tool execution was always given the agent-level toolTimeoutSeconds instead. So setting MCP Timeout(s) = 1800 had no effect on long-running tool calls; they were bounded by the agent timeout (capped at 300 in the UI), which is why calls failed around the 5-minute mark.
