### PR TITLE
[codex] Fix workflow creation transaction visibility

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1026,7 +1026,10 @@ async def create_workflow(
         edges=[],
     )
     db.add(workflow)
-    await db.flush()
+    # Commit (not just flush) before returning so the new row is durably visible
+    # to immediate follow-up requests (e.g. the import flow's create-then-update),
+    # which would otherwise race the get_db() teardown commit and 404 on the update.
+    await db.commit()
     await db.refresh(workflow)
     return _build_workflow_response(workflow)
 

--- a/backend/tests/test_workflow_create_commit.py
+++ b/backend/tests/test_workflow_create_commit.py
@@ -1,0 +1,47 @@
+import unittest
+import unittest.mock
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.api.workflows import create_workflow
+from app.models.schemas import WorkflowCreate
+
+
+class CreateWorkflowCommitTests(unittest.IsolatedAsyncioTestCase):
+    """Regression guard for the import flow's create-then-update race.
+
+    ``create_workflow`` must durably ``commit`` before returning, not merely
+    ``flush``. Otherwise a fast follow-up request (the JSON-import flow issues
+    create then immediately update) can start its transaction before the
+    ``get_db()`` teardown commit lands and 404 on the just-created workflow.
+    """
+
+    async def test_create_workflow_commits_before_returning(self) -> None:
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock(side_effect=lambda row: None)
+
+        current_user = SimpleNamespace(id=uuid.uuid4())
+
+        with unittest.mock.patch(
+            "app.api.workflows._build_workflow_response",
+            return_value="response-sentinel",
+        ):
+            result = await create_workflow(
+                workflow_data=WorkflowCreate(name="Imported Workflow"),
+                current_user=current_user,
+                db=db,
+            )
+
+        self.assertEqual(result, "response-sentinel")
+        db.add.assert_called_once()
+        # The durable commit is the fix for the race; a bare flush would not
+        # make the row visible to a concurrent follow-up request.
+        db.commit.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Commit a newly created workflow before returning it from the API.
- Add a regression test for the immediate create-then-update flow.

## Root cause
The JSON import flow creates a workflow and immediately updates it in a separate request. Returning after `flush()` left a window where the follow-up transaction could not see the new row and returned 404.

## Validation
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes uv run pytest tests/test_workflow_create_commit.py`
- `uv run ruff format --check app/api/workflows.py tests/test_workflow_create_commit.py`
- `uv run ruff check app/api/workflows.py tests/test_workflow_create_commit.py`
- `./run_e2e.sh` (21 passed)