### PR TITLE
[codex] fix map string method expressions

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -56,6 +56,8 @@ _DRIVE_DOWNLOAD_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _DOTDICT_BUILTIN_METHOD_NAMES: frozenset[str] = frozenset(
     {"items", "keys", "values", "entries", "map", "filter"}
 )
+_ITEM_DOT_PATH_RE = re.compile(r"^item(?:\.[a-zA-Z_][a-zA-Z0-9_]*)+$")
+_ITEM_REF_IN_TEMPLATE_RE = re.compile(r"item\.[a-zA-Z_][a-zA-Z0-9_]*\b(?!\()")
 
 _SLUG_RE = re.compile(r"[^a-zA-Z0-9]+")
 
@@ -346,6 +348,14 @@ HTTP_TIMEOUT = 300.0
 def _parse_expression_tree(expr: str) -> ast.AST:
     """Cache parsed ASTs for repeated workflow expressions."""
     return SimpleEval.parse(expr)
+
+
+def _is_valid_expression_syntax(expr: str) -> bool:
+    try:
+        _parse_expression_tree(expr)
+    except Exception:  # noqa: BLE001 - syntax probing only
+        return False
+    return True
 
 
 def _expression_root_node(parsed: ast.AST) -> ast.AST:
@@ -660,7 +670,7 @@ class DotList(list):
         ]
         has_operator = any(op in expr for op in operators)
 
-        if expr.startswith("item.") and not has_operator:
+        if not has_operator and _ITEM_DOT_PATH_RE.fullmatch(expr):
             path = expr[5:].split(".")
             value = item
             for part in path:
@@ -679,7 +689,7 @@ class DotList(list):
                 if not isinstance(arg, str):
                     return arg
                 arg_str = arg.strip()
-                if arg_str.startswith("item."):
+                if _ITEM_DOT_PATH_RE.fullmatch(arg_str):
                     path = arg_str[5:].split(".")
                     value = wrapped_item
                     for part in path:
@@ -745,18 +755,15 @@ class DotList(list):
         return DotList(result)
 
     def map(self, expr: str) -> "DotList":
-        # Fix: Detect if expr looks like a prematurely evaluated concat expression
-        # (contains literal "item." strings that should be expressions)
-        # If so, try to reconstruct the concat call
-        if isinstance(expr, str) and "item." in expr and not expr.strip().startswith("concat("):
-            # This might be a prematurely evaluated concat - try to detect the pattern
-            # Pattern: "- item.source (Page: item.page): item.snippet"
-            # We'll try to parse it back into: concat("- ", item.source, " (Page: ", item.page, "): ", item.snippet)
-            import re
-
-            # Find all "item.xxx" patterns in the string
-            item_pattern = r"item\.\w+"
-            matches = list(re.finditer(item_pattern, expr))
+        if (
+            isinstance(expr, str)
+            and "item." in expr
+            and not expr.strip().startswith("concat(")
+            and not _is_valid_expression_syntax(expr)
+        ):
+            # Keep supporting template-like strings such as
+            # "- item.source (Page: item.page): item.snippet".
+            matches = list(_ITEM_REF_IN_TEMPLATE_RE.finditer(expr))
             if matches:
                 # Try to reconstruct concat call
                 # Split the string by item references and reconstruct as concat arguments

--- a/backend/tests/test_expression_evaluator_service.py
+++ b/backend/tests/test_expression_evaluator_service.py
@@ -821,6 +821,40 @@ class TestExpressionEvaluatorServiceEvaluate(unittest.TestCase):
         self.assertTrue(response.preserved_type)
         self.assertIsNone(response.error)
 
+    def test_array_map_string_method_call_matches_executor(self) -> None:
+        expr = '$set.dates.map("item.substring(0, 5)")'
+        ctx = {"set": {"dates": ["2026-06-13 00:20:33.463147+00:00"]}}
+
+        executor_result = WorkflowExecutor(nodes=[], edges=[]).resolve_expression(
+            expr,
+            ctx,
+            preserve_type=True,
+        )
+        self.assertEqual(list(executor_result), ["2026-"])
+
+        response = self._service().evaluate(expr, ctx)
+        self.assertEqual(response.result, ["2026-"])
+        self.assertEqual(response.result_type, "array")
+        self.assertTrue(response.preserved_type)
+        self.assertIsNone(response.error)
+
+    def test_array_map_template_item_refs_still_match_executor(self) -> None:
+        expr = '$items.map("- item.source (Page: item.page): item.snippet")'
+        ctx = {"items": [{"source": "docs", "page": 2, "snippet": "hello"}]}
+
+        executor_result = WorkflowExecutor(nodes=[], edges=[]).resolve_expression(
+            expr,
+            ctx,
+            preserve_type=True,
+        )
+        self.assertEqual(list(executor_result), ["- docs (Page: 2): hello"])
+
+        response = self._service().evaluate(expr, ctx)
+        self.assertEqual(response.result, ["- docs (Page: 2): hello"])
+        self.assertEqual(response.result_type, "array")
+        self.assertTrue(response.preserved_type)
+        self.assertIsNone(response.error)
+
     def test_template_string_concatenation(self) -> None:
         response = self._service().evaluate("Hello $user.name", {"user": {"name": "John"}})
         self.assertEqual(response.result, "Hello John")


### PR DESCRIPTION
## Summary

Fix `.map()` expression handling so valid item method calls such as `item.substring(0, 5)` are evaluated normally instead of being rewritten as template text.

## Root Cause

`DotList.map()` had a compatibility rewrite for template-like strings containing `item.*` references. That rewrite treated `item.substring(0, 5)` as the field reference `item.substring` followed by literal text, which stringified the bound method and produced output like `<bound method ...>(0, 5)`.

## Changes

- Restrict fast-path item dot lookup to plain paths such as `item.name` and `item.meta.title`.
- Skip template reconstruction when the `.map()` argument is already valid expression syntax.
- Keep the existing template-like `item.*` behavior for strings such as `- item.source (Page: item.page): item.snippet`.
- Add regression coverage for both executor and expression evaluator service behavior.

## Validation

- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh`
- Full check passed: frontend lint/typecheck, backend Ruff/format, and 1143 backend tests.