### PR TITLE
[codex] fix MCP workflow tool calls

### DIFF
--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import secrets
 import uuid
+from collections.abc import AsyncGenerator
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, TypeVar
@@ -63,6 +64,7 @@ from app.services.workflow_executor import execute_workflow
 router = APIRouter()
 T = TypeVar("T")
 _MCP_PROTOCOL_SEMAPHORE = asyncio.Semaphore(max(1, settings.mcp_protocol_max_concurrency))
+_MCP_PROGRESS_INTERVAL_SECONDS = 30.0
 
 
 async def _run_mcp_protocol_limited(operation: Callable[[], Awaitable[T]]) -> T:
@@ -78,6 +80,196 @@ async def _run_mcp_protocol_limited(operation: Callable[[], Awaitable[T]]) -> T:
         return await operation()
     finally:
         _MCP_PROTOCOL_SEMAPHORE.release()
+
+
+def _sanitize_workflow_tool_name(name: str) -> str:
+    tool_name = name.lower().replace(" ", "_").replace("-", "_")
+    return "".join(c if c.isalnum() or c == "_" else "" for c in tool_name)
+
+
+def _mcp_tool_result_jsonrpc_response(
+    msg_id: int | str,
+    output_text: str,
+    *,
+    is_error: bool = False,
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {
+            "content": [{"type": "text", "text": output_text}],
+            "isError": is_error,
+        },
+    }
+
+
+def _mcp_jsonrpc_error_response(msg_id: int | str, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": -32603, "message": message},
+    }
+
+
+def _mcp_progress_token(msg: MCPJSONRPCRequest) -> str | int | None:
+    meta = msg.params.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    progress_token = meta.get("progressToken")
+    if isinstance(progress_token, bool):
+        return None
+    if isinstance(progress_token, (str, int)):
+        return progress_token
+    return None
+
+
+def _mcp_progress_notification(
+    progress_token: str | int,
+    sequence: int,
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "method": "notifications/progress",
+        "params": {
+            "progressToken": progress_token,
+            "progress": sequence,
+            "message": "Workflow is still running",
+        },
+    }
+
+
+def _is_mcp_tool_call_with_response(msg: MCPJSONRPCRequest) -> bool:
+    return msg.id is not None and msg.method == "tools/call"
+
+
+def _format_sse_jsonrpc_message(payload: dict[str, Any]) -> str:
+    return f"event: message\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+async def _run_mcp_operation_with_progress(
+    operation: Callable[[], Awaitable[dict[str, Any]]],
+    *,
+    progress_token: str | int | None,
+    send_progress: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+    send_heartbeat: Callable[[], Awaitable[None]] | None = None,
+) -> dict[str, Any]:
+    operation_task = asyncio.create_task(operation())
+    sequence = 0
+
+    if send_heartbeat is not None:
+        await send_heartbeat()
+    if progress_token is not None and send_progress is not None:
+        await send_progress(_mcp_progress_notification(progress_token, sequence))
+
+    try:
+        while True:
+            try:
+                return await asyncio.wait_for(
+                    asyncio.shield(operation_task),
+                    timeout=_MCP_PROGRESS_INTERVAL_SECONDS,
+                )
+            except TimeoutError:
+                sequence += 1
+                if send_heartbeat is not None:
+                    await send_heartbeat()
+                if progress_token is not None and send_progress is not None:
+                    await send_progress(_mcp_progress_notification(progress_token, sequence))
+    finally:
+        if not operation_task.done():
+            operation_task.cancel()
+
+
+async def _send_legacy_sse_jsonrpc_response(
+    *,
+    session_token: str,
+    msg: MCPJSONRPCRequest,
+    operation_factory: Callable[[AsyncSession], Awaitable[dict[str, Any]]],
+) -> None:
+    async def send_progress(payload: dict[str, Any]) -> None:
+        await mcp_sse_channels.send(session_token, json.dumps(payload, ensure_ascii=False))
+
+    async with async_session_maker() as bg_db:
+        try:
+            response = await _run_mcp_operation_with_progress(
+                lambda: operation_factory(bg_db),
+                progress_token=_mcp_progress_token(msg),
+                send_progress=send_progress,
+            )
+            await bg_db.commit()
+        except Exception as exc:
+            await bg_db.rollback()
+            if msg.id is None:
+                return
+            response = _mcp_jsonrpc_error_response(msg.id, f"Execution error: {exc}")
+
+    await mcp_sse_channels.send(session_token, json.dumps(response, ensure_ascii=False))
+
+
+def _schedule_legacy_sse_jsonrpc_response(
+    *,
+    session_token: str,
+    msg: MCPJSONRPCRequest,
+    operation_factory: Callable[[AsyncSession], Awaitable[dict[str, Any]]],
+) -> None:
+    asyncio.create_task(
+        _send_legacy_sse_jsonrpc_response(
+            session_token=session_token,
+            msg=msg,
+            operation_factory=operation_factory,
+        )
+    )
+
+
+def _stream_mcp_jsonrpc_response(
+    *,
+    msg: MCPJSONRPCRequest,
+    operation: Callable[[], Awaitable[dict[str, Any]]],
+) -> StreamingResponse:
+    async def event_generator() -> AsyncGenerator[str, None]:
+        queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+        async def send_progress(payload: dict[str, Any]) -> None:
+            await queue.put(_format_sse_jsonrpc_message(payload))
+
+        async def send_heartbeat() -> None:
+            await queue.put(": running\n\n")
+
+        async def worker() -> None:
+            try:
+                response = await _run_mcp_operation_with_progress(
+                    operation,
+                    progress_token=_mcp_progress_token(msg),
+                    send_progress=send_progress,
+                    send_heartbeat=send_heartbeat,
+                )
+            except Exception as exc:
+                if msg.id is None:
+                    response = {"jsonrpc": "2.0"}
+                else:
+                    response = _mcp_jsonrpc_error_response(msg.id, f"Execution error: {exc}")
+            await queue.put(_format_sse_jsonrpc_message(response))
+            await queue.put(None)
+
+        worker_task = asyncio.create_task(worker())
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    break
+                yield item
+        finally:
+            if not worker_task.done():
+                worker_task.cancel()
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 def _session_user_from_id(user_id_str: str) -> User:
@@ -265,12 +457,8 @@ def workflow_to_mcp_tool(workflow: Workflow) -> MCPTool:
         )
         required.append(field.key)
 
