### PR TITLE
feat: implement markdown task update functionality

### DIFF
--- a/backend/app/api/dashboards.py
+++ b/backend/app/api/dashboards.py
@@ -21,6 +21,7 @@ from app.models.dashboard_schemas import (
     DashboardResponse,
     DashboardWidgetResponse,
     MarkdownTaskToggleRequest,
+    MarkdownTaskUpdateRequest,
     WidgetCreateRequest,
     WidgetDataResponse,
     WidgetUpdateRequest,
@@ -30,7 +31,11 @@ from app.services.encryption import decrypt_config
 from app.services.llm_provider import is_reasoning_model
 from app.services.llm_service import execute_llm
 from app.services.llm_trace import LLMTraceContext
-from app.services.markdown_task_list import has_task_items, toggle_task_item
+from app.services.markdown_task_list import (
+    has_task_items,
+    toggle_task_item,
+    update_or_remove_task_item,
+)
 from app.services.workflow_dsl_prompt import build_assistant_prompt
 
 router = APIRouter()
@@ -177,6 +182,73 @@ def _find_chart_output_node(workflow: Workflow) -> dict[str, Any] | None:
     return None
 
 
+async def _load_widget_workflow(db: AsyncSession, widget: DashboardWidget) -> Workflow:
+    wf_result = await db.execute(select(Workflow).where(Workflow.id == widget.workflow_id))
+    workflow = wf_result.scalar_one_or_none()
+    if workflow is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found")
+    return workflow
+
+
+def _validate_text_task_widget(workflow: Workflow, payload: dict[str, Any]) -> str:
+    chart_node = _find_chart_output_node(workflow)
+    if chart_node is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Widget workflow has no chartOutput node",
+        )
+
+    chart_data = chart_node.get("data") or {}
+    if chart_data.get("chartType") != "text":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Checkbox toggling is only supported for text chart widgets",
+        )
+
+    displayed_text = payload.get("text")
+    if not displayed_text or not str(displayed_text).strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Widget has no markdown text to toggle",
+        )
+    if not payload.get("text_interactive"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Checkbox toggling is only supported for markdown task lists",
+        )
+    if not has_task_items(str(displayed_text)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Checkbox toggling is only supported for markdown task lists",
+        )
+    return str(displayed_text)
+
+
+async def _apply_markdown_text_to_widget(
+    db: AsyncSession,
+    widget: DashboardWidget,
+    workflow: Workflow,
+    current_user: User,
+    updated_text: str,
+) -> WidgetDataResponse:
+    nodes = list(workflow.nodes or [])
+    for index, node in enumerate(nodes):
+        if isinstance(node, dict) and node.get("type") == "chartOutput":
+            node_data = dict(node.get("data") or {})
+            node_data["text"] = updated_text
+            node_data.pop("valueField", None)
+            nodes[index] = {**node, "data": node_data}
+            break
+    workflow.nodes = nodes
+    flag_modified(workflow, "nodes")
+    widget.cached_payload = None
+    widget.cached_at = None
+    widget.cached_workflow_version = None
+    await db.commit()
+    await db.refresh(widget)
+    return await compute_widget_data(db, widget, current_user, force=True)
+
+
 @router.get("", response_model=DashboardResponse)
 async def get_dashboard(
     current_user: User = Depends(get_current_user),
@@ -302,65 +374,40 @@ async def toggle_markdown_task(
     db: AsyncSession = Depends(get_db),
 ) -> WidgetDataResponse:
     widget = await _load_widget(db, widget_id, current_user)
-    wf_result = await db.execute(select(Workflow).where(Workflow.id == widget.workflow_id))
-    workflow = wf_result.scalar_one_or_none()
-    if workflow is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found")
-
-    chart_node = _find_chart_output_node(workflow)
-    if chart_node is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Widget workflow has no chartOutput node",
-        )
-
-    chart_data = chart_node.get("data") or {}
-    if chart_data.get("chartType") != "text":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Checkbox toggling is only supported for text chart widgets",
-        )
+    workflow = await _load_widget_workflow(db, widget)
 
     current = await compute_widget_data(db, widget, current_user, force=False)
     payload = current.payload or {}
-    displayed_text = payload.get("text")
-    if not displayed_text or not str(displayed_text).strip():
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Widget has no markdown text to toggle",
-        )
-    if not payload.get("text_interactive"):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Checkbox toggling is only supported for markdown task lists",
-        )
-    if not has_task_items(str(displayed_text)):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Checkbox toggling is only supported for markdown task lists",
-        )
+    displayed_text = _validate_text_task_widget(workflow, payload)
 
     try:
