### PR TITLE
docs: align trigger output field references

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Describe the agents, orchestration pattern, and user-facing result you want; Hey
 
 > Create a workflow for me that includes a Roadmap Agent and a Best Food Agent. When the Orchestrator Agent receives a request, it will invoke these subagents in parallel and return the result to the user.
 
-### Runing Workflows
+### Running Workflows
 
 Execute the workflow directly from the canvas and inspect each step as results move through the graph.
 

--- a/backend/tests/test_discord_trigger.py
+++ b/backend/tests/test_discord_trigger.py
@@ -4,11 +4,15 @@ import json
 import time
 import unittest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi import HTTPException
 from starlette.datastructures import Headers
+
+from app.db.models import ExecutionHistory
+from app.services.workflow_executor import ExecutionResult
 
 
 def _generate_keypair() -> tuple[str, Ed25519PrivateKey]:
@@ -185,6 +189,62 @@ class TestDiscordValidSignature(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response, {"type": 5})
         mock_bg.assert_called_once()
+
+    async def test_background_execution_persists_trigger_input_fields(self) -> None:
+        from app.api.discord import _execute_workflow_background
+
+        owner_id = uuid.uuid4()
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            owner_id=owner_id,
+            name="Discord workflow",
+            nodes=[],
+            edges=[],
+        )
+        added_rows: list[object] = []
+        db = SimpleNamespace(
+            execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: workflow)),
+            add=added_rows.append,
+            commit=AsyncMock(),
+        )
+        execution_result = ExecutionResult(
+            workflow_id=workflow_id,
+            status="success",
+            outputs={"ok": True},
+            execution_time_ms=12.3,
+            node_results=[],
+            sub_workflow_executions=[],
+        )
+
+        with (
+            patch("app.api.discord.async_session_maker") as mock_session_maker,
+            patch("app.api.discord.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.discord.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.discord.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.discord.execute_workflow", return_value=execution_result),
+            patch("app.api.discord.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch("app.api.discord._persist_global_variables_from_execution", AsyncMock()),
+            patch("app.api.discord._send_discord_followup_message", AsyncMock()),
+        ):
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = db
+            mock_session.__aexit__.return_value = None
+            mock_session_maker.return_value = mock_session
+
+            await _execute_workflow_background(
+                workflow,
+                "discord-node",
+                {"type": 2, "token": "interaction-token", "data": {"name": "hello"}},
+                {"x-signature-timestamp": "123"},
+            )
+
+        history = next(row for row in added_rows if isinstance(row, ExecutionHistory))
+        self.assertEqual(history.trigger_source, "Discord")
+        self.assertEqual(history.inputs["triggered_by"], "Discord")
+        self.assertEqual(history.inputs["trigger_node_id"], "discord-node")
+        self.assertEqual(history.inputs["data"]["name"], "hello")
+        self.assertIn("triggered_at", history.inputs)
 
 
 class TestDiscordInvalidSignature(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_imap_trigger_service.py
+++ b/backend/tests/test_imap_trigger_service.py
@@ -152,6 +152,7 @@ class ImapTriggerExecutionHistoryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(parent.trigger_source, "imap")
         self.assertEqual(child.trigger_source, "SUB_WORKFLOW")
         self.assertEqual(parent.inputs["triggered_by"], "imap")
+        self.assertEqual(parent.inputs["trigger_node_id"], "imap-node")
         self.assertEqual(parent.inputs["email"]["subject"], "New ticket")
 
 

--- a/backend/tests/test_slack_trigger.py
+++ b/backend/tests/test_slack_trigger.py
@@ -6,10 +6,14 @@ import json
 import time
 import unittest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import HTTPException
 from starlette.datastructures import Headers
+
+from app.db.models import ExecutionHistory
+from app.services.workflow_executor import ExecutionResult
 
 
 def _make_signature(signing_secret: str, timestamp: str, body: str) -> str:
@@ -105,6 +109,60 @@ class TestSlackValidSignature(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response, {"ok": True})
         mock_bg.assert_called_once()
+
+    async def test_background_execution_persists_trigger_input_fields(self) -> None:
+        from app.api.slack import _execute_workflow_background
+
+        owner_id = uuid.uuid4()
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            owner_id=owner_id,
+            name="Slack workflow",
+            nodes=[],
+            edges=[],
+        )
+        added_rows: list[object] = []
+        db = SimpleNamespace(
+            execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: workflow)),
+            add=added_rows.append,
+            commit=AsyncMock(),
+        )
+        execution_result = ExecutionResult(
+            workflow_id=workflow_id,
+            status="success",
+            outputs={"ok": True},
+            execution_time_ms=12.3,
+            node_results=[],
+            sub_workflow_executions=[],
+        )
+
+        with (
+            patch("app.api.slack.async_session_maker") as mock_session_maker,
+            patch("app.api.slack.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.slack.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.slack.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.slack.execute_workflow", return_value=execution_result),
+            patch("app.api.slack.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch("app.api.slack._persist_global_variables_from_execution", AsyncMock()),
+        ):
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = db
+            mock_session.__aexit__.return_value = None
+            mock_session_maker.return_value = mock_session
+
+            await _execute_workflow_background(
+                workflow,
+                "slack-node",
+                {"event": {"type": "message", "text": "hello"}},
+                {"x-slack-request-timestamp": "123"},
+            )
+
+        history = next(row for row in added_rows if isinstance(row, ExecutionHistory))
+        self.assertEqual(history.trigger_source, "Slack")
+        self.assertEqual(history.inputs["triggered_by"], "Slack")
+        self.assertEqual(history.inputs["trigger_node_id"], "slack-node")
+        self.assertEqual(history.inputs["event"]["event"]["text"], "hello")
 
 
 class TestSlackInvalidSignature(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_telegram_trigger.py
+++ b/backend/tests/test_telegram_trigger.py
@@ -4,10 +4,14 @@ import asyncio
 import json
 import unittest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import HTTPException
 from starlette.datastructures import Headers
+
+from app.db.models import ExecutionHistory
+from app.services.workflow_executor import ExecutionResult
 
 
 def _make_request(body_bytes: bytes, headers: dict[str, str]) -> MagicMock:
@@ -78,6 +82,61 @@ class TestTelegramTriggerWebhook(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response, {"ok": True})
         mock_execute_background.assert_awaited_once()
+
+    async def test_background_execution_persists_trigger_input_fields(self) -> None:
+        from app.api.telegram import _execute_workflow_background
+
+        owner_id = uuid.uuid4()
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            owner_id=owner_id,
+            name="Telegram workflow",
+            nodes=[],
+            edges=[],
+        )
+        added_rows: list[object] = []
+        db = SimpleNamespace(
+            execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: workflow)),
+            add=added_rows.append,
+            commit=AsyncMock(),
+        )
+        execution_result = ExecutionResult(
+            workflow_id=workflow_id,
+            status="success",
+            outputs={"ok": True},
+            execution_time_ms=12.3,
+            node_results=[],
+            sub_workflow_executions=[],
+        )
+
+        with (
+            patch("app.api.telegram.async_session_maker") as mock_session_maker,
+            patch("app.api.telegram.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.telegram.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.telegram.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.telegram.execute_workflow", return_value=execution_result),
+            patch("app.api.telegram.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch("app.api.telegram._persist_global_variables_from_execution", AsyncMock()),
+        ):
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = db
+            mock_session.__aexit__.return_value = None
+            mock_session_maker.return_value = mock_session
+
+            await _execute_workflow_background(
+                workflow,
+                "telegram-node",
+                {"message": {"message_id": 7, "chat": {"id": 12345}, "text": "hello"}},
+                {"x-telegram-bot-api-secret-token": "expected-secret"},
+            )
+
+        history = next(row for row in added_rows if isinstance(row, ExecutionHistory))
+        self.assertEqual(history.trigger_source, "telegram")
+        self.assertEqual(history.inputs["triggered_by"], "telegram")
+        self.assertEqual(history.inputs["trigger_node_id"], "telegram-node")
+        self.assertEqual(history.inputs["message"]["text"], "hello")
+        self.assertIn("triggered_at", history.inputs)
 
     async def test_invalid_secret_token_returns_403(self) -> None:
         from app.api.telegram import telegram_webhook

--- a/frontend/src/docs/content/nodes/discord-trigger-node.md
+++ b/frontend/src/docs/content/nodes/discord-trigger-node.md
@@ -8,7 +8,7 @@ The **Discord Trigger** node is a zero-input entry point that receives Discord I
 |----------|-------|
 | Inputs | 0 |
 | Outputs | 1 |
-| Output | `$nodeLabel.interaction`, `$nodeLabel.type`, `$nodeLabel.data`, `$nodeLabel.headers`, `$nodeLabel.triggered_at` |
+| Output | `$nodeLabel.interaction`, `$nodeLabel.type`, `$nodeLabel.data`, `$nodeLabel.headers`, `$nodeLabel.triggered_by`, `$nodeLabel.trigger_node_id`, `$nodeLabel.triggered_at` |
 
 ## Parameters
 
@@ -54,6 +54,8 @@ After the node triggers, downstream nodes can access:
 | `$nodeLabel.data.name` | Slash command name, when applicable |
 | `$nodeLabel.data.options` | Slash command options array |
 | `$nodeLabel.headers` | Sanitized webhook headers |
+| `$nodeLabel.triggered_by` | Trigger source label (`"Discord"`) |
+| `$nodeLabel.trigger_node_id` | Canvas node ID that received the Discord interaction |
 | `$nodeLabel.triggered_at` | ISO timestamp for this workflow execution |
 
 ## Example Workflow

--- a/frontend/src/docs/content/nodes/imap-trigger-node.md
+++ b/frontend/src/docs/content/nodes/imap-trigger-node.md
@@ -8,7 +8,7 @@ The **IMAP Trigger** node polls an email inbox on a fixed interval and starts a 
 |----------|-------|
 | Inputs | 0 |
 | Outputs | 1 |
-| Output | `$nodeLabel.email`, `$nodeLabel.triggered_at` |
+| Output | `$nodeLabel.email`, `$nodeLabel.triggered_by`, `$nodeLabel.trigger_node_id`, `$nodeLabel.triggered_at` |
 
 ## Parameters
 
@@ -64,6 +64,8 @@ After the node triggers, downstream nodes can access:
 | `$nodeLabel.email.attachments` | Array of attachment metadata (`filename`, `content_type`, `size_bytes`) |
 | `$nodeLabel.email.headers` | Decoded header object |
 | `$nodeLabel.email.uid` | IMAP UID for deduping or logging |
+| `$nodeLabel.triggered_by` | Trigger source label (`"imap"`) |
+| `$nodeLabel.trigger_node_id` | Canvas node ID that detected the email |
 | `$nodeLabel.triggered_at` | ISO timestamp for the workflow execution |
 
 ## Example Workflow

--- a/frontend/src/docs/content/nodes/slack-trigger-node.md
+++ b/frontend/src/docs/content/nodes/slack-trigger-node.md
@@ -8,7 +8,7 @@ The **Slack Trigger** node is a zero-input entry point that receives Slack Event
 |----------|-------|
 | Inputs | 0 |
 | Outputs | 1 |
-| Output | `$nodeLabel.event`, `$nodeLabel.headers` |
+| Output | `$nodeLabel.event`, `$nodeLabel.headers`, `$nodeLabel.triggered_by`, `$nodeLabel.trigger_node_id` |
 
 ## Parameters
 
@@ -57,6 +57,8 @@ After the node triggers, downstream nodes can access:
 | `$nodeLabel.event.channel` | Channel ID |
 | `$nodeLabel.event.ts` | Event timestamp |
 | `$nodeLabel.headers` | Sanitized HTTP headers from Slack |
+| `$nodeLabel.triggered_by` | Trigger source label (`"Slack"`) |
+| `$nodeLabel.trigger_node_id` | Canvas node ID that received the Slack event |
 
 ## Example Workflow
 

--- a/frontend/src/docs/content/nodes/telegram-trigger-node.md
+++ b/frontend/src/docs/content/nodes/telegram-trigger-node.md
@@ -8,7 +8,7 @@ The **Telegram Trigger** node is a zero-input entry point that starts a workflow
 |----------|-------|
 | Inputs | 0 |
 | Outputs | 1 |
-| Output | `$nodeLabel.update`, `$nodeLabel.message`, `$nodeLabel.callback_query`, `$nodeLabel.headers`, `$nodeLabel.triggered_at` |
+| Output | `$nodeLabel.update`, `$nodeLabel.message`, `$nodeLabel.callback_query`, `$nodeLabel.headers`, `$nodeLabel.triggered_by`, `$nodeLabel.trigger_node_id`, `$nodeLabel.triggered_at` |
 
 ## Parameters
 
@@ -63,6 +63,8 @@ After the node triggers, downstream nodes can access:
 | `$nodeLabel.message.from.id` | Telegram user ID |
 | `$nodeLabel.callback_query` | Callback payload when the update came from an inline keyboard |
 | `$nodeLabel.headers` | Sanitized webhook headers |
+| `$nodeLabel.triggered_by` | Trigger source label (`"telegram"`) |
+| `$nodeLabel.trigger_node_id` | Canvas node ID that received the Telegram update |
 | `$nodeLabel.triggered_at` | ISO timestamp for this workflow execution |
 
 ## Example Workflow

--- a/frontend/src/docs/content/reference/security.md
+++ b/frontend/src/docs/content/reference/security.md
@@ -67,7 +67,7 @@ Use [Guardrails](./guardrails.md) on LLM and Agent nodes to block unsafe or poli
 - [Running & Deployment](../getting-started/running-and-deployment.md) – Configure `SECRET_KEY`, `ENCRYPTION_KEY`, and `ALLOW_REGISTER` at startup
 - [Execution Tokens](./execution-tokens.md) – Scoped JWTs for calling workflows from external systems
 - [Guardrails](./guardrails.md) – Block unsafe content in LLM and Agent nodes
-- [User Defaults](./user-defaults.md) – Change your password
+- [Settings](./user-settings.md) – Change your password
 - [Credentials Tab](../tabs/credentials-tab.md) – Manage API keys
 - [MCP Tab](../tabs/mcp-tab.md) – MCP API key and OAuth clients
 - [Portal](./portal.md) – Public chat portal access control

--- a/frontend/src/docs/content/reference/triggers.md
+++ b/frontend/src/docs/content/reference/triggers.md
@@ -64,11 +64,11 @@ The WebSocket trigger manager runs in the leader worker and keeps one outbound c
 
 ### Telegram
 
-Telegram sends bot webhook updates to `POST /api/telegram/webhook/{node_id}`. The payload is passed into the workflow as `update`, `message`, optional `callback_query`, sanitized `headers`, `trigger_node_id`, and `triggered_at`. If the selected credential has a secret token, Heym verifies `x-telegram-bot-api-secret-token` before execution.
+Telegram sends bot webhook updates to `POST /api/telegram/webhook/{node_id}`. The payload is passed into the workflow as `update`, `message`, optional `callback_query`, sanitized `headers`, `triggered_by`, `trigger_node_id`, and `triggered_at`. If the selected credential has a secret token, Heym verifies `x-telegram-bot-api-secret-token` before execution.
 
 ### Discord
 
-Discord sends interaction webhooks to `POST /api/discord/webhook/{node_id}`. The payload is passed into the workflow as `interaction`, `type`, `data`, sanitized `headers`, `trigger_node_id`, and `triggered_at`. Heym verifies the request using Ed25519 and the selected `discord_trigger` credential's application public key before execution.
+Discord sends interaction webhooks to `POST /api/discord/webhook/{node_id}`. The payload is passed into the workflow as `interaction`, `type`, `data`, sanitized `headers`, `triggered_by`, `trigger_node_id`, and `triggered_at`. Heym verifies the request using Ed25519 and the selected `discord_trigger` credential's application public key before execution.
 
 ### RabbitMQ
 
@@ -100,12 +100,12 @@ Execution history records `trigger_source` for every entry point:
 
 - **HTTP/Webhook**: `body`, `headers`, `query` from the request
 - **Cron**: `{"triggered_by": "cron"}`
-- **Telegram**: `update` + `message` + optional `callback_query` + sanitized `headers` + `triggered_by: "telegram"`
-- **Discord**: `interaction` + `type` + `data` + sanitized `headers` + `triggered_by: "Discord"`
-- **IMAP**: `email` + `triggered_by: "imap"` + `triggered_at`
+- **Telegram**: `update` + `message` + optional `callback_query` + sanitized `headers` + `triggered_by: "telegram"` + `trigger_node_id` + `triggered_at`
+- **Discord**: `interaction` + `type` + `data` + sanitized `headers` + `triggered_by: "Discord"` + `trigger_node_id` + `triggered_at`
+- **IMAP**: `email` + `triggered_by: "imap"` + `trigger_node_id` + `triggered_at`
 - **WebSocket**: `eventName` + `url` + `triggered_by: "websocket"` + `message` / `connection` / `close`
 - **RabbitMQ**: `message_data` + `triggered_by: "rabbitmq"`
-- **Slack**: `event` (full Slack event object) + `headers` (sanitized) + `triggered_by: "Slack"`
+- **Slack**: `event` (full Slack event object) + `headers` (sanitized) + `triggered_by: "Slack"` + `trigger_node_id`
 - **Portal**: `body.inputs` + optional `conversation_history`
 
 ## Related


### PR DESCRIPTION
## Summary
- Fix a README typo in the workflow demo section
- Document `triggered_by` and `trigger_node_id` across Slack, Telegram, Discord, and IMAP trigger docs
- Align the central Triggers reference with the trigger node docs
- Fix a broken Security docs related link from `user-defaults.md` to `user-settings.md`
- Add backend regression coverage for persisted trigger input fields

## Testing
- `git diff --check`
- Custom markdown link scan across 98 docs files: 0 broken relative links
- Docs manifest consistency check: 98 files / 98 manifest entries
- `uv run ruff format --check .`
- `uv run ruff check .`
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 ./run_tests.sh` (985 passed)
- `bun run lint:check`
- `bun run typecheck`