-    # Use workflow name directly, sanitized for MCP tool naming
-    tool_name = workflow.name.lower().replace(" ", "_").replace("-", "_")
-    tool_name = "".join(c if c.isalnum() or c == "_" else "" for c in tool_name)
-
     return MCPTool(
-        name=tool_name,
+        name=_sanitize_workflow_tool_name(workflow.name),
         description=workflow.description or f"Execute workflow: {workflow.name}",
         inputSchema=MCPToolInputSchema(
             type="object",
@@ -333,6 +521,65 @@ async def get_credentials_context_for_user(db: AsyncSession, user_id: uuid.UUID)
         except Exception:
             pass
     return context
+
+
+async def _mint_file_upload_tool_payload(
+    request: Request,
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    workflow: Workflow,
+    upload_node: dict[str, Any],
+) -> dict[str, Any]:
+    slot, token = await file_intake_service.mint_slot(
+        db,
+        workflow_id=workflow.id,
+        node=upload_node,
+        created_by_user_id=user_id,
+        mint_source="mcp",
+    )
+    await file_intake_service.write_audit(
+        db,
+        event="minted",
+        slot_id=slot.id,
+        workflow_id=workflow.id,
+        client_ip=None,
+        user_agent=request.headers.get("user-agent"),
+    )
+    await db.commit()
+    return file_intake_service.build_mint_payload(
+        base_url=build_public_base_url(request),
+        token=token,
+        expires_at_iso=slot.expires_at.isoformat(),
+        max_size_bytes=slot.max_size_bytes,
+        allowed_mime=slot.allowed_mime,
+        slot_id=str(slot.id),
+    )
+
+
+async def _maybe_mint_file_upload_jsonrpc_response(
+    request: Request,
+    db: AsyncSession,
+    *,
+    msg_id: int | str,
+    user_id: uuid.UUID,
+    workflow: Workflow,
+) -> dict[str, Any] | None:
+    upload_node = file_intake_service.find_file_upload_trigger(workflow.nodes)
+    if upload_node is None:
+        return None
+
+    mint_payload = await _mint_file_upload_tool_payload(
+        request,
+        db,
+        user_id=user_id,
+        workflow=workflow,
+        upload_node=upload_node,
+    )
+    return _mcp_tool_result_jsonrpc_response(
+        msg_id,
+        json.dumps(mint_payload, indent=2, ensure_ascii=False),
+    )
 
 
 def _json_compatible(value: Any) -> Any:
@@ -594,9 +841,7 @@ async def call_mcp_tool(
 
     for w in workflows:
         # Match by sanitized workflow name
-        w_tool_name = w.name.lower().replace(" ", "_").replace("-", "_")
-        w_tool_name = "".join(c if c.isalnum() or c == "_" else "" for c in w_tool_name)
-        if w_tool_name == tool_name:
+        if _sanitize_workflow_tool_name(w.name) == tool_name:
             target_workflow = w
             break
 
@@ -614,29 +859,12 @@ async def call_mcp_tool(
 
     upload_node = file_intake_service.find_file_upload_trigger(target_workflow.nodes)
     if upload_node is not None:
-        slot, token = await file_intake_service.mint_slot(
+        mint_payload = await _mint_file_upload_tool_payload(
+            request,
             db,
-            workflow_id=target_workflow.id,
-            node=upload_node,
-            created_by_user_id=mcp_user.id,
-            mint_source="mcp",
-        )
-        await file_intake_service.write_audit(
-            db,
-            event="minted",
-            slot_id=slot.id,
-            workflow_id=target_workflow.id,
-            client_ip=None,
-            user_agent=request.headers.get("user-agent"),
-        )
-        await db.commit()
-        mint_payload = file_intake_service.build_mint_payload(
-            base_url=build_public_base_url(request),
-            token=token,
-            expires_at_iso=slot.expires_at.isoformat(),
-            max_size_bytes=slot.max_size_bytes,
-            allowed_mime=slot.allowed_mime,
-            slot_id=str(slot.id),
+            user_id=mcp_user.id,
+            workflow=target_workflow,
+            upload_node=upload_node,
         )
         return MCPToolResult(content=[MCPTextContent(text=json.dumps(mint_payload, indent=2))])
 
@@ -792,9 +1020,7 @@ async def _dispatch_mcp_jsonrpc(
 
         for w in workflows:
             # Match by sanitized workflow name
-            w_tool_name = w.name.lower().replace(" ", "_").replace("-", "_")
-            w_tool_name = "".join(c if c.isalnum() or c == "_" else "" for c in w_tool_name)
-            if w_tool_name == tool_name:
+            if _sanitize_workflow_tool_name(w.name) == tool_name:
                 target_workflow = w
                 break
 
@@ -811,6 +1037,16 @@ async def _dispatch_mcp_jsonrpc(
                 "id": msg.id,
                 "error": {"code": -32602, "message": "Workflow has no nodes"},
             }
+
+        upload_response = await _maybe_mint_file_upload_jsonrpc_response(
+            request,
+            db,
+            msg_id=msg.id,
+            user_id=mcp_user.id,
+            workflow=target_workflow,
+        )
+        if upload_response is not None:
+            return upload_response
 
         enriched_inputs = {
             "headers": {},
@@ -892,14 +1128,11 @@ async def _dispatch_mcp_jsonrpc(
 
             output_text = json.dumps(execution_result.outputs, indent=2, ensure_ascii=False)
 
-            return {
-                "jsonrpc": "2.0",
-                "id": msg.id,
-                "result": {
-                    "content": [{"type": "text", "text": output_text}],
-                    "isError": execution_result.status == "error",
-                },
-            }
+            return _mcp_tool_result_jsonrpc_response(
+                msg.id,
+                output_text,
+                is_error=execution_result.status == "error",
+            )
         except Exception as e:
             _add_mcp_workflow_trace(
                 db,
@@ -932,6 +1165,19 @@ async def handle_mcp_message(
     db: AsyncSession = Depends(get_db),
 ) -> dict | Response:
     _reject_if_sse_channel_missing(request)
+    body = await request.json()
+    msg = MCPJSONRPCRequest(**body)
+    session_token = request.query_params.get("session")
+    if session_token and _is_mcp_tool_call_with_response(msg):
+        _schedule_legacy_sse_jsonrpc_response(
+            session_token=session_token,
+            msg=msg,
+            operation_factory=lambda bg_db: _run_mcp_protocol_limited(
+                lambda: _dispatch_mcp_jsonrpc(request=request, mcp_user=mcp_user, db=bg_db)
+            ),
+        )
+        return Response("Accepted", status_code=status.HTTP_202_ACCEPTED)
+
     response = await _run_mcp_protocol_limited(
         lambda: _dispatch_mcp_jsonrpc(request=request, mcp_user=mcp_user, db=db)
     )
@@ -939,12 +1185,22 @@ async def handle_mcp_message(
     return sse_response or response
 
 
-@router.post("/sse")
+@router.post("/sse", response_model=None)
 async def mcp_sse_post_endpoint(
     request: Request,
     mcp_user: User = Depends(get_mcp_user),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> dict | StreamingResponse:
+    body = await request.json()
+    msg = MCPJSONRPCRequest(**body)
+    if _is_mcp_tool_call_with_response(msg):
+        return _stream_mcp_jsonrpc_response(
+            msg=msg,
+            operation=lambda: _run_mcp_protocol_limited(
+                lambda: _dispatch_mcp_jsonrpc(request=request, mcp_user=mcp_user, db=db)
+            ),
+        )
+
     return await _run_mcp_protocol_limited(
         lambda: _dispatch_mcp_jsonrpc(request=request, mcp_user=mcp_user, db=db)
     )

--- a/backend/app/api/mcp_servers.py
+++ b/backend/app/api/mcp_servers.py
@@ -15,9 +15,14 @@ from app.api.deps import get_current_user
 from app.api.mcp import (
     _accept_sse_response_if_active,
     _add_mcp_workflow_trace,
+    _is_mcp_tool_call_with_response,
+    _maybe_mint_file_upload_jsonrpc_response,
+    _mcp_tool_result_jsonrpc_response,
     _reject_if_sse_channel_missing,
     _run_mcp_protocol_limited,
+    _schedule_legacy_sse_jsonrpc_response,
     _session_user_from_id,
+    _stream_mcp_jsonrpc_response,
     get_credentials_context_for_user,
     workflow_to_mcp_tool,
 )
@@ -380,14 +385,26 @@ async def named_server_sse(
     )
 
 
-@router.post("/{server_id}/sse")
+@router.post("/{server_id}/sse", response_model=None)
 async def named_server_sse_post(
     server_id: uuid.UUID,
     request: Request,
     server: tuple[User, MCPServer] = Depends(_get_named_server_context),
     db: AsyncSession = Depends(get_db),
-) -> dict:
+) -> dict | StreamingResponse:
     """Streamable HTTP transport (MCP 2025-03-26): POST directly to SSE endpoint."""
+    body = await request.json()
+    msg = MCPJSONRPCRequest(**body)
+    if _is_mcp_tool_call_with_response(msg):
+        return _stream_mcp_jsonrpc_response(
+            msg=msg,
+            operation=lambda: _run_mcp_protocol_limited(
+                lambda: _dispatch_named_server_jsonrpc(
+                    server_id=server_id, request=request, server=server, db=db
+                )
+            ),
+        )
+
     return await _run_mcp_protocol_limited(
         lambda: _dispatch_named_server_jsonrpc(
             server_id=server_id, request=request, server=server, db=db
@@ -448,6 +465,16 @@ async def _dispatch_named_server_jsonrpc(
                 "id": msg.id,
                 "error": {"code": -32602, "message": "Workflow has no nodes"},
             }
+
+        upload_response = await _maybe_mint_file_upload_jsonrpc_response(
+            request,
+            db,
+            msg_id=msg.id,
+            user_id=user.id,
+            workflow=target_workflow,
+        )
+        if upload_response is not None:
+            return upload_response
 
         enriched_inputs = {"headers": {}, "query": {}, "body": arguments}
         workflow_cache = await collect_referenced_workflows(
@@ -526,14 +553,11 @@ async def _dispatch_named_server_jsonrpc(
             await db.flush()
 
             output_text = json.dumps(execution_result.outputs, indent=2, ensure_ascii=False)
-            return {
-                "jsonrpc": "2.0",
-                "id": msg.id,
-                "result": {
-                    "content": [{"type": "text", "text": output_text}],
-                    "isError": execution_result.status == "error",
-                },
-            }
+            return _mcp_tool_result_jsonrpc_response(
+                msg.id,
+                output_text,
+                is_error=execution_result.status == "error",
+            )
         except Exception as e:
             _add_mcp_workflow_trace(
                 db,
@@ -571,6 +595,21 @@ async def handle_named_server_message(
     db: AsyncSession = Depends(get_db),
 ) -> dict | Response:
     _reject_if_sse_channel_missing(request)
+    body = await request.json()
+    msg = MCPJSONRPCRequest(**body)
+    session_token = request.query_params.get("session")
+    if session_token and _is_mcp_tool_call_with_response(msg):
+        _schedule_legacy_sse_jsonrpc_response(
+            session_token=session_token,
+            msg=msg,
+            operation_factory=lambda bg_db: _run_mcp_protocol_limited(
+                lambda: _dispatch_named_server_jsonrpc(
+                    server_id=server_id, request=request, server=server, db=bg_db
+                )
+            ),
+        )
+        return Response("Accepted", status_code=status.HTTP_202_ACCEPTED)
+
     response = await _run_mcp_protocol_limited(
         lambda: _dispatch_named_server_jsonrpc(
             server_id=server_id, request=request, server=server, db=db

--- a/backend/tests/test_mcp_jsonrpc_tool_calls.py
+++ b/backend/tests/test_mcp_jsonrpc_tool_calls.py
@@ -1,0 +1,242 @@
+import asyncio
+import json
+import unittest
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import Request
+
+from app.api.mcp import (
+    _dispatch_mcp_jsonrpc,
+    handle_mcp_message,
+    mcp_sse_post_endpoint,
+)
+from app.api.mcp_servers import _dispatch_named_server_jsonrpc
+from app.services.mcp_session import mcp_sse_channels
+
+
+def _make_json_request(path: str, body: dict, query_string: bytes = b"") -> Request:
+    async def receive() -> dict[str, object]:
+        return {
+            "type": "http.request",
+            "body": json.dumps(body).encode("utf-8"),
+            "more_body": False,
+        }
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [(b"origin", b"https://heym.run")],
+            "query_string": query_string,
+        },
+        receive,
+    )
+
+
+def _tool_call_body(
+    *,
+    name: str = "file_upload",
+    msg_id: int | str = 1,
+    progress_token: str | None = None,
+) -> dict:
+    params: dict[str, object] = {"name": name, "arguments": {}}
+    if progress_token is not None:
+        params["_meta"] = {"progressToken": progress_token}
+    return {"jsonrpc": "2.0", "id": msg_id, "method": "tools/call", "params": params}
+
+
+def _file_upload_workflow() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+        name="File Upload",
+        description="Upload a file",
+        nodes=[
+            {
+                "id": "upload1",
+                "type": "fileUploadTrigger",
+                "data": {
+                    "label": "fileUpload",
+                    "ttlMinutes": 60,
+                    "maxSizeMb": 100,
+                    "allowedTypes": "",
+                },
+            }
+        ],
+        edges=[],
+    )
+
+
+def _slot() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        expires_at=datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc),
+        max_size_bytes=100 * 1024 * 1024,
+        allowed_mime=[],
+    )
+
+
+class _FakeSessionContext:
+    def __init__(self) -> None:
+        self.session = AsyncMock()
+        self.session.commit = AsyncMock()
+        self.session.rollback = AsyncMock()
+
+    async def __aenter__(self) -> AsyncMock:
+        return self.session
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class MCPJsonRpcFileUploadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_default_jsonrpc_file_upload_mints_slot_instead_of_empty_file(self) -> None:
+        workflow = _file_upload_workflow()
+        user = SimpleNamespace(id=workflow.owner_id)
+        db = AsyncMock()
+        db.commit = AsyncMock()
+
+        with (
+            patch("app.api.mcp.get_user_mcp_workflows", AsyncMock(return_value=[workflow])),
+            patch(
+                "app.api.mcp.file_intake_service.mint_slot",
+                AsyncMock(return_value=(_slot(), "TOK")),
+            ),
+            patch("app.api.mcp.file_intake_service.write_audit", AsyncMock()),
+            patch("app.api.mcp.execute_workflow") as execute_mock,
+        ):
+            response = await _dispatch_mcp_jsonrpc(
+                request=_make_json_request("/api/mcp/sse", _tool_call_body()),
+                mcp_user=user,
+                db=db,
+            )
+
+        execute_mock.assert_not_called()
+        text = response["result"]["content"][0]["text"]
+        payload = json.loads(text)
+        self.assertEqual(payload["upload_url"], "https://heym.run/api/file-intake/u/TOK")
+        self.assertIn("curl", payload)
+        self.assertNotEqual(payload, {"fileUpload": {"file": {}, "uploaded_at": None}})
+
+    async def test_named_jsonrpc_file_upload_mints_slot_instead_of_empty_file(self) -> None:
+        workflow = _file_upload_workflow()
+        user = SimpleNamespace(id=workflow.owner_id)
+        server = SimpleNamespace(id=uuid.uuid4())
+        db = AsyncMock()
+        db.commit = AsyncMock()
+
+        with (
+            patch(
+                "app.api.mcp_servers._get_server_workflows",
+                AsyncMock(return_value=[workflow]),
+            ),
+            patch(
+                "app.api.mcp.file_intake_service.mint_slot",
+                AsyncMock(return_value=(_slot(), "TOK")),
+            ),
+            patch("app.api.mcp.file_intake_service.write_audit", AsyncMock()),
+            patch("app.api.mcp_servers.execute_workflow") as execute_mock,
+        ):
+            response = await _dispatch_named_server_jsonrpc(
+                server_id=server.id,
+                request=_make_json_request(
+                    f"/api/mcp/servers/{server.id}/sse",
+                    _tool_call_body(),
+                ),
+                server=(user, server),
+                db=db,
+            )
+
+        execute_mock.assert_not_called()
+        text = response["result"]["content"][0]["text"]
+        payload = json.loads(text)
+        self.assertEqual(payload["upload_url"], "https://heym.run/api/file-intake/u/TOK")
+        self.assertIn("curl", payload)
+        self.assertNotEqual(payload, {"fileUpload": {"file": {}, "uploaded_at": None}})
+
+
+class MCPJsonRpcProgressTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncTearDown(self) -> None:
+        mcp_sse_channels.unregister("progress-session")
+
+    async def test_legacy_sse_tool_call_returns_accepted_and_pushes_progress(self) -> None:
+        queue = mcp_sse_channels.register("progress-session")
+        done = asyncio.Event()
+
+        async def fake_dispatch(*_args: object, **_kwargs: object) -> dict:
+            await done.wait()
+            return {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"content": [{"type": "text", "text": "{}"}], "isError": False},
+            }
+
+        with (
+            patch("app.api.mcp._MCP_PROGRESS_INTERVAL_SECONDS", 0.01),
+            patch("app.api.mcp._dispatch_mcp_jsonrpc", AsyncMock(side_effect=fake_dispatch)),
+            patch("app.api.mcp.async_session_maker", MagicMock(return_value=_FakeSessionContext())),
+        ):
+            response = await handle_mcp_message(
+                request=_make_json_request(
+                    "/api/mcp/message",
+                    _tool_call_body(progress_token="progress-1"),
+                    b"session=progress-session",
+                ),
+                mcp_user=SimpleNamespace(id=uuid.uuid4()),
+                db=AsyncMock(),
+            )
+
+            self.assertEqual(response.status_code, 202)
+            progress = json.loads(await asyncio.wait_for(queue.get(), timeout=0.2))
+            self.assertEqual(progress["method"], "notifications/progress")
+            self.assertEqual(progress["params"]["progressToken"], "progress-1")
+
+            done.set()
+            final = json.loads(await asyncio.wait_for(queue.get(), timeout=0.2))
+            self.assertEqual(final["id"], 1)
+            self.assertFalse(final["result"]["isError"])
+
+    async def test_streamable_http_tool_call_streams_heartbeat_progress_and_final(self) -> None:
+        done = asyncio.Event()
+
+        async def fake_dispatch(*_args: object, **_kwargs: object) -> dict:
+            await done.wait()
+            return {
+                "jsonrpc": "2.0",
+                "id": "call-1",
+                "result": {"content": [{"type": "text", "text": "{}"}], "isError": False},
+            }
+
+        with (
+            patch("app.api.mcp._MCP_PROGRESS_INTERVAL_SECONDS", 0.01),
+            patch("app.api.mcp._dispatch_mcp_jsonrpc", AsyncMock(side_effect=fake_dispatch)),
+        ):
+            response = await mcp_sse_post_endpoint(
+                request=_make_json_request(
+                    "/api/mcp/sse",
+                    _tool_call_body(msg_id="call-1", progress_token="progress-2"),
+                ),
+                mcp_user=SimpleNamespace(id=uuid.uuid4()),
+                db=AsyncMock(),
+            )
+
+            body_iterator = response.body_iterator
+            first_chunk = await asyncio.wait_for(body_iterator.__anext__(), timeout=0.2)
+            second_chunk = await asyncio.wait_for(body_iterator.__anext__(), timeout=0.2)
+            self.assertEqual(first_chunk, ": running\n\n")
+            self.assertIn("notifications/progress", second_chunk)
+
+            done.set()
+            chunks: list[str] = []
+            for _ in range(5):
+                chunk = await asyncio.wait_for(body_iterator.__anext__(), timeout=0.2)
+                chunks.append(chunk)
+                if '"id": "call-1"' in chunk:
+                    break
+            await body_iterator.aclose()
+
+        self.assertTrue(any('"id": "call-1"' in chunk for chunk in chunks))

--- a/backend/tests/test_mcp_jsonrpc_tool_calls.py
+++ b/backend/tests/test_mcp_jsonrpc_tool_calls.py
@@ -196,7 +196,14 @@ class MCPJsonRpcProgressTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(progress["params"]["progressToken"], "progress-1")
 
             done.set()
-            final = json.loads(await asyncio.wait_for(queue.get(), timeout=0.2))
+            final: dict | None = None
+            for _ in range(5):
+                payload = json.loads(await asyncio.wait_for(queue.get(), timeout=0.2))
+                if payload.get("id") == 1:
+                    final = payload
+                    break
+
+            self.assertIsNotNone(final)
             self.assertEqual(final["id"], 1)
             self.assertFalse(final["result"]["isError"])
 


### PR DESCRIPTION
## What changed

- JSON-RPC MCP `tools/call` now treats `fileUploadTrigger` workflows like the REST MCP tool path: it mints an upload slot and returns the upload payload instead of executing the workflow with empty trigger input.
- Legacy SSE `tools/call` requests now return `202 Accepted` immediately and deliver the final JSON-RPC response through the SSE channel.
- Long-running MCP tool calls now emit periodic progress updates when the client provides `_meta.progressToken`; Streamable HTTP tool calls also stream SSE heartbeat comments so clients receive bytes while the workflow is running.
- Added backend coverage for default and named MCP servers, file upload JSON-RPC calls, legacy SSE progress, and Streamable HTTP progress/final responses.

## Why

The JSON-RPC path skipped the existing file-upload special case and executed file upload workflows without uploaded file input, producing `{ "fileUpload": { "file": {}, "uploaded_at": null } }`.

Long-running workflow calls also held the MCP POST open until completion, so clients with first-byte or idle timeouts could disconnect before Heym returned the tool result.

## Validation

- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes uv run pytest tests/test_mcp_jsonrpc_tool_calls.py tests/test_mcp_servers.py tests/test_mcp_origin_mismatch.py`
- `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh`