### PR TITLE
feat: DataTable duplicate + widget URL links & dashboard nav animation

### DIFF
--- a/backend/app/api/data_tables.py
+++ b/backend/app/api/data_tables.py
@@ -561,6 +561,68 @@ async def delete_data_table(
     await db.delete(table)
 
 
+@router.post(
+    "/{table_id}/clone", response_model=DataTableResponse, status_code=status.HTTP_201_CREATED
+)
+async def clone_data_table(
+    table_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DataTableResponse:
+    """Duplicate a data table (columns + all rows) into a new table owned by the user."""
+    source = await _get_data_table_with_access(table_id, current_user.id, db)
+
+    new_name = f"{source.name} (Copy)"
+    count = 1
+    while True:
+        existing = await db.execute(
+            select(DataTable).where(
+                DataTable.owner_id == current_user.id,
+                DataTable.name == new_name,
+            )
+        )
+        if existing.scalar_one_or_none() is None:
+            break
+        count += 1
+        new_name = f"{source.name} (Copy {count})"
+
+    new_table = DataTable(
+        name=new_name,
+        description=source.description,
+        columns=source.columns,
+        owner_id=current_user.id,
+    )
+    db.add(new_table)
+    await db.flush()
+
+    source_rows = await db.execute(select(DataTableRow).where(DataTableRow.table_id == source.id))
+    row_count = 0
+    for src_row in source_rows.scalars():
+        db.add(
+            DataTableRow(
+                table_id=new_table.id,
+                data=src_row.data,
+                created_by=current_user.id,
+                updated_by=current_user.id,
+            )
+        )
+        row_count += 1
+
+    await db.flush()
+    await db.refresh(new_table)
+
+    return DataTableResponse(
+        id=new_table.id,
+        name=new_table.name,
+        description=new_table.description,
+        columns=new_table.columns,
+        owner_id=new_table.owner_id,
+        row_count=row_count,
+        created_at=new_table.created_at,
+        updated_at=new_table.updated_at,
+    )
+
+
 # ── Row CRUD ─────────────────────────────────────────────────────────────────
 
 

--- a/backend/app/services/chart_payload.py
+++ b/backend/app/services/chart_payload.py
@@ -56,6 +56,10 @@ def build_chart_payload(config: dict, data: Any) -> dict:
     if title:
         payload["title"] = title
 
+    url = config.get("url")
+    if isinstance(url, str) and url.strip():
+        payload["url"] = url.strip()
+
     if chart_type == "text":
         # A markdown message. Prefer a value pulled from upstream data (so the text can
         # be dynamic, e.g. "Last execution at 19:47"), then a static `text` config, then

--- a/backend/tests/test_chart_payload.py
+++ b/backend/tests/test_chart_payload.py
@@ -4,6 +4,34 @@ from app.services.chart_payload import build_chart_payload
 
 
 class TestBuildChartPayload(unittest.TestCase):
+    def test_url_passthrough_for_bar(self):
+        config = {
+            "chartType": "bar",
+            "labelField": "month",
+            "valueField": "revenue",
+            "url": "https://example.com/report",
+        }
+        data = [{"month": "Jan", "revenue": 120}]
+        payload = build_chart_payload(config, data)
+        self.assertEqual(payload["url"], "https://example.com/report")
+
+    def test_url_passthrough_for_numeric_and_is_trimmed(self):
+        config = {"chartType": "numeric", "valueField": "count", "url": "  https://example.com  "}
+        data = [{"count": 5}]
+        payload = build_chart_payload(config, data)
+        self.assertEqual(payload["url"], "https://example.com")
+
+    def test_no_url_key_when_missing_or_blank(self):
+        for url_val in (None, "", "   "):
+            config = {"chartType": "bar", "labelField": "m", "valueField": "v", "url": url_val}
+            payload = build_chart_payload(config, [{"m": "Jan", "v": 1}])
+            self.assertNotIn("url", payload)
+
+    def test_no_url_key_when_non_string(self):
+        config = {"chartType": "bar", "labelField": "m", "valueField": "v", "url": 123}
+        payload = build_chart_payload(config, [{"m": "Jan", "v": 1}])
+        self.assertNotIn("url", payload)
+
     def test_bar_vertical_single_series(self):
         config = {
             "chartType": "bar",

--- a/backend/tests/test_data_table_clone_api.py
+++ b/backend/tests/test_data_table_clone_api.py
@@ -1,0 +1,158 @@
+import datetime
+import unittest
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
+
+from app.api import data_tables as dt_api
+from app.db.models import DataTable, DataTableRow
+
+
+class _User:
+    def __init__(self):
+        self.id = uuid.uuid4()
+
+
+def _source_table(owner_id: uuid.UUID) -> DataTable:
+    table = DataTable(
+        name="Customers",
+        description="People who buy",
+        columns=[
+            {"id": "c1", "name": "email", "type": "string", "order": 0},
+            {"id": "c2", "name": "age", "type": "number", "order": 1},
+        ],
+        owner_id=owner_id,
+    )
+    table.id = uuid.uuid4()
+    return table
+
+
+def _wire_db(db):
+    """Assign PKs on flush and timestamps on refresh, emulating PostgreSQL."""
+
+    async def fake_flush():
+        for call in db.add.call_args_list:
+            obj = call.args[0]
+            if getattr(obj, "id", None) is None:
+                obj.id = uuid.uuid4()
+
+    async def fake_refresh(obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = uuid.uuid4()
+        now = datetime.datetime.now()
+        obj.created_at = now
+        obj.updated_at = now
+
+    db.add = MagicMock()
+    db.flush = AsyncMock(side_effect=fake_flush)
+    db.refresh = AsyncMock(side_effect=fake_refresh)
+
+
+def _scalar(value):
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = value
+    return res
+
+
+def _scalars(values):
+    res = MagicMock()
+    res.scalars.return_value = iter(values)
+    return res
+
+
+class TestCloneDataTable(unittest.IsolatedAsyncioTestCase):
+    async def test_clone_copies_columns_and_all_rows(self):
+        user = _User()
+        source = _source_table(user.id)
+        rows = [
+            DataTableRow(table_id=source.id, data={"email": "a@x.com", "age": 30}),
+            DataTableRow(table_id=source.id, data={"email": "b@x.com", "age": 25}),
+        ]
+
+        db = MagicMock()
+        _wire_db(db)
+        db.execute = AsyncMock(
+            side_effect=[
+                _scalar(source),  # _get_data_table_with_access owner lookup
+                _scalar(None),  # name-collision check -> no existing
+                _scalars(rows),  # source rows
+            ]
+        )
+
+        resp = await dt_api.clone_data_table(table_id=source.id, current_user=user, db=db)
+
+        self.assertEqual(resp.name, "Customers (Copy)")
+        self.assertEqual(resp.description, "People who buy")
+        self.assertEqual(resp.columns, source.columns)
+        self.assertEqual(resp.owner_id, user.id)
+        self.assertEqual(resp.row_count, 2)
+        self.assertNotEqual(resp.id, source.id)
+
+        # Two rows added with copied data, owned/authored by the cloning user.
+        added_rows = [
+            c.args[0] for c in db.add.call_args_list if isinstance(c.args[0], DataTableRow)
+        ]
+        self.assertEqual(len(added_rows), 2)
+        self.assertEqual({r.data["email"] for r in added_rows}, {"a@x.com", "b@x.com"})
+        for r in added_rows:
+            self.assertEqual(r.created_by, user.id)
+            self.assertEqual(r.updated_by, user.id)
+
+    async def test_clone_name_increments_on_collision(self):
+        user = _User()
+        source = _source_table(user.id)
+
+        db = MagicMock()
+        _wire_db(db)
+        db.execute = AsyncMock(
+            side_effect=[
+                _scalar(source),  # access lookup
+                _scalar(MagicMock()),  # "Customers (Copy)" exists
+                _scalar(None),  # "Customers (Copy 2)" free
+                _scalars([]),  # no rows
+            ]
+        )
+
+        resp = await dt_api.clone_data_table(table_id=source.id, current_user=user, db=db)
+
+        self.assertEqual(resp.name, "Customers (Copy 2)")
+        self.assertEqual(resp.row_count, 0)
+
+    async def test_clone_does_not_copy_shares(self):
+        user = _User()
+        source = _source_table(user.id)
+
+        db = MagicMock()
+        _wire_db(db)
+        db.execute = AsyncMock(side_effect=[_scalar(source), _scalar(None), _scalars([])])
+
+        await dt_api.clone_data_table(table_id=source.id, current_user=user, db=db)
+
+        # Only the new DataTable is added (no rows, no DataTableShare objects).
+        added_types = {type(c.args[0]).__name__ for c in db.add.call_args_list}
+        self.assertEqual(added_types, {"DataTable"})
+
+    async def test_clone_inaccessible_table_raises_404(self):
+        user = _User()
+        table_id = uuid.uuid4()
+
+        db = MagicMock()
+        _wire_db(db)
+        empty_first = MagicMock()
+        empty_first.first.return_value = None
+        db.execute = AsyncMock(
+            side_effect=[
+                _scalar(None),  # owner lookup -> none
+                MagicMock(one_or_none=MagicMock(return_value=None)),  # user share
+                empty_first,  # team share
+            ]
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            await dt_api.clone_data_table(table_id=table_id, current_user=user, db=db)
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/superpowers/plans/2026-06-16-widget-url-and-dashboard-tab-anim.md
+++ b/docs/superpowers/plans/2026-06-16-widget-url-and-dashboard-tab-anim.md
@@ -1,0 +1,386 @@
+# Widget URL link + Dashboard tab hover animation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional URL to dashboard widgets (set on the canvas `chartOutput` node) that surfaces as an external-link icon in the widget title, and give the Dashboard nav tab the hover animation every other tab already has.
+
+**Architecture:** The `chartOutput` node config flows through `build_chart_payload()` into the cached payload returned to `DashboardWidgetCard.vue` — the same path `title`/`unit` already use. We add a `url` config field, copy it into the payload (backend), expose `url?` on the `ChartPayload` type, and render a sanitized external-link button in the widget card. The tab animation is a one-line CSS rule.
+
+**Tech Stack:** Vue 3 (`<script setup>`, Composition API), TypeScript (strict), Python 3.11 + FastAPI, pytest.
+
+---
+
+## File Structure
+
+- `backend/app/services/chart_payload.py` — add `url` passthrough into payload (all chart types).
+- `backend/tests/test_chart_payload.py` — tests for `url` present / absent / non-string.
+- `frontend/src/types/dashboard.ts` — add `url?: string` to `ChartPayload`.
+- `frontend/src/components/Panels/PropertiesPanel.vue` — add **Website URL** `ExpressionInput` field to the `chartOutput` config (canvas), register it in the expression-field list/type.
+- `frontend/src/components/Dashboards/DashboardWidgetCard.vue` — sanitized `externalUrl` computed + `ExternalLink` icon button in the header.
+- `frontend/src/components/Layout/DashboardNav.vue` — Dashboard tab hover animation CSS rule.
+
+---
+
+## Task 1: Backend — copy `url` into the chart payload
+
+**Files:**
+- Modify: `backend/app/services/chart_payload.py:49-57`
+- Test: `backend/tests/test_chart_payload.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these methods to the `TestBuildChartPayload` class in `backend/tests/test_chart_payload.py`:
+
+```python
+    def test_url_passthrough_for_bar(self):
+        config = {
+            "chartType": "bar",
+            "labelField": "month",
+            "valueField": "revenue",
+            "url": "https://example.com/report",
+        }
+        data = [{"month": "Jan", "revenue": 120}]
+        payload = build_chart_payload(config, data)
+        self.assertEqual(payload["url"], "https://example.com/report")
+
+    def test_url_passthrough_for_numeric_and_is_trimmed(self):
+        config = {"chartType": "numeric", "valueField": "count", "url": "  https://example.com  "}
+        data = [{"count": 5}]
+        payload = build_chart_payload(config, data)
+        self.assertEqual(payload["url"], "https://example.com")
+
+    def test_no_url_key_when_missing_or_blank(self):
+        for url_val in (None, "", "   "):
+            config = {"chartType": "bar", "labelField": "m", "valueField": "v", "url": url_val}
+            payload = build_chart_payload(config, [{"m": "Jan", "v": 1}])
+            self.assertNotIn("url", payload)
+
+    def test_no_url_key_when_non_string(self):
+        config = {"chartType": "bar", "labelField": "m", "valueField": "v", "url": 123}
+        payload = build_chart_payload(config, [{"m": "Jan", "v": 1}])
+        self.assertNotIn("url", payload)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && SECRET_KEY=test-secret-key-for-tests-only-32-bytes uv run pytest tests/test_chart_payload.py -v -k url`
+Expected: FAIL — `KeyError: 'url'` / assertion errors (no `url` handling yet).
+
+- [ ] **Step 3: Add the `url` passthrough**
+
+In `backend/app/services/chart_payload.py`, the start of `build_chart_payload` currently reads:
+
+```python
+    chart_type = config.get("chartType", "bar")
+    title = config.get("title")
+    rows = _resolve_rows(data, config.get("dataPath"))
+
+    payload: dict = {"type": chart_type}
+    if title:
+        payload["title"] = title
+```
+
+Add the `url` block immediately after the `title` block (before any chart-type branch, so it
+applies to every return path):
+
+```python
+    chart_type = config.get("chartType", "bar")
+    title = config.get("title")
+    rows = _resolve_rows(data, config.get("dataPath"))
+
+    payload: dict = {"type": chart_type}
+    if title:
+        payload["title"] = title
+
+    url = config.get("url")
+    if isinstance(url, str) and url.strip():
+        payload["url"] = url.strip()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && SECRET_KEY=test-secret-key-for-tests-only-32-bytes uv run pytest tests/test_chart_payload.py -v`
+Expected: PASS (all existing + 4 new).
+
+- [ ] **Step 5: Lint/format backend**
+
+Run: `cd backend && uv run ruff format app/services/chart_payload.py tests/test_chart_payload.py && uv run ruff check app/services/chart_payload.py tests/test_chart_payload.py`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/chart_payload.py backend/tests/test_chart_payload.py
+git commit -m "feat: pass optional widget url through chart payload"
+```
+
+---
+
+## Task 2: Frontend type — add `url` to ChartPayload
+
+**Files:**
+- Modify: `frontend/src/types/dashboard.ts:7-33`
+
+- [ ] **Step 1: Add the field**
+
+In `frontend/src/types/dashboard.ts`, add `url?: string;` to the `ChartPayload` interface, right after the `title?: string;` line (currently line 32):
+
+```typescript
+  max?: number;
+  title?: string;
+  // Optional external link set on the chartOutput node; rendered as an icon in the widget title.
+  url?: string;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types/dashboard.ts
+git commit -m "feat: add url field to ChartPayload type"
+```
+
+---
+
+## Task 3: Canvas — add Website URL field to chartOutput config
+
+**Files:**
+- Modify: `frontend/src/components/Panels/PropertiesPanel.vue:493-503` (type union)
+- Modify: `frontend/src/components/Panels/PropertiesPanel.vue:3086` (expression fields list)
+- Modify: `frontend/src/components/Panels/PropertiesPanel.vue:8678-8699` (template, after Title)
+
+- [ ] **Step 1: Add `"url"` to the expression-field key type**
+
+Change the `ChartOutputExpressionFieldKey` union (line 493) to include `"url"`:
+
+```typescript
+type ChartOutputExpressionFieldKey =
+  | "text"
+  | "valueField"
+  | "dataPath"
+  | "labelField"
+  | "xField"
+  | "yField"
+  | "min"
+  | "max"
+  | "unit"
+  | "title"
+  | "url";
+```
+
+- [ ] **Step 2: Register the field in `chartOutputExpressionFields`**
+
+In the `chartOutputExpressionFields` computed, the tail currently reads (line ~3086):
+
+```typescript
+  fields.push({ key: "title", label: "Title" });
+  return fields;
+```
+
+Change it to also push the URL field (shown for all chart types, after Title):
+
+```typescript
+  fields.push({ key: "title", label: "Title" });
+  fields.push({ key: "url", label: "Website URL" });
+  return fields;
+```
+
+- [ ] **Step 3: Add the Website URL input to the template**
+
+In the `chartOutput` template, immediately after the **Title** `<div class="space-y-2">…</div>`
+block (which ends at line ~8699, just before the closing `</template>` at line 8700), add:
+
+```html
+            <div class="space-y-2">
+              <Label>Website URL</Label>
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('url', el)"
+                :model-value="selectedNode.data.url || ''"
+                placeholder="https://… (optional)"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Website URL"
+                field-key="url"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('url')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
+                @update:model-value="updateNodeData('url', $event)"
+              />
+            </div>
+```
+
+- [ ] **Step 4: Lint + typecheck**
+
+Run: `cd frontend && bun run lint && bun run typecheck`
+Expected: PASS. (`updateNodeData`, `selectedNode.data` are dynamic — no new type needed.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Panels/PropertiesPanel.vue
+git commit -m "feat: add Website URL field to chartOutput node config"
+```
+
+---
+
+## Task 4: Widget card — render sanitized external-link icon
+
+**Files:**
+- Modify: `frontend/src/components/Dashboards/DashboardWidgetCard.vue:1-9` (imports)
+- Modify: `frontend/src/components/Dashboards/DashboardWidgetCard.vue:24` (computed near `payload`)
+- Modify: `frontend/src/components/Dashboards/DashboardWidgetCard.vue:157-165` (header template)
+
+- [ ] **Step 1: Import `ExternalLink` and `computed`**
+
+Line 1 currently:
+
+```typescript
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+```
+Change to add `computed`:
+
+```typescript
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+```
+
+Line 5 currently:
+
+```typescript
+import { Loader2, MoreVertical, Pencil, RefreshCw, Settings, Sparkles, Trash2 } from "lucide-vue-next";
+```
+Change to add `ExternalLink` (keep alphabetical-ish order consistent with the file):
+
+```typescript
+import { ExternalLink, Loader2, MoreVertical, Pencil, RefreshCw, Settings, Sparkles, Trash2 } from "lucide-vue-next";
+```
+
+- [ ] **Step 2: Add the `externalUrl` computed**
+
+After the `payload` ref declaration (line 24: `const payload = ref<ChartPayload | null>(null);`), add:
+
+```typescript
+// Only surface http(s) links. The url can come from a dynamic expression over upstream
+// data, so reject javascript:/data:/relative values to avoid an injected-link XSS.
+const externalUrl = computed<string | null>(() => {
+  const raw = payload.value?.url;
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : null;
+  } catch {
+    return null;
+  }
+});
+```
+
+- [ ] **Step 3: Add the icon button to the header**
+
+In the template, the title `<button v-else …>{{ widget.title }}</button>` block ends at line 164
+(`</button>`), followed by a blank line and the `<!-- sm+: inline icon row -->` comment.
+Insert the link button between the title button and that comment:
+
+```html
+      </button>
+
+      <a
+        v-if="externalUrl"
+        :href="externalUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Open link"
+      >
+        <ExternalLink class="h-3.5 w-3.5" />
+      </a>
+
+      <!-- sm+: inline icon row -->
+```
+
+- [ ] **Step 4: Lint + typecheck**
+
+Run: `cd frontend && bun run lint && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/Dashboards/DashboardWidgetCard.vue
+git commit -m "feat: show external-link icon on widgets with a url"
+```
+
+---
+
+## Task 5: Dashboard nav tab hover animation
+
+**Files:**
+- Modify: `frontend/src/components/Layout/DashboardNav.vue:303-318` (per-tab hover block)
+
+- [ ] **Step 1: Add the CSS rule**
+
+In the `<style scoped>` "per-tab hover animations" block, after the `templates` line
+(line 306) add a rule for the dashboard tab (reuse `icon-pop`, consistent with `templates`):
+
+```css
+.tab-item[data-tab-id="templates"]:hover       .tab-icon { animation: icon-pop    0.35s ease-out; }
+.tab-item[data-tab-id="dashboard"]:hover       .tab-icon { animation: icon-pop    0.35s ease-out; }
+```
+
+- [ ] **Step 2: Lint + typecheck**
+
+Run: `cd frontend && bun run lint && bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Manual visual check**
+
+Hover the **Dashboard** tab in the nav — the icon should "pop" (scale up and back) like the
+Templates tab. Confirm it respects reduced-motion (the existing `prefers-reduced-motion` rule
+already disables `.tab-icon` animations).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/Layout/DashboardNav.vue
+git commit -m "feat: add hover animation to dashboard nav tab"
+```
+
+---
+
+## Task 6: Full verification
+
+- [ ] **Step 1: Backend tests + frontend gates**
+
+Run from repo root:
+```bash
+cd frontend && bun run lint && bun run typecheck
+cd ../backend && SECRET_KEY=test-secret-key-for-tests-only-32-bytes uv run pytest tests/test_chart_payload.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Manual end-to-end check**
+
+1. Open a workflow with a `chartOutput` node; set **Website URL** to `https://example.com`.
+2. Add/refresh the dashboard widget for it → an external-link icon appears next to the title;
+   clicking opens `https://example.com` in a new tab.
+3. Set the URL to `javascript:alert(1)` → no icon renders.
+4. Leave URL blank → no icon renders.
+5. Hover the Dashboard nav tab → icon pops.
+
+---
+
+## Notes
+- Per repo convention there is no frontend test harness; frontend changes are verified via
+  `bun run lint` + `bun run typecheck` + manual checks.
+- This is a medium UI feature — if doc updates are wanted, the `heym-documentation` skill
+  covers `frontend/src/docs/content/nodes/chart-output-node.md` (the Website URL field) after
+  implementation. Not required for this plan to be functionally complete.

--- a/docs/superpowers/specs/2026-06-16-datatable-duplicate-design.md
+++ b/docs/superpowers/specs/2026-06-16-datatable-duplicate-design.md
@@ -1,0 +1,51 @@
+# DataTable Duplicate — Design
+
+Date: 2026-06-16
+
+## Goal
+
+Let users one-click duplicate a DataTable from the DataTable list. A copy icon
+appears in the card hover toolbar (alongside rename and delete). Clicking it
+creates a full copy — schema plus all rows — owned by the current user.
+
+## Behavior
+
+- Hover toolbar on each DataTable card gains a `Copy` icon between the rename
+  pencil and the delete trash.
+- Clicking it calls a new clone endpoint and reloads the list.
+- The copy is named `"<name> (Copy)"`, then `"<name> (Copy 2)"`, … if names
+  collide within the owner's tables (matches `clone_vector_store`).
+- Copy contains: all columns (verbatim) and all rows (verbatim). Shares are NOT
+  copied — the copy is private to the current user.
+
+## Backend
+
+`backend/app/api/data_tables.py`
+
+- New `POST /data-tables/{table_id}/clone` → `DataTableResponse` (201).
+- Access checked with existing `_get_data_table_with_access`, so a user may also
+  duplicate a table shared with them; the copy becomes theirs.
+- Unique-name resolution loop against `DataTable.owner_id == current_user.id`,
+  honoring the `uq_data_table_name` constraint.
+- New `DataTable`: `columns` copied verbatim (column ids/names preserved — rows
+  are keyed by column **name**, so this is safe). All `DataTableRow`s copied with
+  fresh ids, `data` verbatim, `created_by`/`updated_by` = current user.
+- Response includes the real `row_count`.
+
+## Frontend
+
+- `frontend/src/services/api.ts`: add `dataTablesApi.clone(id)` →
+  `POST /data-tables/{id}/clone`.
+- `frontend/src/components/DataTable/DataTablePanel.vue`: import lucide `Copy`,
+  add a button to the hover toolbar with `@click.stop="handleDuplicate(table.id)"`,
+  and a `handleDuplicate` function that calls the API, reloads tables, and sets
+  `error` on failure.
+
+## Tests
+
+`backend/tests/` — new test covering: clone copies columns + rows; sequential
+names `(Copy)` / `(Copy 2)`; shares not copied; 404 on inaccessible table.
+
+## Out of scope (YAGNI)
+
+- Bulk duplicate, duplicate-into-team, rename-on-duplicate dialog.

--- a/docs/superpowers/specs/2026-06-16-widget-url-and-dashboard-tab-anim-design.md
+++ b/docs/superpowers/specs/2026-06-16-widget-url-and-dashboard-tab-anim-design.md
@@ -1,0 +1,90 @@
+# Widget URL link + Dashboard tab hover animation — Design
+
+Date: 2026-06-16
+
+Two small, independent changes to the dashboard experience.
+
+## Feature 1 — Widget external URL
+
+### Goal
+Let a dashboard widget carry an optional URL set on the workflow canvas. When set, the
+widget card shows an external-link icon next to its title; clicking the icon opens the URL
+in a new browser tab. The property is available for **all** widget (chart) types.
+
+### Data flow (existing, reused)
+Canvas `chartOutput` node config → `build_chart_payload(node_data, source_data)`
+→ stored as `cached_payload` → `WidgetDataResponse.payload` → `DashboardWidgetCard.vue`.
+The `title` and `unit` fields already work exactly this way; `url` follows the same path.
+
+### Changes
+
+1. **Canvas config field** — `frontend/src/components/Panels/PropertiesPanel.vue`,
+   `chartOutput` template. Add a **Website URL** field rendered as `ExpressionInput`
+   (same component/pattern as the existing **Title** field), placed right after Title so it
+   shows for every chart type. Bound to `selectedNode.data.url` via
+   `updateNodeData('url', $event)`. Register it in `chartOutputExpressionFields` /
+   `ChartOutputExpressionFieldKey` so navigation/expand dialogs include it. Placeholder:
+   `https://… (optional)`.
+
+2. **Payload build** — `backend/app/services/chart_payload.py`, `build_chart_payload`.
+   After computing the per-type payload, if `config.get("url")` is a non-empty string,
+   set `payload["url"] = url.strip()`. Applies to every chart type (added once near the
+   top, after `title`, so all return branches include it). Keep the function side-effect free.
+
+3. **Types** — `frontend/src/types/dashboard.ts`: add `url?: string` to `ChartPayload`.
+
+4. **Widget card** — `frontend/src/components/Dashboards/DashboardWidgetCard.vue`.
+   - Add a computed `externalUrl` that returns `payload.value?.url` only when it is a
+     safe absolute `http(s)` URL (parsed via `new URL()`, protocol in `{http:, https:}`);
+     otherwise `null`. This rejects `javascript:`/`data:`/relative values — important
+     because the URL can come from a dynamic expression over upstream data (XSS guard).
+   - In the header, when `externalUrl` is set, render a small `ExternalLink` (lucide)
+     anchor/button immediately after the title button, before the action icon row.
+     `target="_blank"`, `rel="noopener noreferrer"`, `title="Open link"`,
+     styled like the existing header action buttons
+     (`rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground`).
+   - Title click behavior is unchanged (still opens inline rename).
+
+### Security
+Only `http://` and `https://` absolute URLs render the icon. Any other scheme or an
+unparseable value yields no icon and no link. This is enforced in the frontend computed
+(the click target) and is the authoritative guard.
+
+### Tests
+`backend/tests/` — extend the chart_payload test module:
+- `url` is copied into the payload when present (for at least one representative chart
+  type, e.g. `bar`, and one scalar type, e.g. `numeric`).
+- empty/missing `url` produces no `url` key.
+Frontend has no test harness (per repo convention) — verify via lint + typecheck + manual.
+
+## Feature 2 — Dashboard tab hover animation
+
+### Goal
+Every nav tab in `DashboardNav.vue` has a per-tab icon hover animation except the
+**Dashboard** tab (no `data-tab-id="dashboard"` rule exists). Add one consistent with
+the others.
+
+### Change
+`frontend/src/components/Layout/DashboardNav.vue`, `<style scoped>`, per-tab hover block.
+Add:
+```css
+.tab-item[data-tab-id="dashboard"]:hover .tab-icon { animation: icon-pop 0.35s ease-out; }
+```
+Reuses the existing `icon-pop` keyframe (same as the `templates` tab, also a layout-type
+icon). Respects the existing `prefers-reduced-motion` reset already in the file.
+
+### Tests
+None (CSS-only, no test harness for frontend). Verify visually + lint/typecheck.
+
+## Out of scope
+- Per-widget URL stored separately from the chart payload (widget-level column). Reusing
+  the payload path matches the "given on the canvas" requirement and the existing `title`
+  pattern.
+- Editing the URL from the dashboard widget settings dialog.
+
+## Verification
+- `bun run lint && bun run typecheck` (frontend)
+- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./run_tests.sh` (backend) or targeted
+  chart_payload test run.
+- Manual: set a URL on a chartOutput node, open dashboard, confirm icon appears and opens
+  the link in a new tab; confirm a `javascript:` value shows no icon; hover the Dashboard tab.

--- a/frontend/src/components/Dashboards/DashboardWidgetCard.vue
+++ b/frontend/src/components/Dashboards/DashboardWidgetCard.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import type { Component } from "vue";
 import { onClickOutside } from "@vueuse/core";
-import { Loader2, MoreVertical, Pencil, RefreshCw, Settings, Sparkles, Trash2 } from "lucide-vue-next";
+import { ExternalLink, Loader2, MoreVertical, Pencil, RefreshCw, Settings, Sparkles, Trash2 } from "lucide-vue-next";
 
 import ChartRenderer from "@/components/Dashboards/ChartRenderer.vue";
 import { dashboardApi } from "@/services/api";
@@ -22,6 +22,18 @@ const emit = defineEmits<{
 }>();
 
 const payload = ref<ChartPayload | null>(null);
+// Only surface http(s) links. The url can come from a dynamic expression over upstream
+// data, so reject javascript:/data:/relative values to avoid an injected-link XSS.
+const externalUrl = computed<string | null>(() => {
+  const raw = payload.value?.url;
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : null;
+  } catch {
+    return null;
+  }
+});
 const loading = ref(true);
 const error = ref<string | null>(null);
 const editingTitle = ref(false);
@@ -162,6 +174,17 @@ onBeforeUnmount(() => {
       >
         {{ widget.title }}
       </button>
+
+      <a
+        v-if="externalUrl"
+        :href="externalUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Open link"
+      >
+        <ExternalLink class="h-3.5 w-3.5" />
+      </a>
 
       <!-- sm+: inline icon row -->
       <div class="hidden shrink-0 items-center gap-1 sm:flex">

--- a/frontend/src/components/DataTable/DataTablePanel.vue
+++ b/frontend/src/components/DataTable/DataTablePanel.vue
@@ -83,7 +83,7 @@ const rowPageSizeOptions: Array<{ value: RowPageSize; label: string }> = [
   { value: "all", label: "All" },
 ];
 const DATA_GRID_COLUMN_WIDTH_REM = 12;
-const DATA_GRID_META_WIDTH_REM = 33;
+const DATA_GRID_META_WIDTH_REM = 36;
 
 // ── Create dialog ──
 const showCreateDialog = ref(false);
@@ -229,6 +229,15 @@ async function handleDelete(id: string) {
     await loadTables();
   } catch {
     error.value = "Failed to delete data table";
+  }
+}
+
+async function handleDuplicate(id: string) {
+  try {
+    await dataTablesApi.clone(id);
+    await loadTables();
+  } catch {
+    error.value = "Failed to duplicate data table";
   }
 }
 
@@ -760,12 +769,21 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
             <div class="ml-2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100">
               <button
                 class="rounded p-1 hover:bg-accent"
+                title="Rename"
                 @click.stop="startRename(table)"
               >
                 <Pencil class="h-3.5 w-3.5 text-muted-foreground" />
               </button>
               <button
+                class="rounded p-1 hover:bg-accent"
+                title="Duplicate"
+                @click.stop="handleDuplicate(table.id)"
+              >
+                <Copy class="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+              <button
                 class="rounded p-1 hover:bg-destructive/10"
+                title="Delete"
                 @click.stop="handleDelete(table.id)"
               >
                 <Trash2 class="h-4 w-4 text-destructive" />
@@ -907,6 +925,7 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
           :style="{ minWidth: dataGridMinWidth }"
         >
           <colgroup>
+            <col class="w-12">
             <col
               v-for="col in sortedColumns"
               :key="`width-${col.id}`"
@@ -919,6 +938,9 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
           </colgroup>
           <thead>
             <tr class="border-b bg-muted/50">
+              <th class="w-12 min-w-12 px-3 py-2 text-center text-xs font-medium text-muted-foreground">
+                #
+              </th>
               <th
                 v-for="col in sortedColumns"
                 :key="col.id"
@@ -967,17 +989,20 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
                 ID
               </th>
               <th class="w-24 min-w-24 px-3 py-2 text-right font-medium">
-                Actions
+                Delete
               </th>
             </tr>
           </thead>
           <tbody>
             <!-- Existing rows -->
             <tr
-              v-for="row in rows"
+              v-for="(row, rowIndex) in rows"
               :key="row.id"
               class="group border-b last:border-0 hover:bg-accent/30"
             >
+              <td class="w-12 min-w-12 px-3 py-2 text-center text-xs font-mono text-muted-foreground whitespace-nowrap">
+                {{ rowIndex + 1 }}
+              </td>
               <td
                 v-for="col in sortedColumns"
                 :key="col.id"
@@ -1052,7 +1077,7 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
               </td>
               <td class="w-28 min-w-28 px-3 py-2 text-right">
                 <button
-                  class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-mono text-muted-foreground opacity-0 transition-opacity hover:bg-accent group-hover:opacity-100"
+                  class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-mono text-muted-foreground transition-opacity hover:bg-accent"
                   :title="row.id"
                   @click="copyRowId(row.id)"
                 >
@@ -1067,7 +1092,7 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
               </td>
               <td class="w-24 min-w-24 px-3 py-2 text-right">
                 <button
-                  class="rounded p-1 opacity-0 hover:bg-destructive/10 group-hover:opacity-100"
+                  class="rounded p-1 hover:bg-destructive/10"
                   @click="handleDeleteRow(row.id)"
                 >
                   <Trash2 class="h-3.5 w-3.5 text-destructive" />
@@ -1080,6 +1105,7 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
               v-if="addingRow"
               class="border-b bg-accent/20"
             >
+              <td />
               <td
                 v-for="col in sortedColumns"
                 :key="col.id"
@@ -1143,7 +1169,7 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
             <!-- Empty state -->
             <tr v-if="rows.length === 0 && !addingRow && !rowsLoading">
               <td
-                :colspan="sortedColumns.length + 4"
+                :colspan="sortedColumns.length + 5"
                 class="px-3 py-8 text-center text-muted-foreground"
               >
                 No rows yet. Click "Add Row" to get started.

--- a/frontend/src/components/Layout/DashboardNav.vue
+++ b/frontend/src/components/Layout/DashboardNav.vue
@@ -304,6 +304,7 @@ watch(activeTab, () => {
 .tab-item[data-tab-id="workflows"]:hover       .tab-icon { animation: icon-spin   0.45s ease-out; }
 .tab-item[data-tab-id="schedules"]:hover       .tab-icon { animation: icon-tick   0.40s ease-out; }
 .tab-item[data-tab-id="templates"]:hover       .tab-icon { animation: icon-pop    0.35s ease-out; }
+.tab-item[data-tab-id="dashboard"]:hover       .tab-icon { animation: icon-pop    0.35s ease-out; }
 .tab-item[data-tab-id="globalvariables"]:hover .tab-icon { animation: icon-bounce 0.40s ease-out; }
 .tab-item[data-tab-id="chat"]:hover            .tab-icon { animation: icon-pulse  0.40s ease-out; }
 .tab-item[data-tab-id="drive"]:hover           .tab-icon { animation: icon-spin   0.50s ease-out; }

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -500,7 +500,8 @@ type ChartOutputExpressionFieldKey =
   | "min"
   | "max"
   | "unit"
-  | "title";
+  | "title"
+  | "url";
 
 interface ChartOutputExpressionField {
   key: ChartOutputExpressionFieldKey;
@@ -3084,6 +3085,7 @@ const chartOutputExpressionFields = computed<ChartOutputExpressionField[]>(() =>
   }
 
   fields.push({ key: "title", label: "Title" });
+  fields.push({ key: "url", label: "Website URL" });
   return fields;
 });
 
@@ -8695,6 +8697,29 @@ onUnmounted(() => {
                 @navigate="handleChartOutputExpressionFieldNavigate"
                 @register-field-index="onChartOutputRegisterExpressionFieldIndex"
                 @update:model-value="updateNodeData('title', $event)"
+              />
+            </div>
+
+            <div class="space-y-2">
+              <Label>Website URL</Label>
+              <ExpressionInput
+                :ref="(el: unknown) => setChartOutputExpressionInputRef('url', el)"
+                :model-value="selectedNode.data.url || ''"
+                placeholder="https://… (optional)"
+                single-line
+                :nodes="workflowStore.nodes"
+                :node-results="workflowStore.nodeResults"
+                :edges="workflowStore.edges"
+                :current-node-id="selectedNode.id"
+                :dialog-node-label="selectedNodeEvaluateDialogLabel"
+                dialog-key-label="Website URL"
+                field-key="url"
+                :navigation-enabled="chartOutputExpressionFieldCount > 1"
+                :navigation-index="chartOutputExpressionFieldIndex('url')"
+                :navigation-total="chartOutputExpressionFieldCount"
+                @navigate="handleChartOutputExpressionFieldNavigate"
+                @register-field-index="onChartOutputRegisterExpressionFieldIndex"
+                @update:model-value="updateNodeData('url', $event)"
               />
             </div>
           </template>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2513,6 +2513,11 @@ export const dataTablesApi = {
     return response.data;
   },
 
+  clone: async (id: string): Promise<DataTable> => {
+    const response = await api.post<DataTable>(`/data-tables/${id}/clone`);
+    return response.data;
+  },
+
   generateSchema: async (payload: {
     credential_id: string;
     model: string;

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -30,6 +30,8 @@ export interface ChartPayload {
   min?: number;
   max?: number;
   title?: string;
+  // Optional external link set on the chartOutput node; rendered as an icon in the widget title.
+  url?: string;
 }
 
 export interface WidgetLayout {

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -549,6 +549,8 @@ export interface NodeData {
   // Static markdown body for the `text` chart type.
   text?: string;
   title?: string;
+  // Optional external link for a chartOutput widget; surfaced as an icon in the dashboard widget title.
+  url?: string;
 }
 
 export interface WorkflowShare {


### PR DESCRIPTION
## Summary

Bundles 9 commits from this work session into a single PR.

### DataTable duplicate (clone)
- New `POST /data-tables/{id}/clone` endpoint — copies columns + all rows into a new table named `"X (Copy)"`, `"X (Copy 2)"`, … (mirrors vector-store clone). Shares are not copied; the copy is private to the cloning user.
- `Copy` icon added to the DataTable card hover toolbar (between rename and delete) → one-click duplicate.
- `dataTablesApi.clone()` API client method.
- Backend tests: column/row copy, name increment on collision, shares not copied, 404 on inaccessible table.

### Widget URL links + dashboard nav animation
- `Website URL` field on the `chartOutput` node config; `url` threaded through `ChartPayload`.
- External-link icon shown on widgets that have a URL.
- Hover animation on dashboard nav tabs.

### Docs
- Design + implementation specs under `docs/superpowers/specs/`.

## Testing
- `./check.sh` passes: frontend lint + typecheck clean, backend ruff clean, **1191 backend tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)