### PR TITLE
fix: harden oauth popup messaging

### DIFF
--- a/backend/app/api/bigquery_oauth.py
+++ b/backend/app/api/bigquery_oauth.py
@@ -1,5 +1,6 @@
 """Google BigQuery OAuth2 authorization and callback endpoints."""
 
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
@@ -78,29 +79,33 @@ def build_auth_url(client_id: str, redirect_uri: str, state: str) -> str:
     return f"{_GOOGLE_AUTH_URL}?{urlencode(params)}"
 
 
+def _json_for_inline_script(payload: dict) -> str:
+    """Serialize JSON for direct embedding in an inline script element."""
+    return (
+        json.dumps(payload)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
 def _popup_html(success: bool, credential_id: str = "", message: str = "") -> str:
     """Return an HTML page that posts a message to the opener and closes."""
     if success:
-        script = f"""
-            if (window.opener) {{
-                window.opener.postMessage(
-                    {{type: 'google-oauth-success', credentialId: '{credential_id}'}},
-                    '*'
-                );
-            }}
-            window.close();
-        """
+        payload = {"type": "google-oauth-success", "credentialId": credential_id}
     else:
-        safe_msg = message.replace("'", "\\'").replace("\n", " ")
-        script = f"""
-            if (window.opener) {{
-                window.opener.postMessage(
-                    {{type: 'google-oauth-error', message: '{safe_msg}'}},
-                    '*'
-                );
-            }}
-            window.close();
-        """
+        payload = {"type": "google-oauth-error", "message": message.replace("\n", " ")}
+
+    script = f"""
+        const message = {_json_for_inline_script(payload)};
+        const targetOrigin = window.location.origin;
+        if (window.opener) {{
+            window.opener.postMessage(message, targetOrigin);
+        }}
+        window.close();
+    """
     return f"<html><body><script>{script}</script></body></html>"
 
 

--- a/backend/app/api/google_sheets_oauth.py
+++ b/backend/app/api/google_sheets_oauth.py
@@ -1,5 +1,6 @@
 """Google Sheets OAuth2 authorization and callback endpoints."""
 
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
@@ -78,29 +79,33 @@ def build_auth_url(client_id: str, redirect_uri: str, state: str) -> str:
     return f"{_GOOGLE_AUTH_URL}?{urlencode(params)}"
 
 
+def _json_for_inline_script(payload: dict) -> str:
+    """Serialize JSON for direct embedding in an inline script element."""
+    return (
+        json.dumps(payload)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
+
+
 def _popup_html(success: bool, credential_id: str = "", message: str = "") -> str:
     """Return an HTML page that posts a message to the opener and closes."""
     if success:
-        script = f"""
-            if (window.opener) {{
-                window.opener.postMessage(
-                    {{type: 'google-oauth-success', credentialId: '{credential_id}'}},
-                    '*'
-                );
-            }}
-            window.close();
-        """
+        payload = {"type": "google-oauth-success", "credentialId": credential_id}
     else:
-        safe_msg = message.replace("'", "\\'").replace("\n", " ")
-        script = f"""
-            if (window.opener) {{
-                window.opener.postMessage(
-                    {{type: 'google-oauth-error', message: '{safe_msg}'}},
-                    '*'
-                );
-            }}
-            window.close();
-        """
+        payload = {"type": "google-oauth-error", "message": message.replace("\n", " ")}
+
+    script = f"""
+        const message = {_json_for_inline_script(payload)};
+        const targetOrigin = window.location.origin;
+        if (window.opener) {{
+            window.opener.postMessage(message, targetOrigin);
+        }}
+        window.close();
+    """
     return f"<html><body><script>{script}</script></body></html>"
 
 

--- a/backend/tests/test_google_sheets_oauth.py
+++ b/backend/tests/test_google_sheets_oauth.py
@@ -151,6 +151,8 @@ class TestPopupHtml(unittest.TestCase):
         self.assertIn("google-oauth-success", html)
         self.assertIn("credentialId", html)
         self.assertIn("cred-123", html)
+        self.assertIn("window.location.origin", html)
+        self.assertNotIn("postMessage(message, '*')", html)
 
     def test_error_html_contains_message(self) -> None:
         from app.api.google_sheets_oauth import _popup_html
@@ -159,12 +161,39 @@ class TestPopupHtml(unittest.TestCase):
         self.assertIn("google-oauth-error", html)
         self.assertIn("Something went wrong", html)
 
-    def test_error_html_escapes_single_quotes(self) -> None:
+    def test_error_html_serializes_message_as_json(self) -> None:
         from app.api.google_sheets_oauth import _popup_html
 
-        html = _popup_html(False, message="it's broken")
-        self.assertNotIn("it's broken", html)
-        self.assertIn("\\'", html)
+        html = _popup_html(False, message="it's\nbroken")
+        self.assertNotIn("it's\nbroken", html)
+        self.assertIn('"message": "it\'s broken"', html)
+
+    def test_error_html_escapes_script_breaking_payload(self) -> None:
+        from app.api.google_sheets_oauth import _popup_html
+
+        html = _popup_html(False, message="</script><script>window.__xss = true</script>")
+        self.assertNotIn("</script><script>", html)
+        self.assertNotIn("window.__xss = true</script>", html)
+        self.assertIn("\\u003c/script\\u003e", html)
+        self.assertIn("\\u003cscript\\u003e", html)
+
+    def test_bigquery_success_html_uses_current_origin_target(self) -> None:
+        from app.api.bigquery_oauth import _popup_html
+
+        html = _popup_html(True, credential_id="bq-cred-123")
+        self.assertIn("google-oauth-success", html)
+        self.assertIn("bq-cred-123", html)
+        self.assertIn("window.location.origin", html)
+        self.assertNotIn("postMessage(message, '*')", html)
+
+    def test_bigquery_error_html_escapes_script_breaking_payload(self) -> None:
+        from app.api.bigquery_oauth import _popup_html
+
+        html = _popup_html(False, message="</script><script>window.__xss = true</script>")
+        self.assertNotIn("</script><script>", html)
+        self.assertNotIn("window.__xss = true</script>", html)
+        self.assertIn("\\u003c/script\\u003e", html)
+        self.assertIn("\\u003cscript\\u003e", html)
 
 
 def _make_db_result(credential) -> Mock:

--- a/frontend/src/components/Credentials/CredentialDialog.vue
+++ b/frontend/src/components/Credentials/CredentialDialog.vue
@@ -112,6 +112,10 @@ const typeOptions = [
   { value: "bigquery", label: CREDENTIAL_TYPE_LABELS.bigquery },
 ];
 
+function isTrustedOAuthMessage(evt: MessageEvent, popup: Window | null): boolean {
+  return evt.origin === window.location.origin && evt.source === popup;
+}
+
 watch(
   () => props.open,
   (open) => {
@@ -412,8 +416,14 @@ async function startGoogleSheetsOAuth(): Promise<void> {
     const { auth_url } = await credentialsApi.googleSheetsOAuthAuthorize(credId);
 
     const popup = window.open(auth_url, "google-oauth", "width=520,height=620");
+    if (!popup) {
+      throw new Error("OAuth popup was blocked. Allow popups for Heym and try again.");
+    }
 
     const onMessage = (evt: MessageEvent): void => {
+      if (!isTrustedOAuthMessage(evt, popup)) {
+        return;
+      }
       if (evt.data?.type === "google-oauth-success" && evt.data.credentialId === credId) {
         window.removeEventListener("message", onMessage);
         clearInterval(pollClosed);
@@ -482,8 +492,14 @@ async function startBigQueryOAuth(): Promise<void> {
 
     const { auth_url } = await credentialsApi.bigQueryOAuthAuthorize(credId);
     const popup = window.open(auth_url, "bq-oauth", "width=520,height=620");
+    if (!popup) {
+      throw new Error("OAuth popup was blocked. Allow popups for Heym and try again.");
+    }
 
     const onMessage = (evt: MessageEvent): void => {
+      if (!isTrustedOAuthMessage(evt, popup)) {
+        return;
+      }
       if (evt.data?.type === "google-oauth-success" && evt.data.credentialId === credId) {
         window.removeEventListener("message", onMessage);
         clearInterval(pollClosed);


### PR DESCRIPTION
## Summary
- Restrict Google Sheets and BigQuery OAuth callback `postMessage` calls to the callback page origin instead of using a wildcard target
- Ignore OAuth popup messages unless they come from the popup window opened by the credential dialog and from the current app origin
- Serialize OAuth popup payloads with JSON and escape that JSON for safe inline script embedding
- Cover callback target-origin behavior and script-breaking `</script>` payloads in regression tests

## Testing
- `bun run lint:check`
- `bun run typecheck`
- `bun run build`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `git diff --check`
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 uv run python -m unittest tests.test_google_sheets_oauth` (19 passed)
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 ./run_tests.sh` (986 passed before the follow-up inline-script escape)