### PR TITLE
[codex] Add chart output expression dialog support

### DIFF
--- a/backend/app/api/dashboards.py
+++ b/backend/app/api/dashboards.py
@@ -1,5 +1,5 @@
-import asyncio
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
@@ -10,7 +10,6 @@ from app.api.ai_assistant import (
     _extract_generated_workflow_config,
     _record_chat_workflow_edit_version,
     get_credential_for_user,
-    get_openai_client,
 )
 from app.api.deps import get_current_user
 from app.db.models import CredentialType, Dashboard, DashboardWidget, User, Workflow
@@ -27,6 +26,8 @@ from app.models.dashboard_schemas import (
 from app.services.dashboard_data import compute_widget_data
 from app.services.encryption import decrypt_config
 from app.services.llm_provider import is_reasoning_model
+from app.services.llm_service import execute_llm
+from app.services.llm_trace import LLMTraceContext
 from app.services.workflow_dsl_prompt import build_assistant_prompt
 
 router = APIRouter()
@@ -44,31 +45,45 @@ _AI_WIDGET_SUFFIX = (
 
 
 async def generate_widget_dsl(
-    prompt: str, *, credential, model: str, user: User, current_workflow: dict | None = None
-) -> dict:
+    prompt: str,
+    *,
+    credential: Any,
+    model: str,
+    user: User,
+    current_workflow: dict[str, Any] | None = None,
+    workflow_id: uuid.UUID | None = None,
+    node_label: str | None = None,
+) -> dict[str, Any]:
     """Generate a widget workflow DSL (nodes + edges) ending in a chartOutput node.
 
     When ``current_workflow`` is provided the model edits that existing widget
     workflow (used by the per-widget AI refine action) instead of building a new one.
     """
     config = decrypt_config(credential.encrypted_config)
-    client, _ = get_openai_client(credential.type, config)
+    api_key = str(config.get("api_key") or "")
+    raw_base_url = config.get("base_url")
+    base_url = str(raw_base_url) if raw_base_url else None
     system_prompt = build_assistant_prompt(current_workflow, [], getattr(user, "user_rules", None))
-    messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": prompt + _AI_WIDGET_SUFFIX},
-    ]
-    kwargs: dict = {"model": model, "messages": messages, "stream": False}
-    if not is_reasoning_model(model):
-        kwargs["temperature"] = WORKFLOW_BUILDER_TEMPERATURE
-
-    def _call() -> str:
-        resp = client.chat.completions.create(**kwargs)
-        choice = resp.choices[0] if resp.choices else None
-        return choice.message.content if choice else ""
-
-    content = await asyncio.to_thread(_call)
-    return _extract_generated_workflow_config(content or "", prompt)
+    trace_context = LLMTraceContext(
+        user_id=user.id,
+        credential_id=credential.id,
+        workflow_id=workflow_id,
+        source="dashboard_widget_ai",
+        node_label=node_label
+        or ("AI Widget Fine-tune" if current_workflow else "AI Widget Create"),
+    )
+    result = await execute_llm(
+        credential_type=credential.type.value,
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        system_instruction=system_prompt,
+        user_message=prompt + _AI_WIDGET_SUFFIX,
+        temperature=None if is_reasoning_model(model) else WORKFLOW_BUILDER_TEMPERATURE,
+        trace_context=trace_context,
+    )
+    content = str(result.get("text") or "")
+    return _extract_generated_workflow_config(content, prompt)
 
 
 async def _get_or_create_dashboard(db: AsyncSession, user: User) -> Dashboard:
