### PR TITLE
impl/count-operation-for-datatable

### DIFF
--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -2331,8 +2331,8 @@ Each row object includes **`rowIndex`**: the 1-based sheet row number (useful fo
 - **Data fields**:
   - `label`: Node identifier
   - `dataTableId`: UUID of the DataTable to operate on (required)
-  - `dataTableOperation`: Operation type - "find" | "getAll" | "getById" | "insert" | "update" | "remove" | "upsert"
-  - `dataTableFilter`: JSON object for exact-match filtering {"column_name": "value"} (for find, upsert)
+  - `dataTableOperation`: Operation type - "find" | "getAll" | "count" | "getById" | "insert" | "update" | "remove" | "upsert"
+  - `dataTableFilter`: JSON object for filtering (for find, upsert, count). `find`/`upsert` do exact-match {"column_name": "value"}. `count` also supports comparison operators via object values: {"age": {"$gt": 18}} — supported operators: $eq $ne $gt $gte $lt $lte $contains (case-insensitive substring) $in (array). A plain value still means equals. Numeric comparisons apply to columns typed as "number". You can also filter on row metadata (`id`, `created_at`, `updated_at`, `created_by`, `updated_by`) which are real columns — use a full date for range comparisons (e.g. {"created_at": {"$gt": "2026-06-04"}}) or $contains for partial date text matches.
   - `dataTableData`: JSON object mapping column names to values (for insert, update, upsert)
   - `dataTableRowId`: Row UUID for single-row operations (for getById, update, remove)
   - `dataTableLimit`: Maximum rows to return (default: 100, for find, getAll)
@@ -2342,8 +2342,9 @@ Each row object includes **`rowIndex`**: the 1-based sheet row number (useful fo
 
 | Operation | Required Fields | Description |
 |-----------|----------------|-------------|
-| `find` | dataTableId | Find rows matching a filter with optional sort/limit |
+| `find` | dataTableId | Find rows matching an exact-match filter with optional sort/limit |
 | `getAll` | dataTableId | Get all rows with optional sort/limit |
+| `count` | dataTableId | Count rows matching an optional operator filter (DB-side, returns just a number) |
 | `getById` | dataTableId, dataTableRowId | Get a single row by its UUID |
 | `insert` | dataTableId, dataTableData | Insert a new row |
 | `update` | dataTableId, dataTableRowId, dataTableData | Update an existing row (merges data) |
@@ -2392,16 +2393,29 @@ Each row object includes **`rowIndex`**: the 1-based sheet row number (useful fo
   }
 }
 ```
+```json
+{
+  "id": "dt-count",
+  "type": "dataTable",
+  "position": {"x": 400, "y": 800},
+  "data": {
+    "label": "activeAdults",
+    "dataTableId": "datatable-uuid",
+    "dataTableOperation": "count",
+    "dataTableFilter": "{\"status\": \"active\", \"age\": {\"$gt\": 18}}"
+  }
+}
+```
 
 **Output access**:
 - `$nodeLabel.success` - Boolean success status
 - `$nodeLabel.rows` - Array of row objects (for find, getAll)
 - `$nodeLabel.row` - Single row object (for getById, insert, update, upsert)
 - `$nodeLabel.row.data.column_name` - Access specific column value
-- `$nodeLabel.count` - Number of rows returned
+- `$nodeLabel.count` - Number of rows (rows returned for find/getAll; matching-row total for count)
 - `$nodeLabel.id` - Row ID (for insert, update, remove)
 - `$nodeLabel.found` - Boolean (for getById)
-- `$nodeLabel.operation` - "insert" or "update" (for upsert)
+- `$nodeLabel.operation` - Operation name (e.g. "count"; "insert"/"update" for upsert)
 
 ### 24. throwError (Stop Workflow with Error)
 - **Purpose**: Immediately stop workflow execution and return an error response with a custom HTTP status code

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -67,6 +67,86 @@ def _slugify_tool_name(label: str) -> str:
     return slug[:64] or "node_tool"
 
 
+def _build_data_table_filter_clauses(filter_dict: dict, columns: list) -> list:
+    """Build SQLAlchemy filter clauses for a DataTable Mongo-style filter.
+
+    A plain value means equality. An object value applies comparison operators:
+    ``$eq``, ``$ne``, ``$gt``, ``$gte``, ``$lt``, ``$lte``, ``$contains`` (ILIKE
+    substring) and ``$in`` (list membership).
+
+    User-defined schema columns live in the JSONB ``data`` blob and are matched as
+    text (numeric comparisons cast to ``NUMERIC`` when the column type is ``number``).
+    Row metadata (``id``, ``created_at``, ``updated_at``, ``created_by``,
+    ``updated_by``, ``table_id``) are real table columns, so they are matched against
+    the model attribute directly; ``$contains`` casts them to text. A schema column
+    that happens to share a metadata name still resolves against the JSONB blob.
+    Unknown operators are ignored.
+    """
+    from sqlalchemy import Numeric, String, cast
+
+    from app.db.models import DataTableRow
+
+    if not isinstance(filter_dict, dict) or not filter_dict:
+        return []
+
+    schema_cols = {c["name"]: c for c in (columns or [])}
+    meta_columns = {
+        "id": DataTableRow.id,
+        "table_id": DataTableRow.table_id,
+        "created_at": DataTableRow.created_at,
+        "updated_at": DataTableRow.updated_at,
+        "created_by": DataTableRow.created_by,
+        "updated_by": DataTableRow.updated_by,
+    }
+    clauses: list = []
+
+    for col_name, condition in filter_dict.items():
+        is_meta = col_name not in schema_cols and col_name in meta_columns
+        if is_meta:
+            # Real typed column (timestamp/uuid): compare natively, no text coercion.
+            field = meta_columns[col_name]
+            is_json = False
+            is_number = False
+        else:
+            # User data lives in JSONB; ``->>`` yields text.
+            field = DataTableRow.data.op("->>")(col_name)
+            is_json = True
+            is_number = schema_cols.get(col_name, {}).get("type") == "number"
+
+        def _coerce(value: object) -> object:
+            return str(value) if is_json else value
+
+        if isinstance(condition, dict):
+            for op, raw_value in condition.items():
+                if op == "$eq":
+                    clauses.append(field == _coerce(raw_value))
+                elif op == "$ne":
+                    clauses.append(field != _coerce(raw_value))
+                elif op in ("$gt", "$gte", "$lt", "$lte"):
+                    if is_number:
+                        left, right = cast(field, Numeric), raw_value
+                    else:
+                        left, right = field, _coerce(raw_value)
+                    if op == "$gt":
+                        clauses.append(left > right)
+                    elif op == "$gte":
+                        clauses.append(left >= right)
+                    elif op == "$lt":
+                        clauses.append(left < right)
+                    else:
+                        clauses.append(left <= right)
+                elif op == "$contains":
+                    target = field if is_json else cast(field, String)
+                    clauses.append(target.ilike(f"%{raw_value}%"))
+                elif op == "$in" and isinstance(raw_value, list):
+                    clauses.append(field.in_([_coerce(v) for v in raw_value]))
+                # Unknown operators are ignored.
+        else:
+            clauses.append(field == _coerce(condition))
+
+    return clauses
+
+
 def _build_agent_execution_log_output(agent_result: dict) -> dict:
     """Rich agent fields for execution logs (e.g. sub-agent node_complete)."""
     out: dict = {"text": agent_result.get("text", "")}
@@ -1786,7 +1866,7 @@ class WorkflowExecutor:
     def _get_accessible_data_table(self, db, data_table_id: object, operation: str):
         from app.db.models import DataTable, DataTableShare, DataTableTeamShare, TeamMember
 
-        write_required = operation not in ("find", "getAll", "getById")
+        write_required = operation not in ("find", "getAll", "getById", "count")
         actor_user_id = self._require_actor_user_id("DataTable")
 
         table = (
@@ -9050,6 +9130,34 @@ class WorkflowExecutor:
                                 for r in rows
                             ],
                             "count": len(rows),
+                        }
+
+                    elif operation == "count":
+                        filter_template = node_data.get("dataTableFilter", "{}")
+                        filter_str = self.evaluate_message_template(
+                            filter_template, inputs, node_id
+                        )
+                        try:
+                            filter_dict = (
+                                json.loads(filter_str)
+                                if isinstance(filter_str, str)
+                                else filter_str
+                            )
+                        except Exception:
+                            filter_dict = {}
+
+                        query = db.query(DataTableRow).filter(
+                            DataTableRow.table_id == data_table_id
+                        )
+                        if isinstance(filter_dict, dict) and filter_dict:
+                            clauses = _build_data_table_filter_clauses(filter_dict, columns)
+                            if clauses:
+                                query = query.filter(*clauses)
+                        total = query.count()
+                        output = {
+                            "success": True,
+                            "operation": "count",
+                            "count": int(total),
                         }
 
                     elif operation == "getById":

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -686,8 +686,9 @@ class _ScalarsResult:
 
 
 class _FakeQuery:
-    def __init__(self, result: object) -> None:
+    def __init__(self, result: object, count_result: int = 0) -> None:
         self._result = result
+        self._count_result = count_result
 
     def filter(self, *_args: object) -> "_FakeQuery":
         return self
@@ -700,6 +701,9 @@ class _FakeQuery:
 
     def all(self) -> list[object]:
         return [] if self._result is None else [self._result]
+
+    def count(self) -> int:
+        return self._count_result
 
 
 class _SequenceQuery:
@@ -733,9 +737,15 @@ class _SequenceSession:
 
 
 class _FakeDataTableSession:
-    def __init__(self, table: object, existing_row: object | None = None) -> None:
+    def __init__(
+        self,
+        table: object,
+        existing_row: object | None = None,
+        count_result: int = 0,
+    ) -> None:
         self.table = table
         self.existing_row = existing_row
+        self.count_result = count_result
         self.added_rows: list[DataTableRow] = []
         self.commits = 0
 
@@ -749,7 +759,7 @@ class _FakeDataTableSession:
         if model is DataTable:
             return _FakeQuery(self.table)
         if model is DataTableRow:
-            return _FakeQuery(self.existing_row)
+            return _FakeQuery(self.existing_row, count_result=self.count_result)
         return _FakeQuery(None)
 
     def add(self, row: DataTableRow) -> None:
@@ -917,6 +927,213 @@ class WorkflowExecutorDataTableNodeTests(unittest.TestCase):
             fake_db.added_rows[0].data,
             {"username": "ada", "githubToken": "tok", "targetRepo": ""},
         )
+
+    def test_data_table_lookup_allows_count_with_read_only_team_share(self) -> None:
+        actor_id = uuid.uuid4()
+        table = SimpleNamespace(id=uuid.uuid4(), owner_id=uuid.uuid4(), columns=[])
+        fake_db = _SequenceSession(
+            [
+                _SequenceQuery(first_result=None),
+                _SequenceQuery(all_result=[]),
+                _SequenceQuery(all_result=[(table, "read")]),
+            ]
+        )
+        executor = WorkflowExecutor(nodes=[], edges=[], actor_user_id=actor_id)
+
+        result = executor._get_accessible_data_table(fake_db, table.id, "count")
+
+        self.assertIs(result, table)
+
+    def test_count_returns_total_without_filter(self) -> None:
+        table_id = uuid.uuid4()
+        table = SimpleNamespace(
+            id=table_id,
+            owner_id=uuid.uuid4(),
+            columns=[{"name": "status", "type": "string"}],
+        )
+        fake_db = _FakeDataTableSession(table, count_result=7)
+        nodes = [
+            {
+                "id": "dt",
+                "type": "dataTable",
+                "data": {
+                    "label": "dataTable",
+                    "dataTableId": str(table_id),
+                    "dataTableOperation": "count",
+                },
+            }
+        ]
+        executor = WorkflowExecutor(nodes=nodes, edges=[], actor_user_id=table.owner_id)
+
+        with patch("app.db.session.SessionLocal", return_value=fake_db):
+            result = executor.execute_node("dt", {})
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.output["operation"], "count")
+        self.assertEqual(result.output["count"], 7)
+        self.assertTrue(result.output["success"])
+
+    def test_count_returns_filtered_total(self) -> None:
+        table_id = uuid.uuid4()
+        table = SimpleNamespace(
+            id=table_id,
+            owner_id=uuid.uuid4(),
+            columns=[
+                {"name": "status", "type": "string"},
+                {"name": "age", "type": "number"},
+            ],
+        )
+        fake_db = _FakeDataTableSession(table, count_result=3)
+        nodes = [
+            {
+                "id": "dt",
+                "type": "dataTable",
+                "data": {
+                    "label": "dataTable",
+                    "dataTableId": str(table_id),
+                    "dataTableOperation": "count",
+                    "dataTableFilter": '{"status": "active", "age": {"$gt": 18}}',
+                },
+            }
+        ]
+        executor = WorkflowExecutor(nodes=nodes, edges=[], actor_user_id=table.owner_id)
+
+        with patch("app.db.session.SessionLocal", return_value=fake_db):
+            result = executor.execute_node("dt", {})
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.output["operation"], "count")
+        self.assertEqual(result.output["count"], 3)
+
+
+class DataTableFilterClauseTests(unittest.TestCase):
+    """Unit tests for the Mongo-style operator -> SQLAlchemy clause builder."""
+
+    @staticmethod
+    def _sql(clause: object) -> str:
+        from sqlalchemy.dialects import postgresql
+
+        return str(
+            clause.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+    def test_plain_value_is_equality(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"status": "active"}, [{"name": "status", "type": "string"}]
+        )
+        self.assertEqual(len(clauses), 1)
+        sql = self._sql(clauses[0])
+        self.assertIn("data ->> 'status'", sql)
+        self.assertIn("= 'active'", sql)
+
+    def test_ne_operator(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"status": {"$ne": "done"}}, [{"name": "status", "type": "string"}]
+        )
+        sql = self._sql(clauses[0])
+        self.assertIn("data ->> 'status'", sql)
+        self.assertIn("!= 'done'", sql)
+
+    def test_gt_on_number_column_casts_to_numeric(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"age": {"$gt": 18}}, [{"name": "age", "type": "number"}]
+        )
+        sql = self._sql(clauses[0]).upper()
+        self.assertIn("CAST", sql)
+        self.assertIn("NUMERIC", sql)
+        self.assertIn("> 18", sql)
+
+    def test_gt_on_string_column_does_not_cast(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"name": {"$gt": "m"}}, [{"name": "name", "type": "string"}]
+        )
+        sql = self._sql(clauses[0])
+        self.assertNotIn("CAST", sql.upper())
+        self.assertIn("data ->> 'name'", sql)
+        self.assertIn("> 'm'", sql)
+
+    def test_contains_uses_ilike(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"name": {"$contains": "john"}}, [{"name": "name", "type": "string"}]
+        )
+        sql = self._sql(clauses[0]).upper()
+        self.assertIn("ILIKE", sql)
+        self.assertIn("%JOHN%", sql)
+
+    def test_in_uses_in_clause(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"plan": {"$in": ["pro", "team"]}}, [{"name": "plan", "type": "string"}]
+        )
+        sql = self._sql(clauses[0]).upper()
+        self.assertIn("IN (", sql)
+        self.assertIn("'PRO'", sql)
+        self.assertIn("'TEAM'", sql)
+
+    def test_meta_created_at_maps_to_real_column(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"created_at": {"$gt": "2026-06-04"}}, [{"name": "status", "type": "string"}]
+        )
+        sql = self._sql(clauses[0])
+        self.assertIn("data_table_rows.created_at", sql)
+        self.assertNotIn("->>", sql)
+        self.assertIn("> '2026-06-04'", sql)
+
+    def test_meta_created_at_contains_casts_to_text(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses({"created_at": {"$contains": "06-04"}}, [])
+        sql = self._sql(clauses[0]).upper()
+        self.assertIn("CAST", sql)
+        self.assertIn("ILIKE", sql)
+        self.assertIn("%06-04%", sql)
+
+    def test_meta_id_plain_value_maps_to_real_column(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses({"id": "abc-123"}, [])
+        sql = self._sql(clauses[0])
+        self.assertIn("data_table_rows.id", sql)
+        self.assertNotIn("->>", sql)
+
+    def test_schema_column_shadowing_meta_name_uses_json(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        # A user-defined data column literally named created_at must still use JSONB.
+        clauses = _build_data_table_filter_clauses(
+            {"created_at": "x"}, [{"name": "created_at", "type": "string"}]
+        )
+        sql = self._sql(clauses[0])
+        self.assertIn("->>", sql)
+
+    def test_unknown_operator_is_ignored(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        clauses = _build_data_table_filter_clauses(
+            {"age": {"$regex": ".*"}}, [{"name": "age", "type": "number"}]
+        )
+        self.assertEqual(clauses, [])
+
+    def test_empty_filter_yields_no_clauses(self) -> None:
+        from app.services.workflow_executor import _build_data_table_filter_clauses
+
+        self.assertEqual(_build_data_table_filter_clauses({}, []), [])
 
 
 class CredentialContextTeamShareTests(unittest.IsolatedAsyncioTestCase):

--- a/docs/superpowers/specs/2026-06-16-datatable-count-operation-design.md
+++ b/docs/superpowers/specs/2026-06-16-datatable-count-operation-design.md
@@ -1,0 +1,106 @@
+# DataTable `count` Operation — Design
+
+**Date:** 2026-06-16
+**Status:** Approved
+
+## Problem
+
+To count rows matching a condition, users currently chain `getAll` → If/Else → Map in the
+workflow canvas — two nodes of glue just to produce a number. We want a single first-class
+`count` operation on the DataTable node that filters and counts DB-side.
+
+## Goal
+
+Add a `count` operation to the DataTable node that:
+- Counts rows matching an optional filter, returning just an integer.
+- Supports comparison operators (richer than `find`'s exact-match).
+- Counts in the database (no row materialization).
+- Requires only read access.
+
+## Filter syntax (Mongo-style, type-aware)
+
+`dataTableFilter` is a JSON object. A plain value means equality (backward-compatible with
+`find`); an object value applies operators:
+
+```json
+{
+  "status": "active",
+  "age": { "$gt": 18 },
+  "plan": { "$in": ["pro", "team"] },
+  "name": { "$contains": "john" }
+}
+```
+
+Supported operators:
+
+| Operator | Meaning | SQL |
+|----------|---------|-----|
+| `$eq` (or plain value) | equals | `data ->> col = '<v>'` |
+| `$ne` | not equals | `data ->> col != '<v>'` |
+| `$gt` `$gte` `$lt` `$lte` | comparison | numeric columns cast `CAST(data ->> col AS NUMERIC)`, otherwise text compare |
+| `$contains` | substring (case-insensitive) | `data ->> col ILIKE '%<v>%'` |
+| `$in` | membership | `data ->> col IN (...)` |
+
+- Numeric comparison casts to `NUMERIC` only when the column's declared `type == "number"`.
+- Empty/omitted filter counts all rows.
+- The filter template is run through `evaluate_message_template` first so `$`-expressions work,
+  exactly like `find`/`upsert`.
+- Unknown operators are ignored (no clause emitted).
+
+## Implementation
+
+### Backend — `backend/app/services/workflow_executor.py`
+
+1. **New module-level helper** `_build_data_table_filter_clauses(filter_dict, columns) -> list`
+   returns a list of SQLAlchemy `ColumnElement` clauses for the filter. Pure function (no DB),
+   so it is unit-testable by compiling to SQL. Single home for the operator logic.
+2. **New `elif operation == "count":` branch** in the `dataTable` node handler:
+   - Resolve + parse `dataTableFilter` (same as `find`).
+   - `query = db.query(DataTableRow).filter(DataTableRow.table_id == data_table_id)`
+   - Apply `query.filter(*_build_data_table_filter_clauses(filter_dict, columns))`.
+   - `total = query.count()` (emits `SELECT count(*)`, no ORM materialization).
+   - Output: `{"success": True, "operation": "count", "count": int(total)}`.
+3. **Read access:** add `"count"` to the read-only set in `_get_accessible_data_table`
+   (`write_required = operation not in ("find", "getAll", "getById", "count")`).
+
+### Frontend — `frontend/src/components/Panels/PropertiesPanel.vue`
+
+- Add `{ value: "count", label: "Count Rows" }` to `dataTableOperationOptions`.
+- Show the Filter field for `count` (add `'count'` to the filter `v-if` list) with a hint that
+  comparison operators are supported. No row-data / sort / limit fields for count.
+
+### DSL prompt — `backend/app/services/workflow_dsl_prompt.py`
+
+- Add `count` to the `dataTableOperation` union and params notes (operator syntax).
+- Add a row to the operations table.
+- Add an example `count` node.
+- Document the output ref `$nodeLabel.count`.
+
+## Testing (backend pytest)
+
+In `backend/tests/test_workflow_execution_api.py`:
+
+1. **Operator clause builder** (`_build_data_table_filter_clauses`), compiling each clause to
+   Postgres SQL and asserting structure:
+   - plain value → equality
+   - `$ne`, `$gt` on a number column (asserts `CAST(... AS NUMERIC)`), `$gt` on a string column
+     (text compare, no cast), `$contains` → `ILIKE`, `$in` → `IN (...)`.
+   - unknown operator → no clause.
+2. **`count` via `execute_node`** with a fake session: returns `operation == "count"` and the
+   count integer, both with no filter and with a filter (extend `_FakeQuery`/`_FakeDataTableSession`
+   with a `count()` returning a preset).
+3. **Read access:** `_get_accessible_data_table(..., "count")` with a read-only team share returns
+   the table (no write required).
+
+No frontend tests (repo convention — no Vitest harness).
+
+## Docs
+
+Update the DataTable node documentation via the `heym-documentation` skill: new `count` operation
+and the operator filter reference.
+
+## Out of scope
+
+- `find`'s exact-match filter is unchanged (avoids executor/evaluator drift); `count` carries the
+  richer operators standalone.
+- No new sort/limit semantics for count.

--- a/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
+++ b/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
@@ -418,12 +418,14 @@ function handleKeyDown(event: KeyboardEvent): void {
 
   if (event.key === "Escape") {
     event.preventDefault();
+    event.stopPropagation();
     emit("close");
     return;
   }
 
   if (event.key === "ArrowDown" || (event.key === "Tab" && !event.shiftKey)) {
     event.preventDefault();
+    event.stopPropagation();
     if (allItems.value.length > 0) {
       selectedIndex.value =
         selectedIndex.value >= allItems.value.length - 1
@@ -436,6 +438,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 
   if (event.key === "ArrowUp" || (event.key === "Tab" && event.shiftKey)) {
     event.preventDefault();
+    event.stopPropagation();
     if (allItems.value.length > 0) {
       selectedIndex.value =
         selectedIndex.value <= 0
@@ -448,6 +451,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 
   if (event.key === "Enter") {
     event.preventDefault();
+    event.stopPropagation();
     const item = allItems.value[selectedIndex.value];
     if (item) {
       handleSelectItem(item, selectedIndex.value, event);

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -1840,7 +1840,10 @@ function openPrimaryExpandDialogForSelectedNode(): void {
       } else if (rowDataOps.includes(op) && rawData && dataTableDataExpressionInputRef.value) {
         nextTick(() => openDataTableExpressionFieldAtIndex(0));
         return;
-      } else if (op === "find" && dataTableFilterExpressionInputRef.value) {
+      } else if (
+        ["find", "count"].includes(op) &&
+        dataTableFilterExpressionInputRef.value
+      ) {
         nextTick(() => openDataTableExpressionFieldAtIndex(0));
         return;
       } else if (op === "getAll" && dataTableSortExpressionInputRef.value) {
@@ -2881,6 +2884,10 @@ function openDataTableExpressionFieldAtIndex(index: number): void {
     }
     return;
   }
+  if (op === "count") {
+    dataTableFilterExpressionInputRef.value?.openExpandDialog();
+    return;
+  }
   if (op === "getAll") {
     dataTableSortExpressionInputRef.value?.openExpandDialog();
     return;
@@ -3521,6 +3528,7 @@ const dataTableOperationOptions = [
   { value: "", label: "Select operation..." },
   { value: "find", label: "Find Rows" },
   { value: "getAll", label: "Get All Rows" },
+  { value: "count", label: "Count Rows" },
   { value: "getById", label: "Get Row by ID" },
   { value: "insert", label: "Insert Row" },
   { value: "update", label: "Update Row" },
@@ -10548,7 +10556,7 @@ onUnmounted(() => {
               <p class="text-xs text-muted-foreground mt-1">
                 <a
                   href="/?tab=datatable"
-                  class="text-primary hover:underline"
+                  class="font-medium text-violet-600 hover:underline dark:text-violet-400"
                   @click.prevent="$router.push('/?tab=datatable')"
                 >Manage DataTables</a> in Dashboard
               </p>
@@ -10701,12 +10709,20 @@ onUnmounted(() => {
               </template>
             </div>
 
-            <!-- Filter — for find, upsert -->
+            <!-- Filter — for find, upsert, count -->
             <div
-              v-if="['find', 'upsert'].includes(selectedNode.data.dataTableOperation || '')"
+              v-if="['find', 'upsert', 'count'].includes(selectedNode.data.dataTableOperation || '')"
               class="space-y-2"
             >
-              <Label>Filter (JSON)</Label>
+              <div class="flex items-center justify-between">
+                <Label>Filter (JSON)</Label>
+                <button
+                  class="text-xs font-medium text-violet-600 hover:underline dark:text-violet-400"
+                  @click="() => { try { const parsed = JSON.parse(selectedNode?.data.dataTableFilter || '{}'); updateNodeData('dataTableFilter', JSON.stringify(parsed, null, 2)); } catch {} }"
+                >
+                  Format
+                </button>
+              </div>
               <ExpressionInput
                 ref="dataTableFilterExpressionInputRef"
                 :model-value="selectedNode.data.dataTableFilter || '{}'"
@@ -10719,7 +10735,7 @@ onUnmounted(() => {
                 :current-node-id="selectedNode.id"
                 :navigation-enabled="dataTableExpressionFieldCount > 1"
                 :navigation-index="
-                  selectedNode.data.dataTableOperation === 'find'
+                  ['find', 'count'].includes(selectedNode.data.dataTableOperation || '')
                     ? 0
                     : (selectedNode.data.dataTableInputMode || 'raw') === 'raw'
                       ? 1
@@ -10732,17 +10748,13 @@ onUnmounted(() => {
                 @register-field-index="onDataTableRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('dataTableFilter', $event)"
               />
-              <div class="flex items-center justify-between">
-                <p class="text-xs text-muted-foreground">
-                  Exact-match filter: {"column": "$input.value"}
-                </p>
-                <button
-                  class="text-xs text-primary hover:underline"
-                  @click="() => { try { const parsed = JSON.parse(selectedNode?.data.dataTableFilter || '{}'); updateNodeData('dataTableFilter', JSON.stringify(parsed, null, 2)); } catch {} }"
-                >
-                  Format
-                </button>
-              </div>
+              <p class="text-xs text-muted-foreground">
+                {{
+                  selectedNode.data.dataTableOperation === "count"
+                    ? 'Plain value = equals. Operators: $eq $ne $gt $gte $lt $lte $contains $in (e.g. age with $gt 18)'
+                    : 'Exact-match filter: {"column": "$input.value"}'
+                }}
+              </p>
             </div>
 
             <!-- Sort — for find, getAll -->

--- a/frontend/src/docs/content/nodes/datatable-node.md
+++ b/frontend/src/docs/content/nodes/datatable-node.md
@@ -15,10 +15,10 @@ The **DataTable** node reads, writes, and manages data in Heym DataTables. Use i
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `dataTableId` | UUID | DataTable from [DataTable tab](../tabs/datatable-tab.md) |
-| `dataTableOperation` | string | Operation: `find`, `getAll`, `getById`, `insert`, `update`, `remove`, `upsert` |
+| `dataTableOperation` | string | Operation: `find`, `getAll`, `count`, `getById`, `insert`, `update`, `remove`, `upsert` |
 | `dataTableRowId` | expression | Row UUID (for getById, update, remove) |
 | `dataTableData` | JSON string | Column values: `{"column_name": "value"}` |
-| `dataTableFilter` | JSON string | Exact-match filter: `{"column_name": "value"}` |
+| `dataTableFilter` | JSON string | Filter (find/upsert/count). `find`/`upsert` exact-match `{"column_name": "value"}`; `count` also supports operators `{"age": {"$gt": 18}}` |
 | `dataTableSort` | string | Sort column, prefix `-` for descending |
 | `dataTableLimit` | number | Max rows returned (default: 100) |
 
@@ -26,8 +26,9 @@ The **DataTable** node reads, writes, and manages data in Heym DataTables. Use i
 
 | Operation | Required Fields | Description |
 |-----------|----------------|-------------|
-| `find` | dataTableId | Find rows matching a filter with optional sort/limit |
+| `find` | dataTableId | Find rows matching an exact-match filter with optional sort/limit |
 | `getAll` | dataTableId | Get all rows with optional sort/limit |
+| `count` | dataTableId | Count rows matching an optional operator filter (counted in the database; returns just a number) |
 | `getById` | dataTableId, dataTableRowId | Get a single row by UUID |
 | `insert` | dataTableId, dataTableData | Insert a new row |
 | `update` | dataTableId, dataTableRowId, dataTableData | Update row (merges data) |
@@ -64,16 +65,50 @@ The **DataTable** node reads, writes, and manages data in Heym DataTables. Use i
 }
 ```
 
+## Example - Count Rows
+
+Count rows matching a condition in a single node, instead of `getAll` → If/Else → Map.
+
+```json
+{
+  "type": "dataTable",
+  "data": {
+    "label": "activeAdults",
+    "dataTableId": "table-uuid",
+    "dataTableOperation": "count",
+    "dataTableFilter": "{\"status\": \"active\", \"age\": {\"$gt\": 18}}"
+  }
+}
+```
+
+The result is available as `$activeAdults.count`. An empty or omitted filter counts every row.
+
+### Count filter operators
+
+In a `count` filter, a plain value means equals; an object value applies an operator:
+
+| Operator | Meaning |
+|----------|---------|
+| `$eq` (or a plain value) | Equals |
+| `$ne` | Not equals |
+| `$gt`, `$gte`, `$lt`, `$lte` | Greater/less than comparisons (numeric for columns typed as `number`, otherwise text) |
+| `$contains` | Case-insensitive substring match |
+| `$in` | Value is in the given array |
+
+Example combining several: `{"status": "active", "age": {"$gte": 18}, "plan": {"$in": ["pro", "team"]}, "name": {"$contains": "jo"}}`. Unknown operators are ignored.
+
+You can also filter on row metadata — `id`, `created_at`, `updated_at`, `created_by`, `updated_by` — which are stored as real columns rather than inside your data. For dates, pass a full value for range comparisons (e.g. `{"created_at": {"$gt": "2026-06-04"}}`) or use `$contains` for a partial text match (e.g. `{"created_at": {"$contains": "2026-06-04"}}`). If one of your own columns is named the same as a metadata field, the data column takes precedence.
+
 ## Output Access
 
 - `$nodeLabel.success` - Boolean success status
 - `$nodeLabel.rows` - Array of rows (find, getAll)
 - `$nodeLabel.row` - Single row object (getById, insert, update, upsert)
 - `$nodeLabel.row.data.column_name` - Access specific column value
-- `$nodeLabel.count` - Number of rows
+- `$nodeLabel.count` - Number of rows (rows returned for find/getAll; matching-row total for count)
 - `$nodeLabel.id` - Row UUID (insert, update, remove)
 - `$nodeLabel.found` - Boolean (getById)
-- `$nodeLabel.operation` - "insert" or "update" (upsert)
+- `$nodeLabel.operation` - Operation name (e.g. `count`; `insert`/`update` for upsert)
 
 ## No Credential Required
 

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -233,6 +233,7 @@ export type GristOperation =
 export type DataTableOperation =
   | "find"
   | "getAll"
+  | "count"
   | "getById"
   | "insert"
   | "update"


### PR DESCRIPTION
* Add 'count' operation to DataTable and enhance filtering logic

- Introduced 'count' operation for DataTable, allowing users to count rows based on filters.
- Updated filtering logic to support Mongo-style operators for counting, including `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$contains`, and `$in`.
- Enhanced frontend components to accommodate the new 'count' operation and updated documentation accordingly.
- Added unit tests to validate the new functionality and ensure correct behavior of filtering clauses.