### PR TITLE
fix(editor): keep workflow name visible on small screens + responsive toolbar tooltips

### DIFF
--- a/frontend/e2e/tab-workflows.spec.ts
+++ b/frontend/e2e/tab-workflows.spec.ts
@@ -186,6 +186,44 @@ test("renders multiple connected nodes and persists the edge", async ({ page }) 
   await deleteWorkflow(page, workflow.id);
 });
 
+test("shows the workflow name without overflow on small screens", async ({ page }) => {
+  const longName = `Small Screen Workflow ${Date.now()} With A Very Long Name That Should Truncate`;
+  const workflow = await createWorkflow(page, longName);
+
+  try {
+    // Emulate a small / narrow viewport where the header has little horizontal room.
+    await page.setViewportSize({ width: 380, height: 720 });
+    await page.goto(`/workflows/${workflow.id}`);
+
+    const title = page.getByTestId("workflow-title");
+    // The name must remain visible on small screens, not hidden away.
+    await expect(title).toBeVisible();
+    await expect(title).toHaveText(longName);
+
+    // The title must stay within the viewport (truncated), never overflowing horizontally.
+    const box = await title.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.x).toBeGreaterThanOrEqual(0);
+    expect(box!.x + box!.width).toBeLessThanOrEqual(380);
+
+    // The element is actually clipped (truncated) rather than rendering its full width.
+    const overflow = await title.evaluate(
+      (el) => ({ scrollWidth: el.scrollWidth, clientWidth: el.clientWidth }),
+    );
+    expect(overflow.scrollWidth).toBeGreaterThan(overflow.clientWidth);
+
+    // Inline editing must not blow out the header width either.
+    await title.dispatchEvent("mousedown");
+    const titleInput = page.locator("[data-heym-inline-edit] input").first();
+    await expect(titleInput).toBeVisible();
+    const inputBox = await titleInput.boundingBox();
+    expect(inputBox).not.toBeNull();
+    expect(inputBox!.x + inputBox!.width).toBeLessThanOrEqual(380);
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});
+
 test("shows a failed workflow execution", async ({ page }) => {
   const workflow = await createWorkflow(page, `Failing Workflow ${Date.now()}`);
 

--- a/frontend/e2e/tab-workflows.spec.ts
+++ b/frontend/e2e/tab-workflows.spec.ts
@@ -224,6 +224,38 @@ test("shows the workflow name without overflow on small screens", async ({ page 
   }
 });
 
+test("collapses toolbar labels to icons when tight and keeps them when wide, with tooltips", async ({ page }) => {
+  const workflow = await createWorkflow(page, `Toolbar Workflow ${Date.now()}`);
+  const historyLabel = page
+    .locator("header.editor-header span")
+    .filter({ hasText: /^History$/ });
+
+  try {
+    // Wide screen that comfortably fits both the toolbar labels and the name:
+    // the text labels stay visible (nothing changes for screens that fit).
+    await page.setViewportSize({ width: 1700, height: 800 });
+    await page.goto(`/workflows/${workflow.id}`);
+    await expect(page.getByTestId("workflow-title")).toBeVisible();
+    await expect(historyLabel).toBeVisible();
+
+    // Tighter screen: the workflow name must still be fully visible, and the
+    // toolbar text labels collapse to icons to make room.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await expect(page.getByTestId("workflow-title")).toBeVisible();
+    await expect(historyLabel).toBeHidden();
+
+    // Hovering an icon-only button reveals its name in a tooltip popup.
+    const themeButton = page
+      .locator("header.editor-header button")
+      .filter({ has: page.locator("svg.lucide-sun, svg.lucide-moon") })
+      .first();
+    await themeButton.hover();
+    await expect(page.getByRole("tooltip")).toContainText(/mode/i);
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});
+
 test("shows a failed workflow execution", async ({ page }) => {
   const workflow = await createWorkflow(page, `Failing Workflow ${Date.now()}`);
 

--- a/frontend/src/components/ui/Tooltip.vue
+++ b/frontend/src/components/ui/Tooltip.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import {
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  TooltipProvider,
+  TooltipRoot,
+  TooltipTrigger,
+} from "radix-vue";
+
+interface Props {
+  label: string;
+  side?: "top" | "bottom" | "left" | "right";
+  disabled?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  side: "bottom",
+  disabled: false,
+});
+</script>
+
+<template>
+  <TooltipProvider :delay-duration="150">
+    <TooltipRoot>
+      <TooltipTrigger as-child>
+        <slot />
+      </TooltipTrigger>
+      <TooltipPortal>
+        <TooltipContent
+          v-if="!disabled && label"
+          :side="side"
+          :side-offset="6"
+          class="z-[200] select-none rounded-md border border-border/60 bg-popover px-2 py-1 text-xs font-medium text-popover-foreground shadow-md"
+        >
+          {{ label }}
+          <TooltipArrow class="fill-popover" />
+        </TooltipContent>
+      </TooltipPortal>
+    </TooltipRoot>
+  </TooltipProvider>
+</template>

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -1215,16 +1215,15 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
         </router-link>
         <div class="hidden sm:block w-px h-6 bg-border/50 shrink-0" />
         <div
-          class="hidden sm:block min-w-0"
+          class="min-w-0 flex-1"
           data-heym-inline-edit
         >
           <input
             v-if="isTitleEditing"
             ref="titleInputRef"
             v-model="editingTitleValue"
-            class="font-semibold text-sm md:text-base bg-transparent border-b border-primary outline-none"
+            class="w-full max-w-full min-w-0 font-semibold text-sm md:text-base bg-transparent border-b border-primary outline-none"
             maxlength="100"
-            :size="Math.max(12, editingTitleValue.length + 2)"
             @blur="commitTitleEdit"
             @keydown.enter.prevent="commitTitleEdit"
             @keydown.escape="cancelTitleEdit"
@@ -1232,7 +1231,8 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           <h1
             v-else
             data-testid="workflow-title"
-            class="font-semibold text-sm md:text-base truncate max-w-[120px] sm:max-w-[150px] md:max-w-[250px] cursor-text hover:bg-muted/50 rounded px-0.5 -mx-0.5"
+            class="block w-full font-semibold text-sm md:text-base truncate cursor-text hover:bg-muted/50 rounded px-0.5 -mx-0.5"
+            :title="workflowName"
             @mousedown.prevent="startTitleEdit"
           >
             {{ workflowName }}
@@ -1241,30 +1241,29 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             v-if="isDescriptionEditing"
             ref="descriptionInputRef"
             v-model="editingDescriptionValue"
-            class="text-xs text-muted-foreground bg-transparent border-b border-primary outline-none"
+            class="hidden sm:block w-full max-w-full min-w-0 text-xs text-muted-foreground bg-transparent border-b border-primary outline-none"
             maxlength="300"
             placeholder="Add description..."
-            :size="Math.max(16, editingDescriptionValue.length + 2)"
             @blur="commitDescriptionEdit"
             @keydown.enter.prevent="commitDescriptionEdit"
             @keydown.escape="cancelDescriptionEdit"
           >
           <p
             v-else-if="hasUnsavedChanges"
-            class="text-xs text-amber-500"
+            class="hidden sm:block text-xs text-amber-500"
           >
             Unsaved changes
           </p>
           <p
             v-else-if="workflowDescription"
-            class="text-xs text-muted-foreground truncate max-w-[120px] sm:max-w-[150px] md:max-w-[250px] cursor-text hover:bg-muted/50 rounded px-0.5 -mx-0.5"
+            class="hidden sm:block w-full text-xs text-muted-foreground truncate cursor-text hover:bg-muted/50 rounded px-0.5 -mx-0.5"
             @mousedown.prevent="startDescriptionEdit"
           >
             {{ workflowDescription }}
           </p>
           <p
             v-else
-            class="text-xs text-muted-foreground/40 truncate max-w-[120px] sm:max-w-[150px] md:max-w-[250px] cursor-text hover:bg-muted/50 rounded px-0.5 -mx-0.5"
+            class="hidden sm:block w-full text-xs text-muted-foreground/40 truncate cursor-text hover:bg-muted/50 rounded px-0.5 -mx-0.5"
             @mousedown.prevent="startDescriptionEdit"
           >
             Add description...

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -38,6 +38,7 @@ import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
 import Select from "@/components/ui/Select.vue";
 import Textarea from "@/components/ui/Textarea.vue";
+import Tooltip from "@/components/ui/Tooltip.vue";
 import { onDismissOverlays, pushOverlayState } from "@/composables/useOverlayBackHandler";
 import { getDocPath } from "@/docs/manifest";
 import { joinOriginAndPath } from "@/lib/appUrl";
@@ -1291,17 +1292,21 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
         >
           <Trash2 class="w-4 h-4" />
         </Button>
-        <Button
+        <Tooltip
           v-if="!isDashboardWidget"
-          variant="ghost"
-          size="sm"
-          class="hidden md:inline-flex gap-2 text-destructive hover:text-destructive"
-          :disabled="workflowStore.nodes.length === 0"
-          @click="workflowStore.clearCanvas()"
+          label="Clear"
         >
-          <Trash2 class="w-4 h-4" />
-          <span class="hidden lg:inline">Clear</span>
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden md:inline-flex gap-2 text-destructive hover:text-destructive"
+            :disabled="workflowStore.nodes.length === 0"
+            @click="workflowStore.clearCanvas()"
+          >
+            <Trash2 class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Clear</span>
+          </Button>
+        </Tooltip>
         <Button
           v-if="isDashboardWidget"
           variant="ghost"
@@ -1312,17 +1317,20 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
         >
           <ChevronLeft class="w-4 h-4" />
         </Button>
-        <Button
+        <Tooltip
           v-if="isDashboardWidget"
-          variant="ghost"
-          size="sm"
-          class="hidden md:inline-flex gap-2 text-foreground"
-          title="Back to Dashboard"
-          @click="returnToDashboard"
+          label="Back to Dashboard"
         >
-          <ChevronLeft class="w-4 h-4" />
-          <span class="hidden lg:inline">Dashboard</span>
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden md:inline-flex gap-2 text-foreground"
+            @click="returnToDashboard"
+          >
+            <ChevronLeft class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Dashboard</span>
+          </Button>
+        </Tooltip>
         <Button
           variant="ghost"
           size="icon"
@@ -1331,136 +1339,165 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
         >
           <History class="w-4 h-4" />
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          class="hidden md:inline-flex gap-2 text-foreground"
-          @click="historyOpen = true; pushOverlayState()"
-        >
-          <History class="w-4 h-4" />
-          <span class="hidden lg:inline">History</span>
-        </Button>
+        <Tooltip label="History">
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden md:inline-flex gap-2 text-foreground"
+            @click="historyOpen = true; pushOverlayState()"
+          >
+            <History class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">History</span>
+          </Button>
+        </Tooltip>
         <Button
           variant="ghost"
           size="icon"
-          class="h-11 w-11 min-h-[44px] min-w-[44px] md:hidden text-foreground"
+          class="h-11 w-11 min-h-[44px] min-w-[44px] hidden sm:flex md:hidden text-foreground"
           @click="editHistoryOpen = true; pushOverlayState()"
         >
           <GitBranch class="w-4 h-4" />
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          class="hidden md:inline-flex gap-2 text-foreground"
-          @click="editHistoryOpen = true; pushOverlayState()"
-        >
-          <GitBranch class="w-4 h-4" />
-          <span class="hidden lg:inline">Edit History</span>
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          class="hidden lg:inline-flex gap-2 text-foreground"
-          @click="downloadWorkflow"
-        >
-          <Download class="w-4 h-4" />
-          Download
-        </Button>
-        <Button
+        <Tooltip label="Edit History">
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden md:inline-flex gap-2 text-foreground"
+            @click="editHistoryOpen = true; pushOverlayState()"
+          >
+            <GitBranch class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Edit History</span>
+          </Button>
+        </Tooltip>
+        <Tooltip label="Download">
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden lg:inline-flex gap-2 text-foreground"
+            @click="downloadWorkflow"
+          >
+            <Download class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Download</span>
+          </Button>
+        </Tooltip>
+        <Tooltip
           v-if="isStandardWorkflow"
-          variant="ghost"
-          size="sm"
-          class="hidden lg:inline-flex gap-2 text-foreground"
-          @click="portalDialogRef?.openDialog(); pushOverlayState()"
+          label="Portal"
         >
-          <Globe class="w-4 h-4" />
-          Portal
-        </Button>
-        <Button
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden lg:inline-flex gap-2 text-foreground"
+            @click="portalDialogRef?.openDialog(); pushOverlayState()"
+          >
+            <Globe class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Portal</span>
+          </Button>
+        </Tooltip>
+        <Tooltip
           v-if="isStandardWorkflow"
-          variant="ghost"
-          size="sm"
-          class="hidden lg:inline-flex gap-2 text-foreground"
-          @click="shareOpen = true; pushOverlayState()"
+          label="Share"
         >
-          <Share2 class="w-4 h-4" />
-          Share
-        </Button>
-        <Button
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden lg:inline-flex gap-2 text-foreground"
+            @click="shareOpen = true; pushOverlayState()"
+          >
+            <Share2 class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Share</span>
+          </Button>
+        </Tooltip>
+        <Tooltip
           v-if="isStandardWorkflow"
-          variant="ghost"
-          size="sm"
-          class="hidden xl:inline-flex gap-2 text-foreground"
-          title="Save as reusable template"
-          @click="shareTemplateOpen = true"
+          label="Save as reusable template"
         >
-          <LayoutTemplate class="w-4 h-4" />
-          Template
-        </Button>
-        <Button
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden xl:inline-flex gap-2 text-foreground"
+            @click="shareTemplateOpen = true"
+          >
+            <LayoutTemplate class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Template</span>
+          </Button>
+        </Tooltip>
+        <Tooltip
           v-if="isStandardWorkflow"
-          variant="ghost"
-          size="sm"
-          class="hidden xl:inline-flex gap-2 text-foreground"
-          @click="curlOpen = true; pushOverlayState()"
+          label="cURL"
         >
-          <TerminalSquare class="w-4 h-4" />
-          cURL
-        </Button>
-        <Button
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden xl:inline-flex gap-2 text-foreground"
+            @click="curlOpen = true; pushOverlayState()"
+          >
+            <TerminalSquare class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">cURL</span>
+          </Button>
+        </Tooltip>
+        <Tooltip
           v-if="isStandardWorkflow"
-          variant="ghost"
-          size="sm"
-          class="hidden xl:inline-flex gap-2 text-foreground"
-          :class="{ 'text-primary': analysisPanelOpen }"
-          title="Analyze my workflow"
-          @click="toggleAnalysisPanel"
+          label="Analyze my workflow"
         >
-          <Sparkles class="w-4 h-4" />
-          Analyze
-        </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden xl:inline-flex gap-2 text-foreground"
+            :class="{ 'text-primary': analysisPanelOpen }"
+            @click="toggleAnalysisPanel"
+          >
+            <Sparkles class="w-4 h-4" />
+            <span class="hidden min-[1600px]:inline">Analyze</span>
+          </Button>
+        </Tooltip>
         <Button
           variant="ghost"
           size="icon"
-          class="h-11 w-11 min-h-[44px] min-w-[44px] md:hidden text-foreground"
+          class="h-11 w-11 min-h-[44px] min-w-[44px] hidden sm:flex md:hidden text-foreground"
           title="Page Guide"
           @click="toggleShowcaseGuide"
         >
           <Compass class="w-4 h-4 text-foreground" />
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          class="hidden xl:inline-flex gap-2 text-foreground"
-          @click="toggleShowcaseGuide"
-        >
-          <Compass class="w-4 h-4 text-foreground" />
-          Page Guide
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-9 md:w-9 text-foreground"
-          title="Search (Ctrl+K)"
-          @click="showCommandPalette = true; pushOverlayState()"
-        >
-          <Search class="w-4 h-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-9 md:w-9 text-foreground"
-          @click="themeStore.toggle"
-        >
-          <Sun
-            v-if="themeStore.isDark"
-            class="w-4 h-4"
-          />
-          <Moon
-            v-else
-            class="w-4 h-4"
-          />
-        </Button>
+        <Tooltip label="Page Guide">
+          <Button
+            variant="ghost"
+            size="sm"
+            class="hidden xl:inline-flex gap-2 text-foreground"
+            @click="toggleShowcaseGuide"
+          >
+            <Compass class="w-4 h-4 text-foreground" />
+            <span class="hidden min-[1600px]:inline">Page Guide</span>
+          </Button>
+        </Tooltip>
+        <Tooltip label="Search (Ctrl+K)">
+          <Button
+            variant="ghost"
+            size="icon"
+            class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-9 md:w-9 text-foreground"
+            @click="showCommandPalette = true; pushOverlayState()"
+          >
+            <Search class="w-4 h-4" />
+          </Button>
+        </Tooltip>
+        <Tooltip :label="themeStore.isDark ? 'Switch to light mode' : 'Switch to dark mode'">
+          <Button
+            variant="ghost"
+            size="icon"
+            class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-9 md:w-9 text-foreground"
+            @click="themeStore.toggle"
+          >
+            <Sun
+              v-if="themeStore.isDark"
+              class="w-4 h-4"
+            />
+            <Moon
+              v-else
+              class="w-4 h-4"
+            />
+          </Button>
+        </Tooltip>
         <Button
           variant="gradient"
           size="sm"

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -1287,6 +1287,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           variant="ghost"
           size="icon"
           class="md:hidden text-destructive hover:text-destructive h-11 w-11 min-h-[44px] min-w-[44px]"
+          aria-label="Clear"
           :disabled="workflowStore.nodes.length === 0"
           @click="workflowStore.clearCanvas()"
         >
@@ -1300,6 +1301,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden md:inline-flex gap-2 text-destructive hover:text-destructive"
+            aria-label="Clear"
             :disabled="workflowStore.nodes.length === 0"
             @click="workflowStore.clearCanvas()"
           >
@@ -1312,6 +1314,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           variant="ghost"
           size="icon"
           class="h-11 w-11 min-h-[44px] min-w-[44px] md:hidden text-foreground"
+          aria-label="Back to Dashboard"
           title="Back to Dashboard"
           @click="returnToDashboard"
         >
@@ -1325,6 +1328,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden md:inline-flex gap-2 text-foreground"
+            aria-label="Back to Dashboard"
             @click="returnToDashboard"
           >
             <ChevronLeft class="w-4 h-4" />
@@ -1335,6 +1339,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           variant="ghost"
           size="icon"
           class="h-11 w-11 min-h-[44px] min-w-[44px] md:hidden text-foreground"
+          aria-label="History"
           @click="historyOpen = true; pushOverlayState()"
         >
           <History class="w-4 h-4" />
@@ -1344,6 +1349,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden md:inline-flex gap-2 text-foreground"
+            aria-label="History"
             @click="historyOpen = true; pushOverlayState()"
           >
             <History class="w-4 h-4" />
@@ -1354,6 +1360,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           variant="ghost"
           size="icon"
           class="h-11 w-11 min-h-[44px] min-w-[44px] hidden sm:flex md:hidden text-foreground"
+          aria-label="Edit History"
           @click="editHistoryOpen = true; pushOverlayState()"
         >
           <GitBranch class="w-4 h-4" />
@@ -1363,6 +1370,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden md:inline-flex gap-2 text-foreground"
+            aria-label="Edit History"
             @click="editHistoryOpen = true; pushOverlayState()"
           >
             <GitBranch class="w-4 h-4" />
@@ -1374,6 +1382,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden lg:inline-flex gap-2 text-foreground"
+            aria-label="Download"
             @click="downloadWorkflow"
           >
             <Download class="w-4 h-4" />
@@ -1388,6 +1397,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden lg:inline-flex gap-2 text-foreground"
+            aria-label="Portal"
             @click="portalDialogRef?.openDialog(); pushOverlayState()"
           >
             <Globe class="w-4 h-4" />
@@ -1402,6 +1412,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden lg:inline-flex gap-2 text-foreground"
+            aria-label="Share"
             @click="shareOpen = true; pushOverlayState()"
           >
             <Share2 class="w-4 h-4" />
@@ -1416,6 +1427,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden xl:inline-flex gap-2 text-foreground"
+            aria-label="Template"
             @click="shareTemplateOpen = true"
           >
             <LayoutTemplate class="w-4 h-4" />
@@ -1430,6 +1442,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden xl:inline-flex gap-2 text-foreground"
+            aria-label="cURL"
             @click="curlOpen = true; pushOverlayState()"
           >
             <TerminalSquare class="w-4 h-4" />
@@ -1445,6 +1458,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             size="sm"
             class="hidden xl:inline-flex gap-2 text-foreground"
             :class="{ 'text-primary': analysisPanelOpen }"
+            aria-label="Analyze"
             @click="toggleAnalysisPanel"
           >
             <Sparkles class="w-4 h-4" />
@@ -1455,6 +1469,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           variant="ghost"
           size="icon"
           class="h-11 w-11 min-h-[44px] min-w-[44px] hidden sm:flex md:hidden text-foreground"
+          aria-label="Page Guide"
           title="Page Guide"
           @click="toggleShowcaseGuide"
         >
@@ -1465,6 +1480,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="sm"
             class="hidden xl:inline-flex gap-2 text-foreground"
+            aria-label="Page Guide"
             @click="toggleShowcaseGuide"
           >
             <Compass class="w-4 h-4 text-foreground" />
@@ -1476,6 +1492,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="icon"
             class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-9 md:w-9 text-foreground"
+            aria-label="Search (Ctrl+K)"
             @click="showCommandPalette = true; pushOverlayState()"
           >
             <Search class="w-4 h-4" />
@@ -1486,6 +1503,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
             variant="ghost"
             size="icon"
             class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-9 md:w-9 text-foreground"
+            :aria-label="themeStore.isDark ? 'Switch to light mode' : 'Switch to dark mode'"
             @click="themeStore.toggle"
           >
             <Sun
@@ -1505,6 +1523,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           :disabled="!hasUnsavedChanges"
           :loading="isSaving"
           class="hidden sm:inline-flex"
+          aria-label="Save"
           @click="handleSave"
         >
           <Save class="w-4 h-4" />
@@ -1516,6 +1535,7 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
           :disabled="!hasUnsavedChanges"
           :loading="isSaving"
           class="sm:hidden h-11 w-11 min-h-[44px] min-w-[44px]"
+          aria-label="Save"
           @click="handleSave"
         >
           <Save class="w-4 h-4" />


### PR DESCRIPTION
## Problem
On smaller / common laptop widths the editor's workflow name disappeared. Measured at 1433px: the action toolbar (full text labels for ~10 buttons) was **1273px wide**, leaving **0px** for the title — which then got clipped by the header's `overflow-x-hidden`. `flex-1` alone couldn't help because there was no leftover space to claim.

## Fix
- **Defer toolbar text labels to `min-[1600px]`** — screens that already fit (≥1600px) keep their labels exactly as before; below that the buttons collapse to icons so the name has room.
- **Reusable `Tooltip` component** (`ui/Tooltip.vue`, radix-vue, portal-based so it isn't clipped by the header overflow). The toolbar icon buttons are wrapped so hovering reveals each action's name.
- **Title** now uses `flex-1 min-w-0 truncate` (dropped the tiny fixed max-widths) and a `title` tooltip with the full name.
- **Phones**: hide the two secondary icon buttons (Edit History, Page Guide) below `sm` so the name stays visible (≈88px at 380px vs 0 before).
- Inline-edit `<input>` width capped so a long name can't overflow the header.

## Verification (live, measured across widths)
| width | name width | toolbar | result |
|------|-----------|---------|--------|
| 1700 | visible (265px) + **labels shown** | fits | wide screens unchanged ✓ |
| 1599 | 689px full | icons | name visible ✓ |
| 1433 | 523px full | icons | name visible, no clipping ✓ |
| 380  | 88px (truncated) | icons | name visible (was 0) ✓ |

Tooltip popups confirmed appearing on hover; no toolbar clipping at any width (Save always within viewport).

## Tests
Extended `frontend/e2e/tab-workflows.spec.ts`:
- `shows the workflow name without overflow on small screens` — name visible, within viewport, truncated; inline-edit input within bounds.
- `collapses toolbar labels to icons when tight and keeps them when wide, with tooltips` — labels visible at 1700px, hidden at 1280px, and a hover tooltip popup appears.

Run: `./run_e2e.sh tab-workflows.spec.ts`

## Checks
- `bun run typecheck` ✅
- `bun run lint` ✅
- E2E not run via the Docker harness locally (Docker daemon off), but behavior verified directly against the running dev app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)