@@ -289,7 +304,11 @@ async def ai_generate_widget(
 
     dashboard = await _get_or_create_dashboard(db, current_user)
     dsl = await generate_widget_dsl(
-        body.prompt, credential=credential, model=body.model, user=current_user
+        body.prompt,
+        credential=credential,
+        model=body.model,
+        user=current_user,
+        node_label="AI Widget Create",
     )
     nodes = dsl.get("nodes", [])
     edges = dsl.get("edges", [])
@@ -367,6 +386,8 @@ async def ai_refine_widget(
         model=body.model,
         user=current_user,
         current_workflow=current_workflow,
+        workflow_id=widget.workflow_id,
+        node_label="AI Widget Fine-tune",
     )
     nodes = dsl.get("nodes", [])
     edges = dsl.get("edges", [])

--- a/backend/app/api/data_tables.py
+++ b/backend/app/api/data_tables.py
@@ -42,6 +42,8 @@ from app.models.schemas import (
 )
 from app.services.encryption import decrypt_config
 from app.services.llm_provider import is_reasoning_model
+from app.services.llm_service import execute_llm
+from app.services.llm_trace import LLMTraceContext
 from app.services.upload_limits import read_upload_file_limited
 
 router = APIRouter()
@@ -1062,7 +1064,7 @@ async def generate_data_table_schema(
     """Generate column suggestions for a data table from a description or JSON."""
     # Imported lazily to avoid a circular import (ai_assistant -> workflow_executor
     # -> data_tables). Tests patch these at app.api.ai_assistant.<name>.
-    from app.api.ai_assistant import get_credential_for_user, get_openai_client
+    from app.api.ai_assistant import get_credential_for_user
 
     credential = await get_credential_for_user(request.credential_id, current_user, db)
     if not credential:
@@ -1084,21 +1086,29 @@ async def generate_data_table_schema(
     existing_names = {col.name for col in existing_cols}
 
     config = decrypt_config(credential.encrypted_config)
-    client, _ = get_openai_client(credential.type, config)
+    api_key = str(config.get("api_key") or "")
+    raw_base_url = config.get("base_url")
+    base_url = str(raw_base_url) if raw_base_url else None
+    trace_context = LLMTraceContext(
+        user_id=current_user.id,
+        credential_id=credential.id,
+        source="data_table_ai",
+        node_label="AI DataTable Extend" if existing_cols else "AI DataTable Create",
+    )
 
-    kwargs: dict[str, Any] = {
-        "model": request.model,
-        "messages": [
-            {"role": "system", "content": _build_schema_system_prompt(bool(existing_cols))},
-            {"role": "user", "content": _build_schema_user_prompt(request.prompt, existing_cols)},
-        ],
-        "extra_body": {"disable_reasoning": True},
-    }
-    if not is_reasoning_model(request.model):
-        kwargs["temperature"] = 0.2
-
-    response = client.chat.completions.create(**kwargs)
-    content = response.choices[0].message.content or ""
+    result = await execute_llm(
+        credential_type=credential.type.value,
+        api_key=api_key,
+        base_url=base_url,
+        model=request.model,
+        system_instruction=_build_schema_system_prompt(bool(existing_cols)),
+        user_message=_build_schema_user_prompt(request.prompt, existing_cols),
+        temperature=None if is_reasoning_model(request.model) else 0.2,
+        extra_body={"disable_reasoning": True},
+        trace_context=trace_context,
+        content_only=True,
+    )
+    content = str(result.get("text") or "")
 
     payload = _extract_schema_payload(content)
     if payload is None:

--- a/backend/app/api/expressions.py
+++ b/backend/app/api/expressions.py
@@ -256,8 +256,9 @@ async def _generate_expression(
         user_id=current_user.id,
         credential_id=request.credential_id,
         workflow_id=request.workflow_id,
-        source="expression_generate",
-        node_label="expression_generate",
+        node_id=request.current_node_id,
+        source="assistant",
+        node_label="Expression Builder",
     )
     result = await execute_llm(
         credential_type=credential.type.value,

--- a/backend/tests/test_dashboards_api.py
+++ b/backend/tests/test_dashboards_api.py
@@ -81,6 +81,84 @@ class TestSeedWidgetNodes(unittest.TestCase):
         self.assertEqual(edges[0]["target"], nodes[1]["id"])
 
 
+class TestGenerateWidgetDsl(unittest.IsolatedAsyncioTestCase):
+    async def test_generate_widget_dsl_passes_trace_context_to_llm(self):
+        user = _User()
+        credential_id = uuid.uuid4()
+        credential = MagicMock()
+        credential.id = credential_id
+        from app.db.models import CredentialType
+
+        credential.type = CredentialType.openai
+        credential.encrypted_config = "enc"
+        content = (
+            '```json\n{"name": "Signups", "description": "Monthly signups", "nodes": ['
+            '{"id": "chart", "type": "chartOutput", "data": {"chartType": "bar"}}], '
+            '"edges": []}\n```'
+        )
+        execute_llm = AsyncMock(return_value={"text": content})
+
+        with (
+            patch.object(dash_api, "decrypt_config", return_value={"api_key": "x"}),
+            patch.object(dash_api, "execute_llm", execute_llm),
+        ):
+            result = await dash_api.generate_widget_dsl(
+                "show signups",
+                credential=credential,
+                model="gpt-4o-mini",
+                user=user,
+                node_label="AI Widget Create",
+            )
+
+        self.assertEqual(result["name"], "Signups")
+        execute_llm.assert_awaited_once()
+        kwargs = execute_llm.await_args.kwargs
+        trace_context = kwargs["trace_context"]
+        self.assertEqual(kwargs["model"], "gpt-4o-mini")
+        self.assertEqual(trace_context.user_id, user.id)
+        self.assertEqual(trace_context.credential_id, credential_id)
+        self.assertEqual(trace_context.source, "dashboard_widget_ai")
+        self.assertEqual(trace_context.node_label, "AI Widget Create")
+        self.assertIsNone(trace_context.workflow_id)
+
+    async def test_generate_widget_dsl_links_fine_tune_trace_to_workflow(self):
+        user = _User()
+        workflow_id = uuid.uuid4()
+        credential = MagicMock()
+        credential.id = uuid.uuid4()
+        from app.db.models import CredentialType
+
+        credential.type = CredentialType.openai
+        credential.encrypted_config = "enc"
+        execute_llm = AsyncMock(
+            return_value={
+                "text": (
+                    '```json\n{"nodes": ['
+                    '{"id": "chart", "type": "chartOutput", "data": {"chartType": "line"}}], '
+                    '"edges": []}\n```'
+                )
+            }
+        )
+
+        with (
+            patch.object(dash_api, "decrypt_config", return_value={"api_key": "x"}),
+            patch.object(dash_api, "execute_llm", execute_llm),
+        ):
+            await dash_api.generate_widget_dsl(
+                "make it line",
+                credential=credential,
+                model="gpt-4o-mini",
+                user=user,
+                current_workflow={"nodes": [], "edges": []},
+                workflow_id=workflow_id,
+                node_label="AI Widget Fine-tune",
+            )
+
+        trace_context = execute_llm.await_args.kwargs["trace_context"]
+        self.assertEqual(trace_context.node_label, "AI Widget Fine-tune")
+        self.assertEqual(trace_context.workflow_id, workflow_id)
+
+
 class TestCreateWidget(unittest.IsolatedAsyncioTestCase):
     async def test_create_widget_creates_hidden_workflow(self):
         user = _User()
@@ -266,8 +344,9 @@ class TestAiRefineWidget(unittest.IsolatedAsyncioTestCase):
 
         credential = MagicMock(type=CredentialType.openai)
         record_version = AsyncMock()
+        generate_dsl = AsyncMock(return_value=fake_dsl)
         with (
-            patch.object(dash_api, "generate_widget_dsl", AsyncMock(return_value=fake_dsl)),
+            patch.object(dash_api, "generate_widget_dsl", generate_dsl),
             patch.object(dash_api, "get_credential_for_user", AsyncMock(return_value=credential)),
             patch.object(dash_api, "_record_chat_workflow_edit_version", record_version),
         ):
@@ -285,6 +364,8 @@ class TestAiRefineWidget(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(widget.cached_at)
         # AI fine-tune records a pre-edit snapshot so it appears in Edit History.
         record_version.assert_awaited_once()
+        self.assertEqual(generate_dsl.await_args.kwargs["workflow_id"], widget.workflow_id)
+        self.assertEqual(generate_dsl.await_args.kwargs["node_label"], "AI Widget Fine-tune")
 
     async def test_refine_records_change_history_snapshot(self):
         user = _User()

--- a/backend/tests/test_data_table_schema_generation.py
+++ b/backend/tests/test_data_table_schema_generation.py
@@ -79,16 +79,8 @@ def _make_request(existing=None) -> DataTableSchemaGenerateRequest:
     )
 
 
-def _llm_client_returning(content: str) -> MagicMock:
-    message = MagicMock()
-    message.content = content
-    choice = MagicMock()
-    choice.message = message
-    completion = MagicMock()
-    completion.choices = [choice]
-    client = MagicMock()
-    client.chat.completions.create.return_value = completion
-    return client
+def _execute_llm_returning(content: str) -> AsyncMock:
+    return AsyncMock(return_value={"text": content})
 
 
 class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
@@ -112,8 +104,8 @@ class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
             ),
             patch("app.api.data_tables.decrypt_config", return_value={"api_key": "x"}),
             patch(
-                "app.api.ai_assistant.get_openai_client",
-                return_value=(_llm_client_returning(content), "openai"),
+                "app.api.data_tables.execute_llm",
+                _execute_llm_returning(content),
             ),
         ):
             result = await generate_data_table_schema(
@@ -127,6 +119,34 @@ class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.columns[0].required)
         self.assertEqual(result.columns[1].type, "number")
 
+    async def test_generate_schema_passes_trace_context_to_llm(self) -> None:
+        content = '```json\n{"name": "Books", "columns": [{"name": "title"}]}\n```'
+        credential = self._credential()
+        user = MagicMock(id=uuid.uuid4())
+        execute_llm = _execute_llm_returning(content)
+        with (
+            patch(
+                "app.api.ai_assistant.get_credential_for_user",
+                AsyncMock(return_value=credential),
+            ),
+            patch("app.api.data_tables.decrypt_config", return_value={"api_key": "x"}),
+            patch("app.api.data_tables.execute_llm", execute_llm),
+        ):
+            await generate_data_table_schema(
+                request=_make_request(),
+                current_user=user,
+                db=AsyncMock(),
+            )
+
+        execute_llm.assert_awaited_once()
+        kwargs = execute_llm.await_args.kwargs
+        trace_context = kwargs["trace_context"]
+        self.assertEqual(kwargs["model"], "gpt-4o-mini")
+        self.assertEqual(trace_context.user_id, user.id)
+        self.assertEqual(trace_context.credential_id, credential.id)
+        self.assertEqual(trace_context.source, "data_table_ai")
+        self.assertEqual(trace_context.node_label, "AI DataTable Create")
+
     async def test_dedupes_against_existing_columns_in_extend_mode(self) -> None:
         existing = [DataTableColumnDef(name="title", type="string", order=0)]
         content = (
@@ -134,16 +154,14 @@ class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
             '{"name": "Title", "type": "string"}, '
             '{"name": "isbn", "type": "string"}]}\n```'
         )
+        execute_llm = _execute_llm_returning(content)
         with (
             patch(
                 "app.api.ai_assistant.get_credential_for_user",
                 AsyncMock(return_value=self._credential()),
             ),
             patch("app.api.data_tables.decrypt_config", return_value={"api_key": "x"}),
-            patch(
-                "app.api.ai_assistant.get_openai_client",
-                return_value=(_llm_client_returning(content), "openai"),
-            ),
+            patch("app.api.data_tables.execute_llm", execute_llm),
         ):
             result = await generate_data_table_schema(
                 request=_make_request(existing=existing),
@@ -151,6 +169,10 @@ class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
                 db=AsyncMock(),
             )
         self.assertEqual([c.name for c in result.columns], ["isbn"])
+        self.assertEqual(
+            execute_llm.await_args.kwargs["trace_context"].node_label,
+            "AI DataTable Extend",
+        )
 
     async def test_missing_credential_returns_400(self) -> None:
         with patch(
@@ -173,8 +195,8 @@ class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
             ),
             patch("app.api.data_tables.decrypt_config", return_value={"api_key": "x"}),
             patch(
-                "app.api.ai_assistant.get_openai_client",
-                return_value=(_llm_client_returning("no json here"), "openai"),
+                "app.api.data_tables.execute_llm",
+                _execute_llm_returning("no json here"),
             ),
         ):
             with self.assertRaises(HTTPException) as ctx:
@@ -194,8 +216,8 @@ class GenerateDataTableSchemaEndpointTests(unittest.IsolatedAsyncioTestCase):
             ),
             patch("app.api.data_tables.decrypt_config", return_value={"api_key": "x"}),
             patch(
-                "app.api.ai_assistant.get_openai_client",
-                return_value=(_llm_client_returning(content), "openai"),
+                "app.api.data_tables.execute_llm",
+                _execute_llm_returning(content),
             ),
         ):
             with self.assertRaises(HTTPException) as ctx:

