### PR TITLE
[codex] Improve mobile dashboard controls

### DIFF
--- a/frontend/e2e/high-frequency-pages.spec.ts
+++ b/frontend/e2e/high-frequency-pages.spec.ts
@@ -104,6 +104,21 @@ test("Global Variables supports create and delete", async ({ page }) => {
   await expect(variableRow).toBeHidden();
 });
 
+test("Dashboard header stays within a mobile viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/?tab=dashboard");
+
+  const header = page.getByTestId("dashboard-header");
+  await expect(header.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  await expect(header.getByRole("button", { name: "Refresh dashboard" })).toBeVisible();
+  await expect(header.getByRole("button", { name: "Add widget" })).toBeVisible();
+
+  const hasHorizontalOverflow = await header.evaluate(
+    (element) => element.scrollWidth > element.clientWidth,
+  );
+  expect(hasHorizontalOverflow).toBe(false);
+});
+
 test("Drive opens and shows the empty state", async ({ page }) => {
   await page.goto("/?tab=drive");
   const main = page.getByRole("main");

--- a/frontend/src/components/Dashboards/DashboardsPanel.vue
+++ b/frontend/src/components/Dashboards/DashboardsPanel.vue
@@ -175,47 +175,75 @@ onMounted(() => {
 
 <template>
   <div class="flex h-full flex-col">
-    <div class="flex items-center justify-between border-b px-4 py-3">
-      <h1 class="text-lg font-semibold">
-        Dashboard
-      </h1>
-      <div class="flex items-center gap-2">
-        <DashboardAutoRefreshControl @refresh="refreshAll" />
+    <div
+      data-testid="dashboard-header"
+      class="flex flex-col gap-3 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+        <h1 class="shrink-0 text-lg font-semibold">
+          Dashboard
+        </h1>
+        <DashboardAutoRefreshControl
+          class="ml-auto sm:ml-0"
+          @refresh="refreshAll"
+        />
+      </div>
+      <div class="flex flex-wrap items-center gap-1 sm:gap-2">
         <Button
           variant="ghost"
           size="sm"
+          class="h-11 w-11 shrink-0 justify-center px-0 sm:h-auto sm:w-auto sm:px-3"
+          title="Refresh dashboard"
+          aria-label="Refresh dashboard"
           @click="refreshAll"
         >
-          <RefreshCw class="mr-1 h-4 w-4" /> Refresh
+          <RefreshCw class="h-4 w-4 sm:mr-1" />
+          <span class="hidden sm:inline">Refresh</span>
         </Button>
         <Button
           v-if="widgets.length > 0"
           variant="ghost"
           size="sm"
+          class="h-11 w-11 shrink-0 justify-center px-0 sm:h-auto sm:w-auto sm:px-3"
           title="Rearrange widgets into a random tidy grid"
+          aria-label="Tidy up dashboard"
           @click="tidyUp"
         >
-          <LayoutGrid class="mr-1 h-4 w-4" /> Tidy up
+          <LayoutGrid class="h-4 w-4 sm:mr-1" />
+          <span class="hidden sm:inline">Tidy up</span>
         </Button>
         <Button
           :variant="editMode ? 'default' : 'ghost'"
           size="sm"
+          class="h-11 w-11 shrink-0 justify-center px-0 sm:h-auto sm:w-auto sm:px-3"
+          :title="editMode ? 'Finish editing dashboard' : 'Edit dashboard'"
+          :aria-label="editMode ? 'Finish editing dashboard' : 'Edit dashboard'"
           @click="editMode = !editMode"
         >
-          <Pencil class="mr-1 h-4 w-4" /> {{ editMode ? "Done" : "Edit" }}
+          <Pencil class="h-4 w-4 sm:mr-1" />
+          <span class="hidden sm:inline">{{ editMode ? "Done" : "Edit" }}</span>
         </Button>
         <Button
           variant="ghost"
           size="sm"
+          class="h-11 w-11 shrink-0 justify-center px-0 sm:h-auto sm:w-auto sm:px-3"
+          title="Generate widget with AI"
+          aria-label="Generate widget with AI"
           @click="showAi = true"
         >
-          <Sparkles class="mr-1 h-4 w-4" /> AI
+          <Sparkles class="h-4 w-4 sm:mr-1" />
+          <span class="hidden sm:inline">AI</span>
         </Button>
         <Button
           size="sm"
+          class="h-11 min-w-[4.5rem] flex-1 justify-center px-2 sm:h-auto sm:min-w-0 sm:flex-none sm:px-3"
+          title="Add widget"
+          aria-label="Add widget"
           @click="showAdd = true"
         >
-          <Plus class="mr-1 h-4 w-4" /> Add widget
+          <Plus class="mr-1 h-4 w-4" />
+          <span class="sm:hidden">Add</span>
+          <span class="hidden sm:inline">Add widget</span>
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Reflow dashboard auto-refresh controls and actions for mobile viewports.
- Use compact accessible icon actions on mobile while preserving desktop labels.
- Add a 390px mobile overflow regression test.

## Validation
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh` (1394 backend tests passed)
- `./run_e2e.sh` (22 passed)