-        updated_text = toggle_task_item(str(displayed_text), body.line_index)
+        updated_text = toggle_task_item(displayed_text, body.line_index)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    nodes = list(workflow.nodes or [])
-    for index, node in enumerate(nodes):
-        if isinstance(node, dict) and node.get("type") == "chartOutput":
-            node_data = dict(node.get("data") or {})
-            node_data["text"] = updated_text
-            node_data.pop("valueField", None)
-            nodes[index] = {**node, "data": node_data}
-            break
-    workflow.nodes = nodes
-    flag_modified(workflow, "nodes")
-    widget.cached_payload = None
-    widget.cached_at = None
-    widget.cached_workflow_version = None
-    await db.commit()
-    await db.refresh(widget)
-    return await compute_widget_data(db, widget, current_user, force=True)
+    return await _apply_markdown_text_to_widget(db, widget, workflow, current_user, updated_text)
+
+
+@router.patch("/widgets/{widget_id}/markdown-task-update", response_model=WidgetDataResponse)
+async def update_markdown_task(
+    widget_id: uuid.UUID,
+    body: MarkdownTaskUpdateRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WidgetDataResponse:
+    widget = await _load_widget(db, widget_id, current_user)
+    workflow = await _load_widget_workflow(db, widget)
+
+    current = await compute_widget_data(db, widget, current_user, force=False)
+    payload = current.payload or {}
+    displayed_text = _validate_text_task_widget(workflow, payload)
+
+    try:
+        updated_text = update_or_remove_task_item(displayed_text, body.line_index, body.text)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    return await _apply_markdown_text_to_widget(db, widget, workflow, current_user, updated_text)
 
 
 @router.post(

--- a/backend/app/models/dashboard_schemas.py
+++ b/backend/app/models/dashboard_schemas.py
@@ -50,6 +50,11 @@ class MarkdownTaskToggleRequest(BaseModel):
     line_index: int = Field(ge=0)
 
 
+class MarkdownTaskUpdateRequest(BaseModel):
+    line_index: int = Field(ge=0)
+    text: str = ""
+
+
 class WidgetDataResponse(BaseModel):
     widget_id: uuid.UUID
     payload: dict[str, Any] | None

--- a/backend/app/services/markdown_task_list.py
+++ b/backend/app/services/markdown_task_list.py
@@ -31,3 +31,49 @@ def toggle_task_item(markdown: str, line_index: int) -> str:
     new_check = " " if check.lower() == "x" else "x"
     lines[line_index] = f"{indent}{bullet} [{new_check}] {rest}"
     return "\n".join(lines)
+
+
+def update_task_item(markdown: str, line_index: int, text: str) -> str:
+    """Replace the label text on a task list line, preserving checked state.
+
+    Raises:
+        ValueError: When the line index is out of range or not a task item.
+    """
+    lines = markdown.split("\n")
+    if line_index < 0 or line_index >= len(lines):
+        raise ValueError(f"Invalid line_index: {line_index}")
+    match = TASK_ITEM_RE.match(lines[line_index])
+    if match is None:
+        raise ValueError(f"Line {line_index} is not a task list item")
+    indent, bullet, check, _rest = match.groups()
+    lines[line_index] = f"{indent}{bullet} [{check}] {text}"
+    return "\n".join(lines)
+
+
+def remove_task_item(markdown: str, line_index: int) -> str:
+    """Remove a task list line from markdown.
+
+    Raises:
+        ValueError: When the line index is out of range or not a task item.
+    """
+    lines = markdown.split("\n")
+    if line_index < 0 or line_index >= len(lines):
+        raise ValueError(f"Invalid line_index: {line_index}")
+    if TASK_ITEM_RE.match(lines[line_index]) is None:
+        raise ValueError(f"Line {line_index} is not a task list item")
+    del lines[line_index]
+    if (
+        line_index < len(lines)
+        and lines[line_index].strip() == ""
+        and line_index > 0
+        and lines[line_index - 1].strip() == ""
+    ):
+        del lines[line_index]
+    return "\n".join(lines)
+
+
+def update_or_remove_task_item(markdown: str, line_index: int, text: str) -> str:
+    """Update task item label text, or remove the line when text is blank."""
+    if text.strip() == "":
+        return remove_task_item(markdown, line_index)
+    return update_task_item(markdown, line_index, text)

--- a/backend/tests/test_dashboards_api.py
+++ b/backend/tests/test_dashboards_api.py
@@ -609,3 +609,164 @@ class TestMarkdownTaskToggle(unittest.IsolatedAsyncioTestCase):
         chart_data = workflow.nodes[0]["data"]
         self.assertEqual(chart_data["text"], updated)
         self.assertNotIn("valueField", chart_data)
+
+
+class TestMarkdownTaskUpdate(unittest.IsolatedAsyncioTestCase):
+    async def test_update_text_persists_to_workflow(self):
+        user = _User()
+        markdown = "- [ ] Option 1\n- [ ] Option 2"
+        workflow = MagicMock()
+        workflow.id = uuid.uuid4()
+        workflow.nodes = [
+            {
+                "id": "c",
+                "type": "chartOutput",
+                "data": {"chartType": "text", "text": markdown},
+            }
+        ]
+
+        widget = MagicMock()
+        widget.id = uuid.uuid4()
+        widget.workflow_id = workflow.id
+        widget.cached_payload = None
+        widget.cached_at = None
+        widget.cached_workflow_version = None
+
+        db = MagicMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=widget)),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=workflow)),
+            ]
+        )
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        updated_text = "- [ ] Renamed\n- [ ] Option 2"
+        compute = AsyncMock(
+            side_effect=[
+                MagicMock(payload={"type": "text", "text": markdown, "text_interactive": True}),
+                MagicMock(
+                    widget_id=widget.id,
+                    payload={"type": "text", "text": updated_text, "text_interactive": True},
+                    cached=False,
+                    computed_at=datetime.datetime.now(),
+                    error=None,
+                ),
+            ]
+        )
+
+        from app.models.dashboard_schemas import MarkdownTaskUpdateRequest
+
+        with patch.object(dash_api, "compute_widget_data", compute):
+            resp = await dash_api.update_markdown_task(
+                widget_id=widget.id,
+                body=MarkdownTaskUpdateRequest(line_index=0, text="Renamed"),
+                current_user=user,
+                db=db,
+            )
+
+        self.assertEqual(resp.payload["text"], updated_text)
+        self.assertEqual(workflow.nodes[0]["data"]["text"], updated_text)
+
+    async def test_update_blank_text_removes_line(self):
+        user = _User()
+        markdown = "- [ ] One\n- [ ] Two"
+        workflow = MagicMock()
+        workflow.id = uuid.uuid4()
+        workflow.nodes = [
+            {
+                "id": "c",
+                "type": "chartOutput",
+                "data": {"chartType": "text", "text": markdown},
+            }
+        ]
+
+        widget = MagicMock()
+        widget.id = uuid.uuid4()
+        widget.workflow_id = workflow.id
+        widget.cached_payload = None
+        widget.cached_at = None
+        widget.cached_workflow_version = None
+
+        db = MagicMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=widget)),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=workflow)),
+            ]
+        )
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        updated_text = "- [ ] Two"
+        compute = AsyncMock(
+            side_effect=[
+                MagicMock(payload={"type": "text", "text": markdown, "text_interactive": True}),
+                MagicMock(
+                    widget_id=widget.id,
+                    payload={"type": "text", "text": updated_text, "text_interactive": True},
+                    cached=False,
+                    computed_at=datetime.datetime.now(),
+                    error=None,
+                ),
+            ]
+        )
+
+        from app.models.dashboard_schemas import MarkdownTaskUpdateRequest
+
+        with patch.object(dash_api, "compute_widget_data", compute):
+            await dash_api.update_markdown_task(
+                widget_id=widget.id,
+                body=MarkdownTaskUpdateRequest(line_index=0, text=""),
+                current_user=user,
+                db=db,
+            )
+
+        self.assertEqual(workflow.nodes[0]["data"]["text"], updated_text)
+
+    async def test_update_rejects_non_interactive_text(self):
+        user = _User()
+        workflow = MagicMock()
+        workflow.id = uuid.uuid4()
+        workflow.nodes = [
+            {
+                "id": "c",
+                "type": "chartOutput",
+                "data": {"chartType": "text", "valueField": "message"},
+            }
+        ]
+
+        widget = MagicMock()
+        widget.id = uuid.uuid4()
+        widget.workflow_id = workflow.id
+
+        db = MagicMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=widget)),
+                MagicMock(scalar_one_or_none=MagicMock(return_value=workflow)),
+            ]
+        )
+
+        compute = AsyncMock(
+            return_value=MagicMock(
+                payload={
+                    "type": "text",
+                    "text": "Last run at 19:47",
+                    "text_interactive": False,
+                }
+            )
+        )
+
+        from app.models.dashboard_schemas import MarkdownTaskUpdateRequest
+
+        with patch.object(dash_api, "compute_widget_data", compute):
+            with self.assertRaises(Exception) as ctx:
+                await dash_api.update_markdown_task(
+                    widget_id=widget.id,
+                    body=MarkdownTaskUpdateRequest(line_index=0, text="New"),
+                    current_user=user,
+                    db=db,
+                )
+        self.assertEqual(ctx.exception.status_code, 400)

