### PR TITLE
fix: ChatGPT MCP connector, hide widgets from MCP, mobile canvas cleanup

### DIFF
--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -211,6 +211,7 @@ async def get_user_mcp_workflows(db: AsyncSession, user_id: uuid.UUID) -> list[W
         .where(
             Workflow.mcp_enabled.is_(True),
             Workflow.owner_id == user_id,
+            Workflow.kind != "dashboard_widget",
         )
         .order_by(Workflow.name.asc())
     )
@@ -222,6 +223,7 @@ async def get_user_mcp_workflows(db: AsyncSession, user_id: uuid.UUID) -> list[W
         .where(
             WorkflowShare.user_id == user_id,
             WorkflowShare.mcp_enabled.is_(True),
+            Workflow.kind != "dashboard_widget",
         )
         .order_by(Workflow.name.asc())
     )
@@ -236,12 +238,13 @@ async def get_all_user_workflows(db: AsyncSession, user_id: uuid.UUID) -> list[W
     result = await db.execute(
         select(Workflow)
         .where(
+            Workflow.kind != "dashboard_widget",
             or_(
                 Workflow.owner_id == user_id,
                 Workflow.id.in_(
                     select(WorkflowShare.workflow_id).where(WorkflowShare.user_id == user_id)
                 ),
-            )
+            ),
         )
         .order_by(Workflow.name.asc())
     )

--- a/backend/tests/test_mcp_dashboard_widget_filter.py
+++ b/backend/tests/test_mcp_dashboard_widget_filter.py
@@ -1,0 +1,44 @@
+import unittest
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from app.api.mcp import get_all_user_workflows, get_user_mcp_workflows
+
+
+def _capturing_db() -> tuple[MagicMock, list[str]]:
+    """Return a mock AsyncSession that records the compiled SQL of each query."""
+    compiled_statements: list[str] = []
+
+    async def execute(statement):  # type: ignore[no-untyped-def]
+        compiled_statements.append(str(statement.compile()))
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        return result
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=execute)
+    return db, compiled_statements
+
+
+class DashboardWidgetMcpFilterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_get_all_user_workflows_excludes_dashboard_widget(self) -> None:
+        db, statements = _capturing_db()
+        await get_all_user_workflows(db, uuid.uuid4())
+        self.assertTrue(statements)
+        self.assertTrue(
+            any("kind" in s and "!=" in s for s in statements),
+            f"Expected a kind inequality filter, got: {statements}",
+        )
+
+    async def test_get_user_mcp_workflows_excludes_dashboard_widget(self) -> None:
+        db, statements = _capturing_db()
+        await get_user_mcp_workflows(db, uuid.uuid4())
+        # Both the owned and shared queries must filter out dashboard widgets.
+        self.assertEqual(len(statements), 2)
+        for s in statements:
+            self.assertIn("kind", s)
+            self.assertIn("!=", s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/MCP/MCPPanel.vue
+++ b/frontend/src/components/MCP/MCPPanel.vue
@@ -35,7 +35,7 @@ const router = useRouter();
 
 const config = ref<MCPConfigResponse | null>(null);
 const loading = ref(true);
-const connectionTab = ref<"api-key" | "claude">("api-key");
+const connectionTab = ref<"api-key" | "claude" | "openai">("api-key");
 const showApiKey = ref(false);
 const regenerating = ref(false);
 const togglingWorkflowId = ref<string | null>(null);
@@ -353,6 +353,15 @@ function addToCursor(): void {
               >
                 Claude Connector
               </button>
+              <button
+                :class="cn(
+                  'px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+                  connectionTab === 'openai' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'
+                )"
+                @click="connectionTab = 'openai'"
+              >
+                ChatGPT Connector
+              </button>
             </div>
 
             <div
@@ -477,6 +486,48 @@ function addToCursor(): void {
               <div class="flex items-start gap-2 p-3 rounded-md bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800/50 text-sm">
                 <Info class="w-4 h-4 shrink-0 mt-0.5" />
                 <span>Claude uses OAuth 2.1 to securely authenticate. Your Heym credentials are used to authorize access and are never shared with Claude.</span>
+              </div>
+            </div>
+
+            <div
+              v-else-if="connectionTab === 'openai'"
+              class="space-y-4"
+            >
+              <div>
+                <label class="text-sm font-medium text-muted-foreground block mb-1.5">
+                  MCP Server URL
+                </label>
+                <div class="flex items-center gap-2">
+                  <code class="flex-1 px-3 py-2 bg-muted rounded-md text-sm font-mono truncate">
+                    {{ sseEndpointUrl }}
+                  </code>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    @click="copyToClipboard(sseEndpointUrl, 'MCP Server URL')"
+                  >
+                    <Copy class="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+
+              <div class="rounded-lg bg-muted/50 border p-4 space-y-3">
+                <h4 class="font-medium text-sm">
+                  Setup Instructions
+                </h4>
+                <ol class="text-sm text-muted-foreground space-y-2 list-decimal list-inside">
+                  <li>Open <strong class="text-foreground">chatgpt.com</strong> in your browser and go to Settings</li>
+                  <li>Navigate to <strong class="text-foreground">Apps → Advanced settings</strong> and enable <strong class="text-foreground">Developer mode</strong></li>
+                  <li>Go to <strong class="text-foreground">Settings → Apps → Create app</strong></li>
+                  <li>Enter the name <strong class="text-foreground">Heym</strong> and paste the MCP Server URL above</li>
+                  <li>Choose <strong class="text-foreground">OAuth</strong> for authentication — ChatGPT will register automatically</li>
+                  <li>Click <strong class="text-foreground">Create</strong> and authorize with your Heym credentials</li>
+                </ol>
+              </div>
+
+              <div class="flex items-start gap-2 p-3 rounded-md bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800/50 text-sm">
+                <Info class="w-4 h-4 shrink-0 mt-0.5" />
+                <span>ChatGPT uses OAuth 2.1 to securely authenticate. Your Heym credentials are used to authorize access and are never shared with ChatGPT. Developer mode is required to add custom MCP connectors.</span>
               </div>
             </div>
           </div>

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -64,8 +64,9 @@ const HITL_RESOLUTION_STORAGE_KEY = "heym-hitl-resolution";
 const isMobile = useMediaQuery("(max-width: 767px)");
 
 const loading = ref(true);
-const leftPanelOpen = ref(true);
-const rightPanelOpen = ref(true);
+// On mobile, start with both side panels collapsed so only the canvas is visible.
+const leftPanelOpen = ref(!isMobile.value);
+const rightPanelOpen = ref(!isMobile.value);
 const historyOpen = ref(false);
 const editHistoryOpen = ref(false);
 const shareOpen = ref(false);
@@ -251,6 +252,15 @@ watch(
     }
   },
 );
