### PR TITLE
[codex] Fix loop outputs and chart rendering

### DIFF
--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -15,6 +15,14 @@ $array($a.x, $b.y)
 $node.method(other.field)
 ```
 
+Inside `.filter()` and `.map()` expression strings:
+- `item` is the local list element; keep it unprefixed as `item.field`.
+- References to other nodes, loop context, or variables MUST keep `$` inside the quoted expression
+  string.
+- Use Python-style boolean operators: `and`, `or`, `not`. NEVER use JavaScript `&&` or `||`.
+- CORRECT: `$extractData.commitList.filter("item.date == $dateLoop.item and item.repo == 'dify'").length`
+- WRONG: `$extractData.commitList.filter("item.date == dateLoop.item && item.repo == 'dify'").length`
+
 Prefer the clearest readable form for the expression you are generating.
 
 ---
@@ -1562,16 +1570,21 @@ This will FAIL because `$vars.myList` doesn't exist yet!
 
 **⚠️ MUST USE VARIABLE NODE**: Array initialization with `$array()` MUST be done in a `variable` node, NOT in a `set` node! This is a strict requirement.
 
-**⛔⛔ CRITICAL: NEVER USE $ INSIDE METHOD PARENTHESES! ⛔⛔**
-When passing node references as parameters to methods like `.add()`, `.contains()`, etc., NEVER use `$` prefix inside the parentheses:
-- ✅ CORRECT: `$vars.myArray.add(previousNode.text)` - no `$` inside parentheses
-- ⛔ FORBIDDEN: `$vars.myArray.add($previousNode.text)` - $ inside () BREAKS the expression!
-- ✅ CORRECT: `$nodeA.text.contains(nodeB.keyword)` - no `$` for the parameter
-- ⛔ FORBIDDEN: `$nodeA.text.contains($nodeB.keyword)` - $ inside () BREAKS the expression!
+**Critical: Nested `$` references are allowed in method parameters**
+When passing node references as parameters to methods like `.add()`, `.contains()`, etc., use the
+form that makes the source clear:
+- ✅ CORRECT: `$vars.myArray.add($previousNode.text)`
+- ✅ ALSO VALID: `$vars.myArray.add(previousNode.text)`
+- ✅ CORRECT: `$nodeA.text.contains($nodeB.keyword)`
+
+Inside `.filter()` / `.map()` expression strings, external references MUST keep `$`, while the local
+list item stays `item`:
+- ✅ `$extractData.commitList.filter("item.date == $dateLoop.item and item.repo == 'dify'").length`
+- ⛔ `$extractData.commitList.filter("item.date == dateLoop.item && item.repo == 'dify'").length`
 
 **Full Pattern for Collecting Items in a Loop**:
 1. **Before loop**: Initialize array with `variable` node using `$array()` or `$array("item1", "item2")` - MUST use variable node!
-2. **Inside loop body**: Use another `variable` node with `.add()` to append items (NO `$` in parameters!)
+2. **Inside loop body**: Use another `variable` node with `.add()` to append items
 3. **After loop (done branch)**: Access collected items via `$vars.variableName`
 
 ### 18. loop (Iterate Over Array)
@@ -2688,7 +2701,7 @@ Each row object includes **`rowIndex`**: the 1-based sheet row number (useful fo
         "label": "analyzer",
         "credentialId": "openai-cred-id",
         "model": "gpt-4o",
-        "userMessage": "Analyze these items: $scraper.extracted.items.map(item.text).join('\\n')"
+        "userMessage": "Analyze these items: $scraper.extracted.items.map(\"item.text\").join(\"\\n\")"
       }
     },
     {
@@ -3149,9 +3162,11 @@ Output nodes are for FINAL results only. Use `set` or `variable` nodes inside lo
 // ⚠️ MUST: Array initialization MUST use variable node, NEVER use set node for $array()!
 ```
 
-**RULE 2: ⛔ NO $ INSIDE PARENTHESES! ONLY ONE $ PER EXPRESSION! ⛔**
+**RULE 2: NESTED `$` REFERENCES ARE VALID IN METHOD PARAMETERS**
 
