### PR TITLE
fix: require credential access when cloning vector stores

### DIFF
--- a/backend/app/api/vector_stores.py
+++ b/backend/app/api/vector_stores.py
@@ -105,6 +105,14 @@ def get_vector_store_service_from_config(config: dict):
     )
 
 
+async def _get_store_credential_config(
+    store: VectorStore,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> tuple[Credential, dict]:
+    return await get_credential_config(store.credential_id, user_id, db)
+
+
 @router.get("", response_model=list[VectorStoreListResponse])
 async def list_vector_stores(
     current_user: User = Depends(get_current_user),
@@ -437,15 +445,7 @@ async def clone_vector_store(
         count += 1
         new_name = f"{store.name} (Copy {count})"
 
-    cred_result = await db.execute(select(Credential).where(Credential.id == store.credential_id))
-    credential = cred_result.scalar_one_or_none()
-    if not credential:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Credential not found",
-        )
-
-    config = decrypt_config(credential.encrypted_config)
+    credential, config = await _get_store_credential_config(store, current_user.id, db)
     service = get_vector_store_service_from_config(config)
 
     try:
@@ -462,7 +462,7 @@ async def clone_vector_store(
         description=store.description,
         collection_name=new_collection,
         owner_id=current_user.id,
-        credential_id=store.credential_id,
+        credential_id=credential.id,
     )
     db.add(new_store)
     await db.flush()

--- a/backend/tests/test_vector_store_credential_access.py
+++ b/backend/tests/test_vector_store_credential_access.py
@@ -1,0 +1,113 @@
+import unittest
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import HTTPException, status
+
+from app.db.models import Credential, CredentialType, VectorStore
+
+
+def make_result(value: object) -> Mock:
+    result = Mock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+class VectorStoreCredentialAccessTests(unittest.IsolatedAsyncioTestCase):
+    async def test_clone_requires_access_to_backing_credential(self) -> None:
+        from app.api.vector_stores import clone_vector_store
+
+        user = SimpleNamespace(id=uuid.uuid4())
+        store = VectorStore(
+            id=uuid.uuid4(),
+            name="Shared docs",
+            description=None,
+            collection_name="shared_collection",
+            owner_id=uuid.uuid4(),
+            credential_id=uuid.uuid4(),
+        )
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                make_result(store),
+                make_result(None),
+            ]
+        )
+
+        with (
+            patch(
+                "app.api.vector_stores.get_credential_config",
+                new=AsyncMock(
+                    side_effect=HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="Credential not found",
+                    )
+                ),
+            ) as get_config,
+            patch("app.api.vector_stores.get_vector_store_service_from_config") as get_service,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await clone_vector_store(store.id, current_user=user, db=db)
+
+        self.assertEqual(raised.exception.status_code, status.HTTP_404_NOT_FOUND)
+        get_config.assert_awaited_once_with(store.credential_id, user.id, db)
+        get_service.assert_not_called()
+        db.add.assert_not_called()
+
+    async def test_clone_uses_access_checked_credential_id(self) -> None:
+        from app.api.vector_stores import clone_vector_store
+
+        user = SimpleNamespace(id=uuid.uuid4())
+        store = VectorStore(
+            id=uuid.uuid4(),
+            name="Shared docs",
+            description="docs",
+            collection_name="shared_collection",
+            owner_id=uuid.uuid4(),
+            credential_id=uuid.uuid4(),
+        )
+        credential = Credential(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Shared Qdrant",
+            type=CredentialType.qdrant,
+            encrypted_config="encrypted",
+        )
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                make_result(store),
+                make_result(None),
+            ]
+        )
+        db.add = Mock()
+        db.flush = AsyncMock()
+
+        async def refresh(obj: VectorStore) -> None:
+            obj.created_at = datetime.now(timezone.utc)
+            obj.updated_at = datetime.now(timezone.utc)
+
+        db.refresh = AsyncMock(side_effect=refresh)
+        service = Mock()
+
+        with (
+            patch(
+                "app.api.vector_stores.get_credential_config",
+                new=AsyncMock(return_value=(credential, {"openai_api_key": "key"})),
+            ),
+            patch(
+                "app.api.vector_stores.get_vector_store_service_from_config", return_value=service
+            ),
+            patch("app.api.vector_stores._get_store_stats", new=AsyncMock(return_value=None)),
+        ):
+            response = await clone_vector_store(store.id, current_user=user, db=db)
+
+        cloned_store = db.add.call_args.args[0]
+        self.assertEqual(cloned_store.owner_id, user.id)
+        self.assertEqual(cloned_store.credential_id, credential.id)
+        self.assertEqual(response.credential_id, credential.id)
+        service.clone_collection.assert_called_once_with(
+            store.collection_name, cloned_store.collection_name
+        )


### PR DESCRIPTION
## Summary
- Require the current user to still have access to a vector store's backing Qdrant credential before cloning the store
- Store the access-checked credential id on the cloned vector store instead of blindly copying the source store's credential id
- Add regression coverage for inaccessible backing credentials and for successful clones using the access-checked credential

## Testing
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 uv run python -m unittest tests.test_vector_store_credential_access` (2 passed)
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 uv run python -m unittest tests.test_workflow_execution_api.WorkflowExecutorDataTableNodeTests.test_shared_vector_store_uses_backing_credential_without_separate_share` (1 passed)
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000001 ./run_tests.sh` (1007 passed)