+
+// Collapse both side panels when the viewport becomes mobile so the canvas
+// (standard workflow or dashboard widget) is shown on its own.
+watch(isMobile, (mobile) => {
+  if (mobile) {
+    leftPanelOpen.value = false;
+    rightPanelOpen.value = false;
+  }
+});
 
 function toggleRightPanel(): void {
   rightPanelOpen.value = !rightPanelOpen.value;
@@ -1222,6 +1232,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
         class="flex items-center gap-1 md:gap-2 flex-wrap shrink-0"
       >
         <Button
+          v-if="!isDashboardWidget"
           variant="ghost"
           size="icon"
           class="md:hidden text-destructive hover:text-destructive h-11 w-11 min-h-[44px] min-w-[44px]"
@@ -1231,6 +1242,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           <Trash2 class="w-4 h-4" />
         </Button>
         <Button
+          v-if="!isDashboardWidget"
           variant="ghost"
           size="sm"
           class="hidden md:inline-flex gap-2 text-destructive hover:text-destructive"


### PR DESCRIPTION
## Summary
Four UI/MCP fixes:

1. **Dashboard-widget toolbar** — hide the Clear button in `dashboard_widget` canvases; it was overlapping the logo and is not meaningful for widgets.
2. **Mobile canvas** — both side panels (node palette + properties) now default to collapsed on mobile and auto-collapse when the viewport becomes mobile, so only the canvas is shown. Applies to standard workflows and dashboard widgets. Chevron toggles still reopen them.
3. **MCP server list** — `dashboard_widget` workflows are excluded from MCP config listing and from the exposed MCP tools (`get_all_user_workflows` + `get_user_mcp_workflows`).
4. **ChatGPT (OpenAI) connector** — new "ChatGPT Connector" tab in the MCP panel alongside Claude, with OAuth 2.1 / developer-mode setup instructions. Reuses the existing connector-agnostic OAuth flow (no backend change).

## Tests
- New `backend/tests/test_mcp_dashboard_widget_filter.py` asserts the `kind != dashboard_widget` filter is present in both MCP query paths.
- `./check.sh`: frontend lint + typecheck, backend ruff, and **1168 backend tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)