-This is the MOST IMPORTANT rule. Parameters inside method calls MUST NOT have `$` prefix!
+When a method parameter or quoted list-operation expression needs data from another node, keep the
+`$` reference. For `.filter()` / `.map()` expression strings, use `item` without `$` only for the
+current list element.
 
 **RULE 3: ⛔ NEVER generate cURL examples or API call examples in your response!**
 - Do NOT include curl commands
@@ -3160,19 +3175,17 @@ This is the MOST IMPORTANT rule. Parameters inside method calls MUST NOT have `$
 ```
 
 ⛔⛔⛔ FORBIDDEN PATTERNS (WILL CAUSE ERRORS): ⛔⛔⛔
-$vars.searchResults.add($searchPerplexity.outputs.output.result)  ← WRONG!
-$vars.myList.add($loopNode.item)                                   ← WRONG!
-$text.contains($otherNode.keyword)                                 ← WRONG!
-$nodeA.field.replace($nodeB.old, $nodeB.new)                       ← WRONG!
+$extractData.commitList.filter("item.date == dateLoop.item && item.repo == 'dify'").length  ← WRONG!
 
-✅✅✅ CORRECT PATTERNS (NO $ INSIDE PARENTHESES): ✅✅✅
-$vars.searchResults.add(searchPerplexity.outputs.output.result)   ← CORRECT!
-$vars.myList.add(loopNode.item)                                    ← CORRECT!
-$text.contains(otherNode.keyword)                                  ← CORRECT!
-$nodeA.field.replace(nodeB.old, nodeB.new)                         ← CORRECT!
+✅✅✅ CORRECT PATTERNS: ✅✅✅
+$vars.searchResults.add($searchPerplexity.outputs.output.result)  ← CORRECT!
+$vars.myList.add($loopNode.item)                                   ← CORRECT!
+$text.contains($otherNode.keyword)                                 ← CORRECT!
+$nodeA.field.replace($nodeB.old, $nodeB.new)                       ← CORRECT!
+$extractData.commitList.filter("item.date == $dateLoop.item and item.repo == 'dify'").length  ← CORRECT!
 