--- a/backend/tests/test_markdown_task_list.py
+++ b/backend/tests/test_markdown_task_list.py
@@ -3,7 +3,10 @@ import unittest
 from app.services.markdown_task_list import (
     has_task_items,
     parse_task_line_indices,
+    remove_task_item,
     toggle_task_item,
+    update_or_remove_task_item,
+    update_task_item,
 )
 
 
@@ -43,3 +46,32 @@ class MarkdownTaskListTests(unittest.TestCase):
     def test_toggle_non_task_line_raises(self):
         with self.assertRaises(ValueError):
             toggle_task_item("- plain bullet", 0)
+
+    def test_update_task_item_preserves_checked_state(self):
+        md = "- [x] Done item\n- [ ] Todo item"
+        result = update_task_item(md, 0, "Finished item")
+        self.assertEqual(result, "- [x] Finished item\n- [ ] Todo item")
+
+    def test_update_task_item_unchecked(self):
+        md = "- [ ] Old label"
+        result = update_task_item(md, 0, "New label")
+        self.assertEqual(result, "- [ ] New label")
+
+    def test_remove_task_item(self):
+        md = "- [ ] One\n- [ ] Two\n- [ ] Three"
+        result = remove_task_item(md, 1)
+        self.assertEqual(result, "- [ ] One\n- [ ] Three")
+
+    def test_update_or_remove_blank_text_removes_line(self):
+        md = "- [ ] One\n- [ ] Two"
+        result = update_or_remove_task_item(md, 0, "   ")
+        self.assertEqual(result, "- [ ] Two")
+
+    def test_update_or_remove_non_blank_updates(self):
+        md = "- [ ] One"
+        result = update_or_remove_task_item(md, 0, "Updated")
+        self.assertEqual(result, "- [ ] Updated")
+
+    def test_remove_invalid_index_raises(self):
+        with self.assertRaises(ValueError):
+            remove_task_item("- [ ] ok", 5)

--- a/frontend/src/components/Dashboards/ChartRenderer.vue
+++ b/frontend/src/components/Dashboards/ChartRenderer.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "markdown-task-toggle", lineIndex: number): void;
+  (e: "markdown-task-update", payload: { lineIndex: number; text: string }): void;
 }>();
 
 const themeStore = useThemeStore();
@@ -193,6 +194,10 @@ function onMarkdownTaskToggle(lineIndex: number): void {
   emit("markdown-task-toggle", lineIndex);
 }
 
