### PR TITLE
docs: clarify license and enterprise contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ If you'd rather contribute through code, please **[start a Discussion](https://g
 
 ## 🏢 Enterprise
 
-Commercial use, enterprise licensing, and professional support are available.
+Commercial licensing, enterprise deployment help, and professional support are available.
 
 **What we offer:**
 - Workflow automation infrastructure & deployment
@@ -658,7 +658,7 @@ Commercial use, enterprise licensing, and professional support are available.
 - Debugging, troubleshooting & solution support
 - Priority support & SLA guarantees
 
-📧 **Contact:** [support@heym.run](mailto:support@heym.run)
+📧 **Contact:** [enterprise@heym.run](mailto:enterprise@heym.run)
 
 ---
 

--- a/frontend/src/docs/content/getting-started/why-heym.md
+++ b/frontend/src/docs/content/getting-started/why-heym.md
@@ -202,7 +202,7 @@ Expressions work in every string field—prompts, HTTP headers, conditions, set 
 
 Like n8n, Heym is self-hostable. Unlike Zapier and Make.com, your automation data, credentials, and LLM calls never touch a third-party SaaS platform. For AI workloads that process sensitive documents, customer data, or proprietary knowledge bases, this is a hard requirement.
 
-Heym is licensed under the **MIT License with the Commons Clause condition**. The source code is source-available—you can use, modify, and self-host it freely. The Commons Clause restricts selling the software as a competing commercial product. For commercial use, enterprise deployments, or professional support, contact [enterprise@heym.run](mailto:enterprise@heym.run).
+Heym is licensed under the **MIT License with the Commons Clause condition**. The source code is source-available—you can use, modify, and self-host it freely. The Commons Clause restricts selling the software, including offering paid hosting or consulting/support services whose value derives substantially from Heym. For commercial licensing, enterprise deployments, or professional support, contact [enterprise@heym.run](mailto:enterprise@heym.run).
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Align the README enterprise contact email with the in-app Enterprise docs
- Clarify Commons Clause wording in the Why Heym docs to include paid hosting or consulting/support services whose value derives substantially from Heym
- Replace broad "commercial use" phrasing in the README Enterprise section with commercial licensing and deployment/support wording

## Testing
- `git diff --check`
- Custom markdown link scan across 98 docs files: 0 broken relative links
- Docs manifest consistency check: 98 files / 98 manifest entries