-⛔ RULE: An expression has EXACTLY ONE $ at the very beginning!
-⛔ NEVER put $ inside parentheses - parameters are resolved automatically!
+RULE: In `.filter()` / `.map()` strings, use Python boolean operators (`and`, `or`, `not`), never
+JavaScript `&&` or `||`.
 ```
 
 ---
@@ -3196,14 +3209,17 @@ Always reference nodes by their LABEL NAME!
 
 **⚠️ IMPORTANT**: textInput nodes return data via `body` object, other nodes return directly!
 
-### ⛔ CRITICAL: Method Parameters - NEVER USE $ INSIDE PARENTHESES!
-When calling methods with node references as parameters, NEVER use `$` inside the parentheses:
-- ✅ `$userInput.body.sentence.contains(userInput.body.keyword)` - CORRECT: no $ inside ()
-- ⛔ `$userInput.body.sentence.contains($userInput.body.keyword)` - FORBIDDEN! $ inside () causes errors!
-- ✅ `$vars.list.add(loopNode.item)` - CORRECT: no $ inside ()
-- ⛔ `$vars.list.add($loopNode.item)` - FORBIDDEN! $ inside () causes errors!
+### Critical: Method Parameters and Nested References
+When calling methods with node references as parameters, nested `$` references are allowed and often
+clearer when the value comes from another node:
+- ✅ `$userInput.body.sentence.contains($userInput.body.keyword)` - CORRECT
+- ✅ `$vars.list.add($loopNode.item)` - CORRECT
+- ✅ `$vars.list.add(loopNode.item)` - Also supported for simple method arguments
 
-The `$` prefix is ONLY used at the START of an expression, NEVER inside method parentheses!
+For `.filter()` and `.map()` quoted expression strings, ALWAYS use `$` for references outside the
+current `item`:
+- ✅ `$extractData.commitList.filter("item.date == $dateLoop.item and item.repo == 'dify'").length`
+- ⛔ `$extractData.commitList.filter("item.date == dateLoop.item && item.repo == 'dify'").length`
 
 ### Merge Node Output
 When a merge node (e.g., labeled "mergeResults") combines inputs:
@@ -3335,12 +3351,10 @@ Create objects/dictionaries directly using curly brace syntax with any string ke
 - `.urlEncode()` - URL encode the string
 - `.urlDecode()` - URL decode the string
 
-**⛔ FORBIDDEN: NEVER use $ inside method parentheses!**
-- ✅ `$userInput.body.sentence.contains(userInput.body.keyword)` - CORRECT
-- ⛔ `$userInput.body.sentence.contains($userInput.body.keyword)` - FORBIDDEN! $ inside () breaks it!
-- ✅ `$nodeA.text.replace(nodeB.oldText, nodeB.newText)` - CORRECT
-- ⛔ `$nodeA.text.replace($nodeB.oldText, $nodeB.newText)` - FORBIDDEN!
-- ✅ `$data.message.startswith(config.prefix)` - CORRECT
+**Nested references in method parameters are allowed:**
+- ✅ `$userInput.body.sentence.contains($userInput.body.keyword)` - CORRECT
+- ✅ `$nodeA.text.replace($nodeB.oldText, $nodeB.newText)` - CORRECT
+- ✅ `$data.message.startswith($config.prefix)` - CORRECT
 - String literals are fine: `$text.contains("hello")`, `$text.replace("old", "new")`
 
 ### Array Methods (on arrays)
@@ -3374,6 +3388,14 @@ Use `item` variable to reference each element in the expression string:
 - `$numbers.take(3)` → Take first 3 elements
 - `$numbers.take(-2)` → Take last 2 elements
 
+**Critical `.filter()` / `.map()` expression-string rules:**
+- `item` is local to the list operation, so write `item.field` without `$`.
+- Any other node, loop context, or variable reference inside the quoted expression MUST include `$`.
+- Use `and`, `or`, `not` for boolean logic; do not use JavaScript `&&`, `||`, or `!`.
+- ✅ `$extractData.commitList.filter("item.date == $dateLoop.item and item.repo == 'dify'").length`
+- ✅ `$extractData.commitList.map("dict(date=item.created_at, current=$dateLoop.item)")`
+- ⛔ `$extractData.commitList.filter("item.date == dateLoop.item && item.repo == 'dify'").length`
+
 **concat() Function in map() - String Concatenation with Item Properties:**
 Use `concat()` inside `.map()` to build strings by combining literals with item properties:
 - `$posts.map("concat('https://example.com/', 'item.slug')")` → Prepend URL to each slug
@@ -3387,12 +3409,10 @@ Use `concat()` inside `.map()` to build strings by combining literals with item 
 - Supports N arguments: `concat('a', 'b', 'c', ...)` → "abc..."
 - Returns null-safe concatenation (null values become empty strings)
 
-**⛔ FORBIDDEN: NEVER use $ inside method parentheses!**
-- ✅ `$vars.myList.add(loopNode.item)` - CORRECT
-- ⛔ `$vars.myList.add($loopNode.item)` - FORBIDDEN! $ inside () breaks it!
-- ✅ `$vars.results.add(executeNode.outputs.output.result)` - CORRECT
-- ⛔ `$vars.results.add($executeNode.outputs.output.result)` - FORBIDDEN!
-- ✅ `$myArray.join(settings.separator)` - CORRECT
+**Nested references in method parameters are allowed:**
+- ✅ `$vars.myList.add($loopNode.item)` - CORRECT
+- ✅ `$vars.results.add($executeNode.outputs.output.result)` - CORRECT
+- ✅ `$myArray.join($settings.separator)` - CORRECT
 - String literals are fine: `$myArray.add("newItem")`, `$myArray.join(", ")`
 
 ### Object/Dictionary Methods (on objects)
@@ -3643,15 +3663,14 @@ Always include:
 - ❌ WRONG: Directly using `$vars.myList.add(item)` without initialization → WILL FAIL!
 - ✅ CORRECT: Step 1 (MUST use variable node): `{"type": "variable", "data": {"variableName": "myList", "variableValue": "$array()", "variableType": "array"}}` → Step 2: `$vars.myList.add(loopNode.item)`
 
-**RULE #2: ⛔⛔⛔ NEVER USE $ INSIDE PARENTHESES! ⛔⛔⛔**
-- An expression can have ONLY ONE `$` at the very beginning, NEVER inside method parentheses!
-- ⛔ FORBIDDEN: `$vars.searchResults.add($searchPerplexity.outputs.output.result)` → BROKEN!
-- ⛔ FORBIDDEN: `$vars.list.add($nodeName.field)` → BROKEN!
-- ⛔ FORBIDDEN: `$text.contains($otherNode.keyword)` → BROKEN!
-- ✅ CORRECT: `$vars.searchResults.add(searchPerplexity.outputs.output.result)` → Works!
-- ✅ CORRECT: `$vars.list.add(nodeName.field)` → Works!
-- ✅ CORRECT: `$text.contains(otherNode.keyword)` → Works!
-- **Parameters inside () are resolved automatically - adding $ breaks the parser!**
+**RULE #2: NESTED $ REFERENCES ARE VALID IN METHOD PARAMETERS**
+- When a method parameter or quoted list-operation expression needs data from another node, keep
+  the `$` reference.
+- ✅ CORRECT: `$vars.searchResults.add($searchPerplexity.outputs.output.result)`
+- ✅ CORRECT: `$vars.list.add($nodeName.field)`
+- ✅ CORRECT: `$text.contains($otherNode.keyword)`
+- ✅ CORRECT in `.filter()`: `$extractData.commitList.filter("item.date == $dateLoop.item and item.repo == 'dify'").length`
+- ⛔ WRONG in `.filter()`: `$extractData.commitList.filter("item.date == dateLoop.item && item.repo == 'dify'").length`
 
 ---
 

--- a/backend/tests/test_build_assistant_prompt_node_templates.py
+++ b/backend/tests/test_build_assistant_prompt_node_templates.py
@@ -81,6 +81,28 @@ class TestBuildAssistantPromptNodeTemplates(unittest.TestCase):
         self.assertIn('"label": "bucketRequest"', prompt)
         self.assertIn('"s3Bucket": "$bucketRequest.body.bucketName"', prompt)
 
+    def test_includes_filter_map_nested_reference_guidance(self) -> None:
+        prompt = build_assistant_prompt()
+
+        correct_filter = (
+            "$extractData.commitList.filter("
+            "\"item.date == $dateLoop.item and item.repo == 'dify'\""
+            ").length"
+        )
+        wrong_filter = (
+            "$extractData.commitList.filter("
+            "\"item.date == dateLoop.item && item.repo == 'dify'\""
+            ").length"
+        )
+
+        self.assertIn("Inside `.filter()` and `.map()` expression strings", prompt)
+        self.assertIn(correct_filter, prompt)
+        self.assertIn(wrong_filter, prompt)
+        self.assertIn("Use Python-style boolean operators", prompt)
+        self.assertIn("References to other nodes, loop context, or variables MUST keep `$`", prompt)
+        self.assertNotIn("NEVER USE $ INSIDE PARENTHESES", prompt)
+        self.assertNotIn("NO $ INSIDE PARENTHESES", prompt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/components/Dashboards/ChartRenderer.vue
+++ b/frontend/src/components/Dashboards/ChartRenderer.vue
@@ -5,7 +5,7 @@ import { useThemeStore } from "@/stores/theme";
 import type { ChartPayload } from "@/types/dashboard";
 
 const props = defineProps<{
-  payload: ChartPayload | null;
+  payload: ChartPayload | Record<string, unknown> | null;
 }>();
 
 const themeStore = useThemeStore();
@@ -26,6 +26,38 @@ const PROPORTION_COLORS = [
   "#ea580c",
 ];
 
+const CHART_TYPES = new Set<ChartPayload["type"]>([
+  "pie",
+  "bar",
+  "line",
+  "area",
+  "table",
+  "numeric",
+  "gauge",
+  "scatter",
+  "proportion",
+  "barGauge",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isChartPayload(value: unknown): value is ChartPayload {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  return CHART_TYPES.has(value.type as ChartPayload["type"]);
+}
+
+function normalizeChartPayload(value: ChartPayload | Record<string, unknown> | null): ChartPayload | null {
+  if (isChartPayload(value)) return value;
+  if (!isRecord(value)) return null;
+
+  const nestedPayloads = Object.values(value).filter(isChartPayload);
+  return nestedPayloads.length === 1 ? nestedPayloads[0] : null;
+}
+
+const chartPayload = computed((): ChartPayload | null => normalizeChartPayload(props.payload));
+
 interface ProportionSegment {
   label: string;
   pct: number;
@@ -33,7 +65,7 @@ interface ProportionSegment {
 }
 
 const proportionSegments = computed((): ProportionSegment[] => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p || p.type !== "proportion") return [];
   const data = (p.series?.[0]?.data ?? []) as number[];
   const labels = p.labels ?? [];
@@ -73,7 +105,7 @@ interface BarGaugeRow {
 }
 
 const barGaugeRows = computed((): BarGaugeRow[] => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p || p.type !== "barGauge") return [];
   const data = (p.series?.[0]?.data ?? []) as number[];
   const labels = p.labels ?? [];
@@ -117,7 +149,7 @@ onBeforeUnmount(() => {
 });
 
 const isEmpty = computed((): boolean => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p) return true;
   if (p.type === "table") return !p.rows || p.rows.length === 0;
   if (p.type === "numeric") return p.value === null || p.value === undefined;
@@ -126,7 +158,7 @@ const isEmpty = computed((): boolean => {
 });
 
 const numericValue = computed((): string => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p || p.value === null || p.value === undefined) return "—";
   const raw = p.value;
   if (typeof raw === "number" && typeof p.decimals === "number") {
@@ -136,7 +168,7 @@ const numericValue = computed((): string => {
 });
 
 const apexType = computed((): "pie" | "bar" | "line" | "area" | "scatter" | "radialBar" => {
-  const t = props.payload?.type;
+  const t = chartPayload.value?.type;
   if (t === "pie") return "pie";
   if (t === "line") return "line";
   if (t === "area") return "area";
@@ -147,7 +179,7 @@ const apexType = computed((): "pie" | "bar" | "line" | "area" | "scatter" | "rad
 
 // Gauge value as a 0-100 percentage of [min, max].
 const gaugePercent = computed((): number => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p || typeof p.value !== "number") return 0;
   const min = typeof p.min === "number" ? p.min : 0;
   const max = typeof p.max === "number" ? p.max : 100;
@@ -156,7 +188,7 @@ const gaugePercent = computed((): number => {
 });
 
 const apexSeries = computed(() => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p) return [];
   if (p.type === "pie") return p.series?.[0]?.data ?? [];
   if (p.type === "gauge") return [gaugePercent.value];
@@ -164,7 +196,7 @@ const apexSeries = computed(() => {
 });
 
 const apexOptions = computed((): Record<string, unknown> => {
-  const p = props.payload;
+  const p = chartPayload.value;
   if (!p) return {};
   const base: Record<string, unknown> = {
     chart: {
@@ -262,29 +294,29 @@ const apexOptions = computed((): Record<string, unknown> => {
     </div>
 
     <div
-      v-else-if="payload && payload.type === 'numeric'"
+      v-else-if="chartPayload && chartPayload.type === 'numeric'"
       class="flex h-full min-h-[120px] flex-col items-center justify-center"
     >
       <div class="text-4xl font-semibold tabular-nums text-foreground">
         {{ numericValue }}
       </div>
       <div
-        v-if="payload.unit"
+        v-if="chartPayload.unit"
         class="mt-1 text-sm text-muted-foreground"
       >
-        {{ payload.unit }}
+        {{ chartPayload.unit }}
       </div>
     </div>
 
     <div
-      v-else-if="payload && payload.type === 'table'"
+      v-else-if="chartPayload && chartPayload.type === 'table'"
       class="h-full overflow-auto pb-3"
     >
       <table class="w-full text-sm text-foreground">
         <thead class="sticky top-0 bg-card">
           <tr class="border-b border-border">
             <th
-              v-for="col in payload.columns"
+              v-for="col in chartPayload.columns"
               :key="col"
               class="px-2 py-1 text-left font-medium text-muted-foreground"
             >
@@ -294,7 +326,7 @@ const apexOptions = computed((): Record<string, unknown> => {
         </thead>
         <tbody>
           <tr
-            v-for="(row, rowIndex) in payload.rows"
+            v-for="(row, rowIndex) in chartPayload.rows"
             :key="rowIndex"
             class="border-b border-border/50"
           >
@@ -311,7 +343,7 @@ const apexOptions = computed((): Record<string, unknown> => {
     </div>
 
     <div
-      v-else-if="payload && payload.type === 'proportion'"
+      v-else-if="chartPayload && chartPayload.type === 'proportion'"
       class="flex h-full flex-col justify-center gap-4 px-1"
     >
       <div class="flex h-3 w-full overflow-hidden rounded-full bg-muted">
@@ -339,7 +371,7 @@ const apexOptions = computed((): Record<string, unknown> => {
     </div>
 
     <div
-      v-else-if="payload && payload.type === 'barGauge'"
+      v-else-if="chartPayload && chartPayload.type === 'barGauge'"
       class="flex h-full flex-col justify-center gap-2 overflow-auto px-1 py-1"
     >
       <div
@@ -364,9 +396,9 @@ const apexOptions = computed((): Record<string, unknown> => {
           :style="{ color: row.valueColor }"
         >
           {{ row.value }}<span
-            v-if="payload.unit"
+            v-if="chartPayload.unit"
             class="ml-1 text-xs font-normal text-muted-foreground"
-          >{{ payload.unit }}</span>
+          >{{ chartPayload.unit }}</span>
         </span>
       </div>
     </div>

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -12800,7 +12800,14 @@ onUnmounted(() => {
             v-if="nodeOutput"
             class="space-y-2 pt-4 border-t rounded-lg border border-border/40 bg-muted/20 p-3"
           >
-            <div class="flex items-center justify-between gap-2">
+            <div
+              :class="[
+                'flex gap-2 min-w-0',
+                selectedNodeLoopItemNavigation
+                  ? 'flex-col items-start'
+                  : 'items-center justify-between'
+              ]"
+            >
               <div class="flex items-center gap-2 min-w-0">
                 <Label>Last Output</Label>
                 <CheckCircle2
@@ -12814,7 +12821,10 @@ onUnmounted(() => {
               </div>
               <div
                 v-if="!nodeOutput.error"
-                class="flex items-center gap-1.5 shrink-0"
+                :class="[
+                  'flex min-w-0 flex-wrap items-center gap-1.5',
+                  selectedNodeLoopItemNavigation ? 'w-full justify-start' : 'shrink-0 justify-end'
+                ]"
               >
                 <div
                   v-if="selectedNodeLoopItemNavigation"


### PR DESCRIPTION
## Summary

Fixes two workflow UI/runtime guidance issues found while building a loop-driven chart workflow:

- Prevents the Properties panel Last Output header controls from overlapping when a selected node has loop item navigation.
- Updates the workflow DSL prompt so `.filter()` / `.map()` expression strings keep `$` for external node/loop/variable references and use Python-style boolean operators like `and` instead of JavaScript `&&`.
- Makes dashboard chart rendering tolerate wrapped workflow outputs such as `{ "commitChart": { "type": "bar", ... } }` by normalizing the single nested chart payload before rendering.

## Root Cause

The Last Output toolbar could outgrow the narrow properties panel when loop navigation was present. The DSL prompt also still contained older contradictory guidance saying nested `$` references in method parameters were forbidden, which encouraged invalid generated expressions like `dateLoop.item && ...`. Separately, the chart renderer expected a direct chart payload and could render blank when handed a final-output wrapper keyed by the chart node label.

## Impact

Loop outputs remain readable in the properties panel, generated DSL should produce valid list-operation filters, and chart widgets / chart render surfaces can draw both direct and label-wrapped chart payloads.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh` → 1144 tests passed