### PR TITLE
fix: centralize chat markdown rendering

### DIFF
--- a/frontend/src/components/Chat/ChatConversation.vue
+++ b/frontend/src/components/Chat/ChatConversation.vue
@@ -20,8 +20,6 @@ import {
   AudioLines,
   X,
 } from "lucide-vue-next";
-import { marked } from "marked";
-import DOMPurify from "dompurify";
 
 import type { Message, WorkflowPreview } from "@/types/chat";
 import type { CredentialListItem, LLMModel } from "@/types/credential";
@@ -31,6 +29,7 @@ import ReadonlyCanvasPreview from "@/components/Canvas/ReadonlyCanvasPreview.vue
 import Button from "@/components/ui/Button.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
 import { estimateTokens } from "@/lib/contextEstimator";
+import { markdownToPlainText, renderMarkdown } from "@/lib/markdown";
 import { aiApi, credentialsApi } from "@/services/api";
 import { useFileAttachment } from "@/composables/useFileAttachment";
 import type { AttachedFile } from "@/composables/useFileAttachment";
@@ -430,22 +429,6 @@ onMounted(() => {
   nextTick(updateMessageScrollbar);
 });
 
-function renderMarkdown(content: string): string {
-  if (!content) return "";
-  const html = marked(content, { breaks: true, gfm: true }) as string;
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: [
-      "p", "br", "strong", "em", "u", "s", "code", "pre", "blockquote",
-      "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "a", "hr",
-      "table", "thead", "tbody", "tr", "th", "td", "img", "video", "source",
-    ],
-    ALLOWED_ATTR: [
-      "href", "target", "rel", "src", "alt", "controls", "playsinline",
-      "muted", "loop", "preload", "type", "style",
-    ],
-  });
-}
-
 function handleMarkdownImageClick(event: MouseEvent): void {
   const target = event.target as HTMLElement;
   if (target.tagName === "IMG") {
@@ -505,19 +488,13 @@ async function copyMessage(msg: Message): Promise<void> {
 const tts = useTextToSpeech();
 const voiceStore = useVoiceStore();
 
-function plainTextFromMarkdown(markdown: string): string {
-  const div = document.createElement("div");
-  div.innerHTML = renderMarkdown(markdown);
-  return (div.textContent || div.innerText || "").trim();
-}
-
 async function readMessageAloud(msg: Message): Promise<void> {
   if (!tts.isConfigured.value) {
     voiceStore.requestVoiceSettings();
     return;
   }
   try {
-    await tts.speak(msg.id, plainTextFromMarkdown(msg.content));
+    await tts.speak(msg.id, markdownToPlainText(msg.content));
   } catch {
     // playback/synthesis failure is non-fatal; reset playback state
     tts.stop();

--- a/frontend/src/components/Dashboard/DashboardChatPanel.vue
+++ b/frontend/src/components/Dashboard/DashboardChatPanel.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { Bot, Check, ChevronDown, Copy, Loader2, Mic, MicOff, Paperclip, Send, Square, Trash2, X } from "lucide-vue-next";
-import { marked } from "marked";
-import DOMPurify from "dompurify";
 import { useRoute } from "vue-router";
 
 import Button from "@/components/ui/Button.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
 import { onDismissOverlays } from "@/composables/useOverlayBackHandler";
+import { renderMarkdown } from "@/lib/markdown";
 import {
   consumeShowcaseChatDraft,
   SHOWCASE_CHAT_DRAFT_EVENT,
@@ -309,20 +308,6 @@ watch(
   },
   { flush: "post" },
 );
-
-function renderMarkdown(content: string): string {
-  if (!content) return "";
-  const html = marked(content, { breaks: true, gfm: true }) as string;
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: [
-      "p", "br", "strong", "em", "u", "s", "code", "pre", "blockquote",
-      "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "a", "hr",
-      "table", "thead", "tbody", "tr", "th", "td", "img",
-      "video", "source",
-    ],
-    ALLOWED_ATTR: ["href", "target", "rel", "src", "alt", "controls", "playsinline", "muted", "loop", "preload", "type", "style"],
-  });
-}
 
 function clearChat(): void {
   messages.value = [];

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -9,7 +9,7 @@ const ALLOWED_TAGS = [
 
 const ALLOWED_ATTR = [
   "href", "target", "rel", "src", "alt", "controls", "playsinline",
-  "muted", "loop", "preload", "type", "style",
+  "muted", "loop", "preload", "type",
 ];
 
 /** Render trusted-but-sanitized markdown to an HTML string for v-html. */
@@ -17,4 +17,11 @@ export function renderMarkdown(content: string): string {
   if (!content) return "";
   const html = marked(content, { breaks: true, gfm: true }) as string;
   return DOMPurify.sanitize(html, { ALLOWED_TAGS, ALLOWED_ATTR });
+}
+
+export function markdownToPlainText(content: string): string {
+  if (!content) return "";
+  const container = document.createElement("div");
+  container.innerHTML = renderMarkdown(content);
+  return (container.textContent || container.innerText || "").trim();
 }

--- a/frontend/src/views/ChatPortalView.vue
+++ b/frontend/src/views/ChatPortalView.vue
@@ -2,8 +2,6 @@
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { AlertCircle, Copy, Download, Eye, EyeOff, Loader2, Moon, Send, Square, Sun, Upload, Workflow } from "lucide-vue-next";
-import { marked } from "marked";
-import DOMPurify from "dompurify";
 
 import Button from "@/components/ui/Button.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
@@ -12,6 +10,7 @@ import { onDismissOverlays } from "@/composables/useOverlayBackHandler";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
 import WorkflowHeroBackground from "@/components/Layout/WorkflowHeroBackground.vue";
+import { markdownToPlainText, renderMarkdown } from "@/lib/markdown";
 import { useThemeStore } from "@/stores/theme";
 import { playSuccessSound } from "@/utils/audio";
 
@@ -843,23 +842,6 @@ function resetTextareaHeight(): void {
   }
 }
 
-function renderMarkdown(content: string): string {
-  if (!content) return "";
-  const html = marked(content, {
-    breaks: true,
-    gfm: true,
-  }) as string;
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: [
-      "p", "br", "strong", "em", "u", "s", "code", "pre", "blockquote",
-      "h1", "h2", "h3", "h4", "h5", "h6", "ul", "ol", "li", "a", "hr",
-      "table", "thead", "tbody", "tr", "th", "td", "img",
-      "video", "source",
-    ],
-    ALLOWED_ATTR: ["href", "target", "rel", "src", "alt", "controls", "playsinline", "muted", "loop", "preload", "type", "style"],
-  });
-}
-
 function handleMarkdownImageClick(event: MouseEvent): void {
   const target = event.target as HTMLElement;
   if (target.tagName === "IMG") {
@@ -868,18 +850,11 @@ function handleMarkdownImageClick(event: MouseEvent): void {
   }
 }
 
-function extractPlainText(html: string): string {
-  const tempDiv = document.createElement("div");
-  tempDiv.innerHTML = html;
-  return tempDiv.textContent || tempDiv.innerText || "";
-}
-
 async function copyMessage(message: ChatMessage): Promise<void> {
   try {
     let textToCopy = message.content;
     if (message.type === "assistant") {
-      const html = renderMarkdown(message.content);
-      textToCopy = extractPlainText(html);
+      textToCopy = markdownToPlainText(message.content);
     }
     await navigator.clipboard.writeText(textToCopy);
     copiedMessageId.value = message.id;
@@ -889,6 +864,25 @@ async function copyMessage(message: ChatMessage): Promise<void> {
   } catch {
     // Silently ignore clipboard errors (e.g., permission denied)
   }
+}
+
+function jsonForInlineScript(value: unknown): string {
+  return JSON.stringify(value).replace(/[<>&\u2028\u2029]/g, (char) => {
+    switch (char) {
+      case "<":
+        return "\\u003C";
+      case ">":
+        return "\\u003E";
+      case "&":
+        return "\\u0026";
+      case "\u2028":
+        return "\\u2028";
+      case "\u2029":
+        return "\\u2029";
+      default:
+        return char;
+    }
+  });
 }
 
 function downloadAsHTML(): void {
@@ -934,7 +928,7 @@ function downloadAsHTML(): void {
 
   const plainTexts = messages.value
     .filter(m => m.type === "user" || m.type === "assistant")
-    .map(m => m.content);
+    .map(m => (m.type === "assistant" ? markdownToPlainText(m.content) : m.content));
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -1027,7 +1021,7 @@ function downloadAsHTML(): void {
   Exported on ${new Date().toLocaleString()}
 </div>
 <script>
-var msgTexts=${JSON.stringify(plainTexts)};
+var msgTexts=${jsonForInlineScript(plainTexts)};
 function toggleTheme(){
   var b=document.body;
   var isDark=b.classList.contains('dark');


### PR DESCRIPTION
## Summary
- Reuse the shared sanitized markdown renderer in portal chat, dashboard chat, and main chat conversation surfaces
- Remove duplicated markdown sanitizer configs that could drift across chat UIs
- Drop the unnecessary `style` attribute from the shared user-markdown allowlist
- Copy rendered plaintext, not raw markdown, from exported portal HTML assistant messages
- Escape JSON embedded in exported portal chat HTML so message text cannot break out of the inline script

## Testing
- `bun run lint:check`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- `uv run ruff check .`