--- a/backend/tests/test_expression_generate.py
+++ b/backend/tests/test_expression_generate.py
@@ -101,6 +101,7 @@ class GenerateExpressionTests(unittest.IsolatedAsyncioTestCase):
             workflow_id=uuid.uuid4(),
             credential_id=uuid.uuid4(),
             model="gpt-4o",
+            current_node_id="node-1",
             node_results=[
                 NodeResultItem(
                     node_id="n1", label="API Call", output={"customer": {"name": "John"}}
@@ -134,6 +135,13 @@ class GenerateExpressionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Evaluator input value: customer name from the API response", user_message)
         self.assertIn("### Workflow `$vars` namespace", user_message)
         self.assertIn("### Global variables", user_message)
+        trace_context = execute_mock.await_args.kwargs["trace_context"]
+        self.assertEqual(trace_context.user_id, user.id)
+        self.assertEqual(trace_context.credential_id, request.credential_id)
+        self.assertEqual(trace_context.workflow_id, request.workflow_id)
+        self.assertEqual(trace_context.node_id, "node-1")
+        self.assertEqual(trace_context.source, "assistant")
+        self.assertEqual(trace_context.node_label, "Expression Builder")
 
     async def test_regenerate_prior_attempt_and_temperature(self) -> None:
         db = AsyncMock()

--- a/frontend/src/components/Canvas/NodeContextMenu.vue
+++ b/frontend/src/components/Canvas/NodeContextMenu.vue
@@ -15,9 +15,12 @@ interface Props {
   hasDisabledNodes: boolean;
   allDisabled: boolean;
   evalNode: { id: string; type: string; data: EvalNodeData } | null;
+  allowShareAsTemplate?: boolean;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  allowShareAsTemplate: true,
+});
 
 const emit = defineEmits<{
   (e: "extract"): void;
@@ -61,7 +64,7 @@ const menuItems = computed(() => [
     label: "Share as Template",
     icon: LayoutTemplate,
     action: () => { emit("shareAsTemplate"); emit("close"); },
-    show: props.selectedCount === 1,
+    show: props.allowShareAsTemplate && props.selectedCount === 1,
   },
   {
     type: "separator",

--- a/frontend/src/components/Canvas/WorkflowCanvas.vue
+++ b/frontend/src/components/Canvas/WorkflowCanvas.vue
@@ -46,12 +46,17 @@ const workflowStore = useWorkflowStore();
 const router = useRouter();
 const { isRunbookPlaying, playRunbookInPlace } = useRunbookPlayer();
 const showTemplatesBrowse = ref(false);
+const isDashboardWidget = computed(
+  () => workflowStore.currentWorkflow?.kind === "dashboard_widget",
+);
 
 function handleRunRunbook(): void {
+  if (isDashboardWidget.value) return;
   void playRunbookInPlace();
 }
 
 function handleBrowseTemplates(): void {
+  if (isDashboardWidget.value) return;
   showTemplatesBrowse.value = true;
 }
 const { showToast } = useToast();
@@ -595,7 +600,15 @@ const contextMenuAllDisabled = computed(() => {
 const shareNodeTemplateOpen = ref(false);
 const shareNodeTemplateData = ref<{ type: string; data: Record<string, unknown> } | null>(null);
 
+watch(isDashboardWidget, (dashboardWidget) => {
+  if (dashboardWidget) {
+    showTemplatesBrowse.value = false;
+    shareNodeTemplateOpen.value = false;
+  }
+});
+
 function handleContextMenuShareAsTemplate(): void {
+  if (isDashboardWidget.value) return;
   if (workflowStore.selectedNodeIds.size !== 1) return;
   const node = workflowStore.selectedNodes[0];
   if (!node) return;
@@ -1624,7 +1637,7 @@ watch(
     @dragleave="handleDragLeave"
   >
     <CanvasEmptyState
-      v-if="workflowStore.nodes.length === 0 && !isRunbookPlaying"
+      v-if="workflowStore.nodes.length === 0 && !isRunbookPlaying && !isDashboardWidget"
       @run-runbook="handleRunRunbook"
       @browse-templates="handleBrowseTemplates"
     />
@@ -1727,6 +1740,7 @@ watch(
       :has-disabled-nodes="contextMenuHasDisabledNodes"
       :all-disabled="contextMenuAllDisabled"
       :eval-node="contextMenuEvalNode"
+      :allow-share-as-template="!isDashboardWidget"
       @extract="handleContextMenuExtract"
       @eval-agent="handleContextMenuEvalAgent"
       @disable="handleContextMenuDisable"
@@ -1737,7 +1751,7 @@ watch(
     />
 
     <ShareTemplateModal
-      v-if="shareNodeTemplateOpen && shareNodeTemplateData"
+      v-if="shareNodeTemplateOpen && shareNodeTemplateData && !isDashboardWidget"
       kind="node"
       :node-type="shareNodeTemplateData.type"
       :node-data="shareNodeTemplateData.data"
@@ -1752,6 +1766,7 @@ watch(
     />
 
     <TemplatesBrowseDialog
+      v-if="!isDashboardWidget"
       :open="showTemplatesBrowse"
       @close="showTemplatesBrowse = false"
     />

--- a/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
+++ b/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
@@ -65,7 +65,14 @@ interface PaletteItem {
   type: PaletteItemType;
   id: string;
   label: string;
-  icon: (typeof TABS)[number]["icon"] | typeof Workflow | typeof BookOpen | typeof Trash2 | typeof LayoutTemplate;
+  icon:
+    | (typeof TABS)[number]["icon"]
+    | typeof Workflow
+    | typeof BookOpen
+    | typeof Trash2
+    | typeof LayoutTemplate
+    | typeof LifeBuoy
+    | typeof Play;
   workflow?: WorkflowListItem;
   folderPath?: string;
   categoryId?: string;
@@ -80,11 +87,13 @@ interface Props {
   workflows: WorkflowListItem[];
   context: "dashboard" | "editor";
   activeTab?: string;
+  hideTemplates?: boolean;
+  hideRunbook?: boolean;
 }
 
 const props = withDefaults(
   defineProps<Props>(),
-  { activeTab: "workflows" }
+  { activeTab: "workflows", hideTemplates: false, hideRunbook: false }
 );
 
 const emit = defineEmits<{
@@ -103,6 +112,11 @@ const workflowTemplates = ref<WorkflowTemplate[]>([]);
 const nodeTemplates = ref<NodeTemplate[]>([]);
 
 async function fetchTemplates(): Promise<void> {
+  if (props.hideTemplates) {
+    workflowTemplates.value = [];
+    nodeTemplates.value = [];
+    return;
+  }
   try {
     const res = await templatesApi.list();
     workflowTemplates.value = res.workflow_templates;
@@ -275,26 +289,28 @@ const categoryGroups = computed((): CategoryGroup[] => {
   }
 
   // 5. Templates (workflow + node)
-  const templateItems: PaletteItem[] = [
-    ...filteredTemplates.value.map((t) => ({
-      type: "template" as const,
-      id: t.id,
-      label: t.name,
-      icon: LayoutTemplate,
-      template: t,
-      categoryLabel: "Workflow Template",
-    })),
-    ...filteredNodeTemplates.value.map((t) => ({
-      type: "node-template" as const,
-      id: t.id,
-      label: t.name,
-      icon: LayoutTemplate,
-      nodeTemplate: t,
-      categoryLabel: "Node Template",
-    })),
-  ];
-  if (templateItems.length > 0) {
-    groups.push({ id: "templates", label: "Templates", items: templateItems });
+  if (!props.hideTemplates) {
+    const templateItems: PaletteItem[] = [
+      ...filteredTemplates.value.map((t) => ({
+        type: "template" as const,
+        id: t.id,
+        label: t.name,
+        icon: LayoutTemplate,
+        template: t,
+        categoryLabel: "Workflow Template",
+      })),
+      ...filteredNodeTemplates.value.map((t) => ({
+        type: "node-template" as const,
+        id: t.id,
+        label: t.name,
+        icon: LayoutTemplate,
+        nodeTemplate: t,
+        categoryLabel: "Node Template",
+      })),
+    ];
+    if (templateItems.length > 0) {
+      groups.push({ id: "templates", label: "Templates", items: templateItems });
+    }
   }
 
   // 5. Documentation (always last)
@@ -323,31 +339,34 @@ const categoryGroups = computed((): CategoryGroup[] => {
     "demo".includes(q) ||
     "tour".includes(q)
   ) {
+    const supportItems: PaletteItem[] = [
+      {
+        type: "documentation" as const,
+        id: "documentation",
+        label: "Documentation",
+        icon: BookOpen,
+        categoryId: "getting-started",
+        slug: "introduction",
+      },
+      {
+        type: "support" as const,
+        id: "support",
+        label: "Contact Support",
+        icon: LifeBuoy,
+      },
+    ];
+    if (!props.hideRunbook) {
+      supportItems.unshift({
+        type: "runbook" as const,
+        id: "runbook",
+        label: "Run the Runbook",
+        icon: Play,
+      });
+    }
     groups.push({
       id: "support",
       label: "Support",
-      items: [
-        {
-          type: "runbook" as const,
-          id: "runbook",
-          label: "Run the Runbook",
-          icon: Play,
-        },
-        {
-          type: "documentation" as const,
-          id: "documentation",
-          label: "Documentation",
-          icon: BookOpen,
-          categoryId: "getting-started",
-          slug: "introduction",
-        },
-        {
-          type: "support" as const,
-          id: "support",
-          label: "Contact Support",
-          icon: LifeBuoy,
-        },
-      ],
+      items: supportItems,
     });
   }
 

--- a/frontend/src/components/Panels/NodePanel.vue
+++ b/frontend/src/components/Panels/NodePanel.vue
@@ -213,6 +213,13 @@ const DASHBOARD_HIDDEN_NODE_TYPES = new Set<NodeType>([
 const isDashboardWidget = computed(
   () => workflowStore.currentWorkflow?.kind === "dashboard_widget",
 );
+const showNodeTemplates = computed(() => !isDashboardWidget.value && !isRunbookPlaying.value);
+
+watch(showNodeTemplates, (visible) => {
+  if (!visible) {
+    showTemplatesBrowse.value = false;
+  }
+});
 
 const paletteNodeTypes = computed(() =>
   isDashboardWidget.value
@@ -234,6 +241,7 @@ const nodeTypes = computed(() => {
 });
 
 const filteredNodeTemplates = computed(() => {
+  if (!showNodeTemplates.value) return [];
   const query = searchQuery.value.toLowerCase().trim();
   const uid = authStore.user?.id;
   const list = [...nodeTemplates.value];
@@ -586,7 +594,7 @@ function handleDoubleClick(type: NodeType): void {
             </div>
           </div>
         </div>
-        <template v-if="!isRunbookPlaying && (filteredNodeTemplates.length > 0 || templatesLoadError)">
+        <template v-if="showNodeTemplates && (filteredNodeTemplates.length > 0 || templatesLoadError)">
           <div class="pt-4 pb-1">
             <h3 class="text-xs font-semibold uppercase tracking-wide text-muted-foreground flex items-center gap-2">
               <LayoutTemplate class="w-3.5 h-3.5" />
@@ -655,6 +663,7 @@ function handleDoubleClick(type: NodeType): void {
             </p>
           </div>
           <button
+            v-if="showNodeTemplates"
             type="button"
             class="node-item w-full flex items-center gap-3 p-3 rounded-xl border border-border/40 cursor-pointer transition-all duration-200 min-h-[44px] text-left hover:border-primary/40 hover:bg-accent/50 hover:shadow-sm"
             @click="openTemplatesBrowse"
@@ -685,6 +694,7 @@ function handleDoubleClick(type: NodeType): void {
     </div>
 
     <TemplatesBrowseDialog
+      v-if="showNodeTemplates"
       :open="showTemplatesBrowse"
       :query="templatesBrowseQuery"
       @close="showTemplatesBrowse = false"

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -490,6 +490,27 @@ const playwrightExprRefsBySlotKey = ref<Record<string, InstanceType<typeof Expre
 const mcpCallArgumentInputRefs = ref<Map<string, InstanceType<typeof ExpressionInput>>>(new Map());
 const mcpCallConnectionEnvInputRef = ref<InstanceType<typeof ExpressionInput> | null>(null);
 const currentMCPCallExpressionFieldIndex = ref(0);
+type ChartOutputExpressionFieldKey =
+  | "text"
+  | "valueField"
+  | "dataPath"
+  | "labelField"
+  | "xField"
+  | "yField"
+  | "min"
+  | "max"
+  | "unit"
+  | "title";
+
+interface ChartOutputExpressionField {
+  key: ChartOutputExpressionFieldKey;
+  label: string;
+}
+
+const chartOutputExpressionInputRefs = ref<
+  Map<ChartOutputExpressionFieldKey, InstanceType<typeof ExpressionInput>>
+>(new Map());
+const currentChartOutputExpressionFieldIndex = ref(0);
 const validationErrors = ref<ValidationError[]>([]);
 const showValidationDialog = ref(false);
 
@@ -1470,6 +1491,7 @@ function closeAllExpressionExpandDialogs(): void {
   closeBigQueryExpressionDialogs();
   closeS3ExpressionDialogs();
   closeMCPCallExpressionDialogs();
+  closeChartOutputExpressionDialogs();
 }
 
 /** Opens the primary expression evaluate dialog for whichever node is currently selected. */
@@ -1495,6 +1517,20 @@ function openPrimaryExpandDialogForSelectedNode(): void {
         }
       } else if (outputMessageInputRef.value) {
         nextTick(() => openOutputExpressionFieldAtIndex(0));
+      } else {
+        setTimeout(() => tryOpenDialog(attempts + 1), 100);
+      }
+    };
+    nextTick(() => tryOpenDialog());
+  } else if (nodeType === "chartOutput") {
+    currentChartOutputExpressionFieldIndex.value = 0;
+    const tryOpenDialog = (attempts = 0): void => {
+      if (attempts > 20) {
+        return;
+      }
+      const firstField = chartOutputExpressionFields.value[0];
+      if (firstField && chartOutputExpressionInputRefs.value.get(firstField.key)) {
+        nextTick(() => openChartOutputExpressionFieldAtIndex(0));
       } else {
         setTimeout(() => tryOpenDialog(attempts + 1), 100);
       }
@@ -1904,6 +1940,7 @@ function selectedNodeHasPrimaryEvaluateExpandTarget(): boolean {
     case "jsonOutputMapper":
       return true;
     case "output":
+    case "chartOutput":
     case "http":
     case "websocketSend":
     case "llm":
@@ -2990,6 +3027,116 @@ function handleDriveExpressionFieldNavigate(direction: "prev" | "next"): void {
 
 function onDriveRegisterExpressionFieldIndex(index: number): void {
   currentDriveExpressionFieldIndex.value = index;
+}
+
+const chartOutputExpressionFields = computed<ChartOutputExpressionField[]>(() => {
+  const n = workflowStore.selectedNode;
+  if (!n || n.type !== "chartOutput") {
+    return [];
+  }
+  const chartType = n.data.chartType || "bar";
+  const fields: ChartOutputExpressionField[] = [];
+
+  if (chartType === "text") {
+    fields.push(
+      { key: "text", label: "Text (markdown)" },
+      { key: "valueField", label: "Value field" },
+    );
+  }
+
+  fields.push({ key: "dataPath", label: "Data path" });
+
+  if (["bar", "line", "area", "pie", "proportion", "barGauge"].includes(chartType)) {
+    fields.push({ key: "labelField", label: "Label field" });
+  }
+
+  if (["bar", "line", "area", "pie", "numeric", "gauge", "proportion", "barGauge"].includes(chartType)) {
+    fields.push({ key: "valueField", label: "Value field" });
+  }
+
+  if (chartType === "scatter") {
+    fields.push(
+      { key: "xField", label: "X field" },
+      { key: "yField", label: "Y field" },
+    );
+  }
+
+  if (chartType === "gauge") {
+    fields.push(
+      { key: "min", label: "Min" },
+      { key: "max", label: "Max" },
+    );
+  }
+
+  if (chartType === "barGauge") {
+    fields.push({ key: "max", label: "Max" });
+  }
+
+  if (["numeric", "gauge", "barGauge"].includes(chartType)) {
+    fields.push({ key: "unit", label: "Unit" });
+  }
+
+  fields.push({ key: "title", label: "Title" });
+  return fields;
+});
+
+const chartOutputExpressionFieldCount = computed((): number => {
+  return chartOutputExpressionFields.value.length;
+});
+
+function chartOutputExpressionFieldIndex(key: ChartOutputExpressionFieldKey): number {
+  const index = chartOutputExpressionFields.value.findIndex((field) => field.key === key);
+  return index >= 0 ? index : 0;
+}
+
+function setChartOutputExpressionInputRef(
+  key: ChartOutputExpressionFieldKey,
+  el: unknown,
+): void {
+  if (el) {
+    chartOutputExpressionInputRefs.value.set(key, el as InstanceType<typeof ExpressionInput>);
+  } else {
+    chartOutputExpressionInputRefs.value.delete(key);
+  }
+}
+
+function openChartOutputExpressionFieldAtIndex(index: number): void {
+  const n = selectedNode.value;
+  if (!n || n.type !== "chartOutput") {
+    return;
+  }
+  const field = chartOutputExpressionFields.value[index];
+  if (!field) {
+    return;
+  }
+  currentChartOutputExpressionFieldIndex.value = index;
+  chartOutputExpressionInputRefs.value.get(field.key)?.openExpandDialog();
+}
+
+function closeChartOutputExpressionDialogs(): void {
+  for (const input of chartOutputExpressionInputRefs.value.values()) {
+    input.closeExpandDialog();
+  }
+}
+
+function handleChartOutputExpressionFieldNavigate(direction: "prev" | "next"): void {
+  const total = chartOutputExpressionFieldCount.value;
+  const newIndex =
+    direction === "prev"
+      ? currentChartOutputExpressionFieldIndex.value - 1
+      : currentChartOutputExpressionFieldIndex.value + 1;
+  if (newIndex < 0 || newIndex >= total) {
+    return;
+  }
+  closeChartOutputExpressionDialogs();
+  currentChartOutputExpressionFieldIndex.value = newIndex;
+  nextTick(() => {
+    openChartOutputExpressionFieldAtIndex(newIndex);
+  });
+}
+
+function onChartOutputRegisterExpressionFieldIndex(index: number): void {
+  currentChartOutputExpressionFieldIndex.value = index;
 }
 
 function onSetMappingRegisterFieldIndex(index: number): void {
@@ -8226,10 +8373,23 @@ onUnmounted(() => {
               class="space-y-2"
             >
               <Label>Text (markdown)</Label>
-              <Textarea
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('text', el)"
                 :model-value="selectedNode.data.text || ''"
                 :rows="5"
                 placeholder="e.g. **Last execution** at `19:47`"
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Text (markdown)"
+                field-key="text"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('text')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('text', $event)"
               />
               <p class="text-xs text-muted-foreground">
@@ -8243,9 +8403,23 @@ onUnmounted(() => {
               class="space-y-2"
             >
               <Label>Value field (optional)</Label>
-              <Input
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('valueField', el)"
                 :model-value="selectedNode.data.valueField || ''"
                 placeholder="row key holding the markdown string"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Value field"
+                field-key="valueField"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('valueField')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('valueField', $event)"
               />
             </div>
@@ -8267,9 +8441,23 @@ onUnmounted(() => {
 
             <div class="space-y-2">
               <Label>Data path</Label>
-              <Input
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('dataPath', el)"
                 :model-value="selectedNode.data.dataPath || ''"
                 placeholder="e.g. data or result.items"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Data path"
+                field-key="dataPath"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('dataPath')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('dataPath', $event)"
               />
               <p class="text-xs text-muted-foreground">
@@ -8285,18 +8473,46 @@ onUnmounted(() => {
                 class="space-y-2"
               >
                 <Label>Label field</Label>
-                <Input
+                <ExpressionInput
+                  :ref="(el: unknown) => setChartOutputExpressionInputRef('labelField', el)"
                   :model-value="selectedNode.data.labelField || ''"
                   placeholder="row key used as category label"
+                  single-line
+                  :nodes="workflowStore.nodes"
+                  :node-results="workflowStore.nodeResults"
+                  :edges="workflowStore.edges"
+                  :current-node-id="selectedNode.id"
+                  :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                  dialog-key-label="Label field"
+                  field-key="labelField"
+                  :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                  :navigation-index="chartOutputExpressionFieldIndex('labelField')"
+                  :navigation-total="chartOutputExpressionFieldCount"
+                  @navigate="handleChartOutputExpressionFieldNavigate"
+                  @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                   @update:model-value="updateNodeData('labelField', $event)"
                 />
               </div>
 
               <div class="space-y-2">
                 <Label>Value field</Label>
-                <Input
+                <ExpressionInput
+                  :ref="(el: unknown) => setChartOutputExpressionInputRef('valueField', el)"
                   :model-value="selectedNode.data.valueField || ''"
                   placeholder="row key used as numeric value"
+                  single-line
+                  :nodes="workflowStore.nodes"
+                  :node-results="workflowStore.nodeResults"
+                  :edges="workflowStore.edges"
+                  :current-node-id="selectedNode.id"
+                  :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                  dialog-key-label="Value field"
+                  field-key="valueField"
+                  :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                  :navigation-index="chartOutputExpressionFieldIndex('valueField')"
+                  :navigation-total="chartOutputExpressionFieldCount"
+                  @navigate="handleChartOutputExpressionFieldNavigate"
+                  @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                   @update:model-value="updateNodeData('valueField', $event)"
                 />
               </div>
@@ -8305,17 +8521,45 @@ onUnmounted(() => {
             <template v-if="selectedNode.data.chartType === 'scatter'">
               <div class="space-y-2">
                 <Label>X field</Label>
-                <Input
+                <ExpressionInput
+                  :ref="(el: unknown) => setChartOutputExpressionInputRef('xField', el)"
                   :model-value="selectedNode.data.xField || ''"
                   placeholder="row key for the X axis (numeric)"
+                  single-line
+                  :nodes="workflowStore.nodes"
+                  :node-results="workflowStore.nodeResults"
+                  :edges="workflowStore.edges"
+                  :current-node-id="selectedNode.id"
+                  :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                  dialog-key-label="X field"
+                  field-key="xField"
+                  :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                  :navigation-index="chartOutputExpressionFieldIndex('xField')"
+                  :navigation-total="chartOutputExpressionFieldCount"
+                  @navigate="handleChartOutputExpressionFieldNavigate"
+                  @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                   @update:model-value="updateNodeData('xField', $event)"
                 />
               </div>
               <div class="space-y-2">
                 <Label>Y field</Label>
-                <Input
+                <ExpressionInput
+                  :ref="(el: unknown) => setChartOutputExpressionInputRef('yField', el)"
                   :model-value="selectedNode.data.yField || ''"
                   placeholder="row key for the Y axis (numeric)"
+                  single-line
+                  :nodes="workflowStore.nodes"
+                  :node-results="workflowStore.nodeResults"
+                  :edges="workflowStore.edges"
+                  :current-node-id="selectedNode.id"
+                  :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                  dialog-key-label="Y field"
+                  field-key="yField"
+                  :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                  :navigation-index="chartOutputExpressionFieldIndex('yField')"
+                  :navigation-total="chartOutputExpressionFieldCount"
+                  @navigate="handleChartOutputExpressionFieldNavigate"
+                  @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                   @update:model-value="updateNodeData('yField', $event)"
                 />
               </div>
@@ -8327,17 +8571,45 @@ onUnmounted(() => {
             >
               <div class="space-y-2">
                 <Label>Min</Label>
-                <Input
-                  type="number"
-                  :model-value="selectedNode.data.min ?? 0"
+                <ExpressionInput
+                  :ref="(el: unknown) => setChartOutputExpressionInputRef('min', el)"
+                  :model-value="String(selectedNode.data.min ?? 0)"
+                  placeholder="0"
+                  single-line
+                  :nodes="workflowStore.nodes"
+                  :node-results="workflowStore.nodeResults"
+                  :edges="workflowStore.edges"
+                  :current-node-id="selectedNode.id"
+                  :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                  dialog-key-label="Min"
+                  field-key="min"
+                  :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                  :navigation-index="chartOutputExpressionFieldIndex('min')"
+                  :navigation-total="chartOutputExpressionFieldCount"
+                  @navigate="handleChartOutputExpressionFieldNavigate"
+                  @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                   @update:model-value="updateNodeData('min', $event)"
                 />
               </div>
               <div class="space-y-2">
                 <Label>Max</Label>
-                <Input
-                  type="number"
-                  :model-value="selectedNode.data.max ?? 100"
+                <ExpressionInput
+                  :ref="(el: unknown) => setChartOutputExpressionInputRef('max', el)"
+                  :model-value="String(selectedNode.data.max ?? 100)"
+                  placeholder="100"
+                  single-line
+                  :nodes="workflowStore.nodes"
+                  :node-results="workflowStore.nodeResults"
+                  :edges="workflowStore.edges"
+                  :current-node-id="selectedNode.id"
+                  :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                  dialog-key-label="Max"
+                  field-key="max"
+                  :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                  :navigation-index="chartOutputExpressionFieldIndex('max')"
+                  :navigation-total="chartOutputExpressionFieldCount"
+                  @navigate="handleChartOutputExpressionFieldNavigate"
+                  @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                   @update:model-value="updateNodeData('max', $event)"
                 />
               </div>
@@ -8348,10 +8620,23 @@ onUnmounted(() => {
               class="space-y-2"
             >
               <Label>Max (optional)</Label>
-              <Input
-                type="number"
-                :model-value="selectedNode.data.max ?? ''"
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('max', el)"
+                :model-value="selectedNode.data.max === undefined || selectedNode.data.max === null ? '' : String(selectedNode.data.max)"
                 placeholder="defaults to the largest row value"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Max"
+                field-key="max"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('max')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('max', $event)"
               />
             </div>
@@ -8361,18 +8646,46 @@ onUnmounted(() => {
               class="space-y-2"
             >
               <Label>Unit</Label>
-              <Input
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('unit', el)"
                 :model-value="selectedNode.data.unit || ''"
                 placeholder="e.g. USD, %, ms"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Unit"
+                field-key="unit"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('unit')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('unit', $event)"
               />
             </div>
 
             <div class="space-y-2">
               <Label>Title</Label>
-              <Input
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('title', el)"
                 :model-value="selectedNode.data.title || ''"
                 placeholder="optional chart title"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Title"
+                field-key="title"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('title')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('title', $event)"
               />
             </div>

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -117,6 +117,9 @@ const workflowDescription = computed(() => workflowStore.currentWorkflow?.descri
 const isDashboardWidget = computed(
   () => workflowStore.currentWorkflow?.kind === "dashboard_widget",
 );
+const isStandardWorkflow = computed(
+  () => Boolean(workflowStore.currentWorkflow) && !isDashboardWidget.value,
+);
 const hasUnsavedChanges = computed(() => workflowStore.hasUnsavedChanges);
 const isSaving = computed(() => workflowStore.isSaving);
 const isEditing = computed(() => isTitleEditing.value || isDescriptionEditing.value);
@@ -665,6 +668,10 @@ watch(webhookBodyMode, async (value) => {
 
 watch(shareOpen, async (open) => {
   if (!open) return;
+  if (!isStandardWorkflow.value) {
+    shareOpen.value = false;
+    return;
+  }
   shareError.value = "";
   await loadShares();
 });
@@ -1291,7 +1298,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           Download
         </Button>
         <Button
-          v-if="!isDashboardWidget"
+          v-if="isStandardWorkflow"
           variant="ghost"
           size="sm"
           class="hidden lg:inline-flex gap-2 text-foreground"
@@ -1301,7 +1308,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           Portal
         </Button>
         <Button
-          v-if="!isDashboardWidget"
+          v-if="isStandardWorkflow"
           variant="ghost"
           size="sm"
           class="hidden lg:inline-flex gap-2 text-foreground"
@@ -1311,7 +1318,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           Share
         </Button>
         <Button
-          v-if="!isDashboardWidget"
+          v-if="isStandardWorkflow"
           variant="ghost"
           size="sm"
           class="hidden xl:inline-flex gap-2 text-foreground"
@@ -1322,7 +1329,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           Template
         </Button>
         <Button
-          v-if="!isDashboardWidget"
+          v-if="isStandardWorkflow"
           variant="ghost"
           size="sm"
           class="hidden xl:inline-flex gap-2 text-foreground"
@@ -2118,6 +2125,8 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
       :open="showCommandPalette"
       :workflows="paletteWorkflows"
       context="editor"
+      :hide-templates="isDashboardWidget"
+      :hide-runbook="isDashboardWidget"
       @select="openWorkflowFromPalette"
       @tab-select="handleTabSelectFromPalette"
       @doc-select="onDocSelectFromPalette"
@@ -2127,7 +2136,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
 
     <!-- Share as Template modal -->
     <ShareTemplateModal
-      v-if="shareTemplateOpen"
+      v-if="shareTemplateOpen && isStandardWorkflow"
       kind="workflow"
       :nodes="(workflowStore.currentWorkflow?.nodes ?? []) as Record<string, unknown>[]"
       :edges="(workflowStore.currentWorkflow?.edges ?? []) as Record<string, unknown>[]"


### PR DESCRIPTION
## Summary
- Add chartOutput to the properties panel expression-dialog open/navigation flow.
- Convert chart output text/path/field/unit/title inputs to ExpressionInput so double-click opens the evaluate dialog.
- Build the visible field list dynamically from chart type so dialog prev/next follows the currently rendered fields.

## Why
Chart output widget nodes had plain inputs, so double-click did not open the expression dialog like other canvas nodes.

## Validation
- SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh
