### PR TITLE
fix: block undo/redo while workflow execution is in progress (#199)

### DIFF
--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -288,7 +288,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
   }
 
   function undo(): void {
-    if (!canUndo.value) return;
+    if (!canUndo.value || isExecuting.value) return;
 
     isUndoRedo.value = true;
     historyIndex.value--;
@@ -300,7 +300,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
   }
 
   function redo(): void {
-    if (!canRedo.value) return;
+    if (!canRedo.value || isExecuting.value) return;
 
     isUndoRedo.value = true;
     historyIndex.value++;


### PR DESCRIPTION
## Summary

- `undo()` and `redo()` in `frontend/src/stores/workflow.ts` only checked `canUndo`/`canRedo` — they did not consult `isExecuting`, so pressing Ctrl+Z or Ctrl+Y while a workflow was running would immediately overwrite the reactive `nodes.value` and `edges.value` refs with a prior history snapshot.
- Since the canvas executor reads those same reactive refs, replacing them mid-execution corrupts the running graph: node positions, edge connections, and execution-state overlays become inconsistent for the remainder of the run.
- Fix is a two-line guard change. `isExecuting` was already defined in the same store (`ref(false)`, line 62) and is correctly set/unset by `startExecution`/`stopExecution` — `undo()`/`redo()` simply never referenced it.

## Changes

- `frontend/src/stores/workflow.ts`
  - `undo()` (line 291): `if (!canUndo.value) return;` → `if (!canUndo.value || isExecuting.value) return;`
  - `redo()` (line 303): `if (!canRedo.value) return;` → `if (!canRedo.value || isExecuting.value) return;`

## Test Plan

- [ ] Open a workflow and make several edits so the undo history is non-empty.
- [ ] Start executing the workflow (click Run / trigger execution).
- [ ] While execution is in flight (execution indicator active), press **Ctrl+Z** — canvas nodes and edges must not change.
- [ ] While execution is in flight, press **Ctrl+Y** — canvas nodes and edges must not change.
- [ ] Let execution complete, then press **Ctrl+Z** — undo should work as normal.
- [ ] Press **Ctrl+Y** after undoing — redo should work as normal.
- [ ] Run frontend lint and typecheck: `bun run lint && bun run typecheck` — both must pass.

Closes #199