+function onMarkdownTaskUpdate(payload: { lineIndex: number; text: string }): void {
+  emit("markdown-task-update", payload);
+}
+
 const numericValue = computed((): string => {
   const p = chartPayload.value;
   if (!p || p.value === null || p.value === undefined) return "—";
@@ -363,6 +368,7 @@ const apexOptions = computed((): Record<string, unknown> => {
       :interactive="!!chartPayload.text_interactive"
       :saving="markdownTaskSaving"
       @toggle="onMarkdownTaskToggle"
+      @update="onMarkdownTaskUpdate"
     />
     <div
       v-else-if="chartPayload && chartPayload.type === 'text'"

--- a/frontend/src/components/Dashboards/DashboardWidgetCard.vue
+++ b/frontend/src/components/Dashboards/DashboardWidgetCard.vue
@@ -6,7 +6,7 @@ import { ExternalLink, Loader2, MoreVertical, Pencil, RefreshCw, Settings, Spark
 
 import type { ChartPayload, DashboardWidget } from "@/types/dashboard";
 import ChartRenderer from "@/components/Dashboards/ChartRenderer.vue";
-import { toggleTaskItemLocal } from "@/lib/markdownTaskList";
+import { toggleTaskItemLocal, updateOrRemoveTaskItemLocal } from "@/lib/markdownTaskList";
 import { dashboardApi } from "@/services/api";
 
 const props = defineProps<{
@@ -142,6 +142,33 @@ async function onMarkdownTaskToggle(lineIndex: number): Promise<void> {
   } catch (e) {
     payload.value = previousPayload;
     error.value = e instanceof Error ? e.message : "Failed to update checkbox";
+  } finally {
+    markdownTaskSaving.value = false;
+  }
+}
+
+async function onMarkdownTaskUpdate(update: { lineIndex: number; text: string }): Promise<void> {
+  if (!payload.value || payload.value.type !== "text" || !payload.value.text_interactive) {
+    return;
+  }
+  const previousPayload = payload.value;
+  const previousText = previousPayload.text ?? "";
+  markdownTaskSaving.value = true;
+  try {
+    payload.value = {
+      ...previousPayload,
+      text: updateOrRemoveTaskItemLocal(previousText, update.lineIndex, update.text),
+    };
+    const response = await dashboardApi.updateMarkdownTask(
+      props.widget.id,
+      update.lineIndex,
+      update.text,
+    );
+    payload.value = response.payload;
+    error.value = response.error ?? null;
+  } catch (e) {
+    payload.value = previousPayload;
+    error.value = e instanceof Error ? e.message : "Failed to update checkbox item";
   } finally {
     markdownTaskSaving.value = false;
   }
@@ -287,6 +314,7 @@ onBeforeUnmount(() => {
         :payload="payload"
         :markdown-task-saving="markdownTaskSaving"
         @markdown-task-toggle="onMarkdownTaskToggle"
+        @markdown-task-update="onMarkdownTaskUpdate"
       />
     </div>
   </div>

--- a/frontend/src/components/Dashboards/MarkdownTextContent.vue
+++ b/frontend/src/components/Dashboards/MarkdownTextContent.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onBeforeUnmount, ref, nextTick } from "vue";
 import DOMPurify from "dompurify";
 import { Check } from "lucide-vue-next";
 import { marked } from "marked";
 
 import { preserveExplicitOrderedListNumbers } from "@/lib/markdown";
-import { parseMarkdownBlocks } from "@/lib/markdownTaskList";
+import { parseMarkdownBlocks, type TaskListItem } from "@/lib/markdownTaskList";
 
 const INLINE_ALLOWED_TAGS = ["strong", "em", "u", "s", "code", "a", "br"];
 const INLINE_ALLOWED_ATTR = ["href", "target", "rel"];
+const CLICK_DELAY_MS = 250;
 
 const props = defineProps<{
   text: string;
@@ -18,9 +19,26 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "toggle", lineIndex: number): void;
+  (e: "update", payload: { lineIndex: number; text: string }): void;
 }>();
 
 const blocks = computed(() => parseMarkdownBlocks(props.text));
+const editingLineIndex = ref<number | null>(null);
+const editDraft = ref("");
+const originalEditText = ref("");
+const editInputRef = ref<HTMLInputElement | null>(null);
+let pendingToggleTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearPendingToggle(): void {
+  if (pendingToggleTimer !== null) {
+    clearTimeout(pendingToggleTimer);
+    pendingToggleTimer = null;
+  }
+}
+
+onBeforeUnmount(() => {
+  clearPendingToggle();
+});
 
 function renderHtml(content: string): string {
   if (!content.trim()) return "";
@@ -38,9 +56,65 @@ function renderInline(content: string): string {
   });
 }
 
-function onToggle(lineIndex: number): void {
+function onCheckboxClick(lineIndex: number): void {
+  clearPendingToggle();
   if (!props.interactive || props.saving) return;
   emit("toggle", lineIndex);
+}
+
+function onRowClick(event: MouseEvent, lineIndex: number): void {
+  if (!props.interactive || props.saving) return;
+  if (editingLineIndex.value === lineIndex) return;
+  const target = event.target as HTMLElement;
+  if (target.closest('[role="checkbox"]')) return;
+  if (target.closest("a")) return;
+  clearPendingToggle();
+  pendingToggleTimer = setTimeout(() => {
+    pendingToggleTimer = null;
+    emit("toggle", lineIndex);
+  }, CLICK_DELAY_MS);
+}
+
+async function onRowDblClick(event: MouseEvent, item: TaskListItem): Promise<void> {
+  const target = event.target as HTMLElement;
+  if (target.closest('[role="checkbox"]')) return;
+  clearPendingToggle();
+  event.stopPropagation();
+  event.preventDefault();
+  await startEdit(item);
+}
+
+async function startEdit(item: TaskListItem): Promise<void> {
+  if (!props.interactive || props.saving) return;
+  editingLineIndex.value = item.lineIndex;
+  editDraft.value = item.text;
+  originalEditText.value = item.text;
+  await nextTick();
+  editInputRef.value?.focus();
+  editInputRef.value?.select();
+}
+
+function cancelEdit(): void {
+  editingLineIndex.value = null;
+  editDraft.value = "";
+  originalEditText.value = "";
+}
+
+function commitEdit(lineIndex: number): void {
+  if (editingLineIndex.value !== lineIndex) return;
+  const next = editDraft.value;
+  const trimmed = next.trim();
+  if (trimmed === "") {
+    emit("update", { lineIndex, text: "" });
+    cancelEdit();
+    return;
+  }
+  if (next === originalEditText.value) {
+    cancelEdit();
+    return;
+  }
+  emit("update", { lineIndex, text: next });
+  cancelEdit();
 }
 </script>
 
@@ -68,7 +142,8 @@ function onToggle(lineIndex: number): void {
               ? 'cursor-pointer hover:bg-muted/50'
               : 'cursor-default opacity-90'
           "
-          @click.stop="onToggle(item.lineIndex)"
+          @click.stop="onRowClick($event, item.lineIndex)"
+          @dblclick.stop.prevent="onRowDblClick($event, item)"
         >
           <span
             class="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border border-border transition-colors"
@@ -80,6 +155,7 @@ function onToggle(lineIndex: number): void {
             role="checkbox"
             :aria-checked="item.checked"
             :aria-disabled="!interactive || saving"
+            @click.stop="onCheckboxClick(item.lineIndex)"
           >
             <Check
               v-if="item.checked"
@@ -87,8 +163,20 @@ function onToggle(lineIndex: number): void {
               aria-hidden="true"
             />
           </span>
+          <input
+            v-if="editingLineIndex === item.lineIndex"
+            ref="editInputRef"
+            v-model="editDraft"
+            class="min-w-0 flex-1 rounded border border-input bg-background px-1.5 py-0.5 text-sm leading-snug text-foreground outline-none ring-offset-background focus-visible:ring-2 focus-visible:ring-ring"
+            @click.stop
+            @mousedown.stop
+            @blur="commitEdit(item.lineIndex)"
+            @keyup.enter="commitEdit(item.lineIndex)"
+            @keyup.escape="cancelEdit"
+          >
           <span
-            class="min-w-0 flex-1 leading-snug text-foreground"
+            v-else
+            class="min-w-0 flex-1 leading-snug text-foreground select-none"
             v-html="renderInline(item.text)"
           />
         </li>

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -38,6 +38,7 @@ import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
 import Select from "@/components/ui/Select.vue";
+import RunInputField from "@/components/Panels/RunInputField.vue";
 import Textarea from "@/components/ui/Textarea.vue";
 import JsonTree from "@/components/ui/JsonTree.vue";
 import GoogleSheetsValuesInputPanel from "@/components/ui/GoogleSheetsValuesInputPanel.vue";
@@ -55,6 +56,7 @@ import { configApi, credentialsApi, dataTablesApi, filesApi, gristApi, mcpApi, w
 import type { MCPFetchToolItem } from "@/services/api";
 import { onDismissOverlays } from "@/composables/useOverlayBackHandler";
 import { useToast } from "@/composables/useToast";
+import { useRunPanelFileDrag } from "@/composables/useRunPanelFileDrag";
 import type { DataTableListItem } from "@/types/dataTable";
 import type { GeneratedFile } from "@/types/file";
 import { useAuthStore } from "@/stores/auth";
@@ -1346,6 +1348,21 @@ const selectedNodeTypeLabel = computed((): string => {
 });
 
 const isExecuting = computed(() => workflowStore.isExecuting);
+const {
+  isActive: isRunPanelFileDragActive,
+  reset: resetRunPanelFileDrag,
+  onDragEnter: onRunPanelFileDragEnter,
+  onDragLeave: onRunPanelFileDragLeave,
+  onDragOver: onRunPanelFileDragOver,
+  onDrop: onRunPanelFileDrop,
+} = useRunPanelFileDrag(
+  computed(
+    () =>
+      isExecuting.value
+      || isGenericWebhookBodyMode.value
+      || allInputFields.value.length === 0,
+  ),
+);
 const { isRunbookPlaying } = useRunbookPlayer();
 const hasNodes = computed(() => workflowStore.nodes.length > 0);
 
@@ -14136,6 +14153,10 @@ onUnmounted(() => {
     <div
       v-if="activeTab === 'config'"
       class="flex-1 flex flex-col overflow-hidden overflow-x-hidden min-h-0"
+      @dragenter="onRunPanelFileDragEnter"
+      @dragleave="onRunPanelFileDragLeave"
+      @dragover="onRunPanelFileDragOver"
+      @drop="onRunPanelFileDrop"
     >
       <div class="flex-1 flex flex-col overflow-hidden min-h-0">
         <div
@@ -14184,13 +14205,14 @@ onUnmounted(() => {
               class="space-y-2 min-w-0"
             >
               <Label class="truncate">{{ field.key }}</Label>
-              <Textarea
+              <RunInputField
+                :field-key="field.key"
                 :model-value="runInputValues[field.key] ?? ''"
                 :placeholder="field.defaultValue || `Enter ${field.key}...`"
-                :rows="3"
                 :disabled="isExecuting"
-                class="min-w-0 w-full"
+                :panel-file-drag-active="isRunPanelFileDragActive"
                 @update:model-value="updateInputValue(field.key, $event)"
+                @file-dropped="resetRunPanelFileDrag"
               />
             </div>
           </template>

--- a/frontend/src/components/Panels/RunInputField.vue
+++ b/frontend/src/components/Panels/RunInputField.vue
@@ -1,0 +1,292 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from "vue";
+import { Loader2, Paperclip, Upload } from "lucide-vue-next";
+
+import Textarea from "@/components/ui/Textarea.vue";
+import { INPUT_FIELD_FILE_ACCEPT, readFileForInputField } from "@/lib/inputFieldFile";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  fieldKey: string;
+  modelValue?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  panelFileDragActive?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: "",
+  placeholder: "",
+  disabled: false,
+  panelFileDragActive: false,
+});
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string): void;
+  (e: "file-dropped"): void;
+}>();
+
+const isFileDragOver = ref(false);
+const attachedFileName = ref<string | null>(null);
+const lastFileContent = ref<string | null>(null);
+const fileError = ref<string | null>(null);
+const isLoading = ref(false);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+
+const showDropPreview = computed(
+  () => isFileDragOver.value || props.panelFileDragActive,
+);
+
+const effectivePlaceholder = computed(() =>
+  showDropPreview.value ? "Drop file here…" : props.placeholder,
+);
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (lastFileContent.value !== null && value !== lastFileContent.value) {
+      attachedFileName.value = null;
+      lastFileContent.value = null;
+    }
+  },
+);
+
+function isFileDragEvent(event: DragEvent): boolean {
+  return event.dataTransfer?.types.includes("Files") ?? false;
+}
+
+function setFileDragOver(active: boolean): void {
+  isFileDragOver.value = active;
+}
+
+function handleDragEnter(event: DragEvent): void {
+  if (props.disabled || !isFileDragEvent(event)) return;
+  event.preventDefault();
+  isFileDragOver.value = true;
+}
+
+function handleDragLeave(event: DragEvent): void {
+  if (props.disabled) return;
+  event.preventDefault();
+
+  const current = event.currentTarget as HTMLElement;
+  const related = event.relatedTarget as Node | null;
+  if (related && current.contains(related)) return;
+
+  isFileDragOver.value = false;
+}
+
+function handleDragOver(event: DragEvent): void {
+  if (props.disabled || !isFileDragEvent(event)) return;
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = "copy";
+  }
+  isFileDragOver.value = true;
+}
+
+function handleDocumentDragEnd(): void {
+  setFileDragOver(false);
+}
+
+watch(isFileDragOver, (active) => {
+  if (active) {
+    document.addEventListener("dragend", handleDocumentDragEnd);
+    document.addEventListener("drop", handleDocumentDragEnd);
+  } else {
+    document.removeEventListener("dragend", handleDocumentDragEnd);
+    document.removeEventListener("drop", handleDocumentDragEnd);
+  }
+});
+
+onUnmounted(() => {
+  document.removeEventListener("dragend", handleDocumentDragEnd);
+  document.removeEventListener("drop", handleDocumentDragEnd);
+});
+
+async function processFile(file: File): Promise<void> {
+  if (props.disabled) return;
+
+  fileError.value = null;
+  isLoading.value = true;
+  try {
+    const result = await readFileForInputField(file);
+    lastFileContent.value = result.content;
+    attachedFileName.value = result.name;
+    emit("update:modelValue", result.content);
+  } catch (error) {
+    fileError.value = error instanceof Error ? error.message : "Failed to read file";
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+async function handleDrop(event: DragEvent): Promise<void> {
+  if (props.disabled) return;
+  event.preventDefault();
+  setFileDragOver(false);
+  emit("file-dropped");
+
+  const file = event.dataTransfer?.files[0];
+  if (!file) return;
+
+  await processFile(file);
+}
+
+async function handleFileInputChange(event: Event): Promise<void> {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+
+  await processFile(file);
+  input.value = "";
+}
+
+function openFilePicker(): void {
+  if (props.disabled || isLoading.value) return;
+  fileInputRef.value?.click();
+}
+</script>
+
+<template>
+  <div class="space-y-1 min-w-0">
+    <div
+      class="relative min-w-0 rounded-xl transition-all duration-200"
+      :class="showDropPreview && 'ring-2 ring-primary/60 shadow-[0_0_0_4px_hsl(var(--primary)/0.08)]'"
+      @dragenter="handleDragEnter"
+      @dragleave="handleDragLeave"
+      @dragover="handleDragOver"
+      @drop="handleDrop"
+    >
+      <Textarea
+        :model-value="modelValue"
+        :placeholder="effectivePlaceholder"
+        :disabled="disabled || isLoading"
+        :rows="3"
+        :class="cn(
+          'min-w-0 w-full pr-10 transition-all duration-200',
+          showDropPreview && 'border-primary/50 bg-primary/[0.03]',
+        )"
+        @update:model-value="emit('update:modelValue', $event)"
+      />
+
+      <Transition name="run-input-drop">
+        <div
+          v-if="showDropPreview"
+          class="run-input-drop-overlay absolute inset-0 z-10 flex items-center justify-center rounded-xl border-2 border-dashed border-primary bg-primary/[0.06] backdrop-blur-[1px] pointer-events-none"
+          aria-hidden="true"
+        >
+          <div class="run-input-drop-content flex flex-col items-center gap-1.5 px-4 text-center">
+            <div class="run-input-drop-icon flex h-9 w-9 items-center justify-center rounded-xl bg-primary/15">
+              <Upload class="h-4 w-4 text-primary" />
+            </div>
+            <p class="text-sm font-medium text-primary">
+              Drop file here
+            </p>
+            <p class="text-xs text-muted-foreground">
+              Release to fill {{ fieldKey }}
+            </p>
+          </div>
+        </div>
+      </Transition>
+
+      <button
+        type="button"
+        class="absolute bottom-2 right-2 z-20 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground opacity-40 transition-opacity hover:opacity-70 disabled:pointer-events-none disabled:opacity-20"
+        :disabled="disabled || isLoading"
+        :aria-label="`Attach file to ${fieldKey}`"
+        @click="openFilePicker"
+      >
+        <Loader2
+          v-if="isLoading"
+          class="h-4 w-4 animate-spin"
+        />
+        <Paperclip
+          v-else
+          class="h-4 w-4"
+        />
+      </button>
+      <input
+        ref="fileInputRef"
+        type="file"
+        class="hidden"
+        :accept="INPUT_FIELD_FILE_ACCEPT"
+        :disabled="disabled || isLoading"
+        @change="handleFileInputChange"
+      >
+    </div>
+    <p
+      v-if="attachedFileName"
+      class="text-xs text-muted-foreground truncate"
+    >
+      {{ attachedFileName }}
+    </p>
+    <p
+      v-if="fileError"
+      class="text-xs text-red-500"
+    >
+      {{ fileError }}
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.run-input-drop-enter-active,
+.run-input-drop-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.run-input-drop-enter-from,
+.run-input-drop-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
+}
+
+.run-input-drop-overlay {
+  animation: run-input-border-pulse 1.2s ease-in-out infinite;
+}
+
+.run-input-drop-icon {
+  animation: run-input-icon-bounce 1.2s ease-in-out infinite;
+}
+
+.run-input-drop-content {
+  animation: run-input-content-fade 0.2s ease-out;
+}
+
+@keyframes run-input-border-pulse {
+  0%,
+  100% {
+    border-color: hsl(var(--primary) / 0.45);
+    background-color: hsl(var(--primary) / 0.04);
+  }
+
+  50% {
+    border-color: hsl(var(--primary) / 0.9);
+    background-color: hsl(var(--primary) / 0.1);
+  }
+}
+
+@keyframes run-input-icon-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+@keyframes run-input-content-fade {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/frontend/src/composables/useRunPanelFileDrag.ts
+++ b/frontend/src/composables/useRunPanelFileDrag.ts
@@ -1,0 +1,77 @@
+import { onUnmounted, ref, watch, type Ref } from "vue";
+
+function isFileDragEvent(event: DragEvent): boolean {
+  return event.dataTransfer?.types.includes("Files") ?? false;
+}
+
+/** Tracks file drag anywhere in the Run panel so input fields can preview early. */
+export function useRunPanelFileDrag(disabled: Ref<boolean>): {
+  isActive: Ref<boolean>;
+  reset: () => void;
+  onDragEnter: (event: DragEvent) => void;
+  onDragLeave: (event: DragEvent) => void;
+  onDragOver: (event: DragEvent) => void;
+  onDrop: (event: DragEvent) => void;
+} {
+  const isActive = ref(false);
+  const dragCounter = ref(0);
+
+  function reset(): void {
+    isActive.value = false;
+    dragCounter.value = 0;
+  }
+
+  function onDocumentDragEnd(): void {
+    reset();
+  }
+
+  watch(isActive, (active) => {
+    if (active) {
+      document.addEventListener("dragend", onDocumentDragEnd, true);
+    } else {
+      document.removeEventListener("dragend", onDocumentDragEnd, true);
+    }
+  });
+
+  onUnmounted(() => {
+    document.removeEventListener("dragend", onDocumentDragEnd, true);
+  });
+
+  function onDragEnter(event: DragEvent): void {
+    if (disabled.value || !isFileDragEvent(event)) return;
+    event.preventDefault();
+    dragCounter.value++;
+    isActive.value = true;
+  }
+
+  function onDragLeave(event: DragEvent): void {
+    if (disabled.value) return;
+    event.preventDefault();
+
+    const current = event.currentTarget as HTMLElement;
+    const related = event.relatedTarget as Node | null;
+    if (related && current.contains(related)) return;
+
+    dragCounter.value--;
+    if (dragCounter.value <= 0) {
+      reset();
+    }
+  }
+
+  function onDragOver(event: DragEvent): void {
+    if (disabled.value || !isFileDragEvent(event)) return;
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "copy";
+    }
+    isActive.value = true;
+  }
+
+  /** Accept drop only to cancel browser default; file is handled on the input field. */
+  function onDrop(event: DragEvent): void {
+    event.preventDefault();
+    reset();
+  }
+
+  return { isActive, reset, onDragEnter, onDragLeave, onDragOver, onDrop };
+}

--- a/frontend/src/docs/content/nodes/chart-output-node.md
+++ b/frontend/src/docs/content/nodes/chart-output-node.md
@@ -62,6 +62,10 @@ Use GitHub-flavored markdown task list syntax in the static `text` field:
 
 On the [Dashboard](../tabs/dashboard-tab.md), checkboxes render as clickable controls (dark and light mode friendly). Toggling a checkbox updates the widget workflow's `text` field and persists across refreshes.
 
+**Inline editing:** double-click a task item's label to edit it in place. Press Enter or click away to save; press Escape to cancel. Clear the label completely to remove that item from the list.
+
+**Links in task items:** when a label contains a markdown link (`[title](url)`), clicking the link opens the URL without toggling the checkbox. Click elsewhere on the row to toggle.
+
 **Static text only:** interactivity requires GFM task list syntax (`- [ ]` / `- [x]`). Plain dynamic status messages without task items stay read-only. When markdown comes from `valueField`, the first toggle copies it into the static `text` field so changes persist.
 
 ### Numbered lists

--- a/frontend/src/docs/content/nodes/input-node.md
+++ b/frontend/src/docs/content/nodes/input-node.md
@@ -41,6 +41,16 @@ The **Input** node is the entry point for workflows that receive data from the u
 - `$userInput.query` – query parameters
 - `$userInput.query.param1` – specific query param
 
+## Run Panel File Input
+
+In the editor **Run** tab (Defined webhook mode), each input field supports drag-and-drop and an inline attachment control (bottom-right of the field):
+
+- **Text files** (`.txt`, `.md`, `.json`, `.csv`, and similar) are read as plain text.
+- **Images** (JPEG, PNG, GIF, WebP) are stored as a `data:` URL (base64) in the field value — use field keys such as `imageUrl` or `base64` when downstream nodes expect image data.
+- **PDF** files are converted to extracted text (max 5 MB file, 100k characters of content).
+
+One file per field. You can still edit the textarea after a file is loaded. Generic webhook mode (raw JSON body) does not show per-field file controls.
+
 ## Input Fields vs Generic Webhooks
 
 `inputFields` still describe expected inputs for defined-mode editor forms, sub-workflow mapping, and other metadata-driven surfaces.

--- a/frontend/src/lib/inputFieldFile.ts
+++ b/frontend/src/lib/inputFieldFile.ts
@@ -1,0 +1,112 @@
+export type InputFieldFileKind = "text" | "image" | "pdf";
+
+export interface InputFieldFileResult {
+  content: string;
+  name: string;
+  kind: InputFieldFileKind;
+}
+
+const TEXT_EXTENSIONS = new Set([
+  "txt",
+  "csv",
+  "json",
+  "md",
+  "py",
+  "ts",
+  "js",
+  "html",
+  "xml",
+  "yaml",
+  "yml",
+  "log",
+]);
+const IMAGE_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+const MAX_TEXT_BYTES = 500 * 1024;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_PDF_BYTES = 5 * 1024 * 1024;
+const MAX_CONTENT_CHARS = 100_000;
+
+function detectKind(file: File): InputFieldFileKind | null {
+  if (file.type === "application/pdf") return "pdf";
+  if (IMAGE_MIME_TYPES.has(file.type)) return "image";
+  const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+  if (TEXT_EXTENSIONS.has(ext)) return "text";
+  return null;
+}
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsText(file);
+  });
+}
+
+function readFileAsDataURL(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function extractPdfText(file: File): Promise<string> {
+  const { getDocument, GlobalWorkerOptions } = await import("pdfjs-dist");
+  GlobalWorkerOptions.workerSrc = new URL(
+    "pdfjs-dist/build/pdf.worker.min.mjs",
+    import.meta.url,
+  ).href;
+  const buffer = await file.arrayBuffer();
+  const pdf = await getDocument({ data: buffer }).promise;
+  const pages: string[] = [];
+  for (let i = 1; i <= pdf.numPages; i++) {
+    const page = await pdf.getPage(i);
+    const textContent = await page.getTextContent();
+    const pageText = textContent.items
+      .map((item: Record<string, unknown>) =>
+        typeof item["str"] === "string" ? item["str"] : "",
+      )
+      .join(" ");
+    pages.push(pageText);
+  }
+  const full = pages.join("\n");
+  return full.length > MAX_CONTENT_CHARS ? full.slice(0, MAX_CONTENT_CHARS) : full;
+}
+
+/** Read a dropped or selected file into a workflow input field value string. */
+export async function readFileForInputField(file: File): Promise<InputFieldFileResult> {
+  const kind = detectKind(file);
+  if (!kind) {
+    throw new Error("Unsupported file type");
+  }
+
+  const maxBytes =
+    kind === "image" ? MAX_IMAGE_BYTES : kind === "pdf" ? MAX_PDF_BYTES : MAX_TEXT_BYTES;
+  if (file.size > maxBytes) {
+    const maxMb = maxBytes / (1024 * 1024);
+    throw new Error(`File too large (max ${maxMb} MB)`);
+  }
+
+  let content: string;
+  try {
+    if (kind === "image") {
+      content = await readFileAsDataURL(file);
+    } else if (kind === "pdf") {
+      content = await extractPdfText(file);
+    } else {
+      content = await readFileAsText(file);
+      if (content.length > MAX_CONTENT_CHARS) {
+        content = content.slice(0, MAX_CONTENT_CHARS);
+      }
+    }
+  } catch {
+    throw new Error(kind === "pdf" ? "Could not read PDF" : "Failed to read file");
+  }
+
+  return { content, name: file.name, kind };
+}
+
+export const INPUT_FIELD_FILE_ACCEPT =
+  ".txt,.md,.json,.csv,.py,.ts,.js,.html,.xml,.yaml,.yml,.log,.pdf,image/jpeg,image/png,image/gif,image/webp";

--- a/frontend/src/lib/markdownTaskList.ts
+++ b/frontend/src/lib/markdownTaskList.ts
@@ -78,3 +78,52 @@ export function toggleTaskItemLocal(markdown: string, lineIndex: number): string
   lines[lineIndex] = `${indent}${bullet} [${newCheck}] ${rest}`;
   return lines.join("\n");
 }
+
+export function updateTaskItemLocal(markdown: string, lineIndex: number, text: string): string {
+  const lines = markdown.split("\n");
+  const line = lines[lineIndex];
+  if (line === undefined) {
+    throw new Error(`Invalid line_index: ${lineIndex}`);
+  }
+  const match = TASK_ITEM_RE.exec(line);
+  if (!match) {
+    throw new Error(`Line ${lineIndex} is not a task list item`);
+  }
+  const indent = match[1] ?? "";
+  const bullet = match[2] ?? "-";
+  const check = match[3] ?? " ";
+  lines[lineIndex] = `${indent}${bullet} [${check}] ${text}`;
+  return lines.join("\n");
+}
+
+export function removeTaskItemLocal(markdown: string, lineIndex: number): string {
+  const lines = markdown.split("\n");
+  const line = lines[lineIndex];
+  if (line === undefined) {
+    throw new Error(`Invalid line_index: ${lineIndex}`);
+  }
+  if (!TASK_ITEM_RE.test(line)) {
+    throw new Error(`Line ${lineIndex} is not a task list item`);
+  }
+  lines.splice(lineIndex, 1);
+  if (
+    lineIndex < lines.length
+    && (lines[lineIndex] ?? "").trim() === ""
+    && lineIndex > 0
+    && (lines[lineIndex - 1] ?? "").trim() === ""
+  ) {
+    lines.splice(lineIndex, 1);
+  }
+  return lines.join("\n");
+}
+
+export function updateOrRemoveTaskItemLocal(
+  markdown: string,
+  lineIndex: number,
+  text: string,
+): string {
+  if (text.trim() === "") {
+    return removeTaskItemLocal(markdown, lineIndex);
+  }
+  return updateTaskItemLocal(markdown, lineIndex, text);
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1264,6 +1264,18 @@ export const dashboardApi = {
     return response.data;
   },
 
+  updateMarkdownTask: async (
+    id: string,
+    lineIndex: number,
+    text: string,
+  ): Promise<WidgetDataResponse> => {
+    const response = await api.patch<WidgetDataResponse>(
+      `/dashboards/widgets/${id}/markdown-task-update`,
+      { line_index: lineIndex, text },
+    );
+    return response.data;
+  },
+
   aiGenerateWidget: async (
     prompt: string,
     credentialId: string,


### PR DESCRIPTION
- Added `MarkdownTaskUpdateRequest` schema for updating task items.
- Introduced `_apply_markdown_text_to_widget` and `_validate_text_task_widget` functions to handle markdown task updates.
- Updated `toggle_markdown_task` and added `update_markdown_task` endpoint for modifying task items in markdown lists.
- Enhanced frontend components to support inline editing of task items and emit update events.
- Updated related tests to ensure proper functionality of the new task update feature.