### PR TITLE
[codex] Improve README onboarding and feature showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,20 @@
 ### AI-Native Workflow Automation Platform
 
 <p align="center">
-  <strong>Build, visualize, and run intelligent AI workflows — without writing code.</strong><br/>
+  <strong>Build, visualize, and run intelligent AI workflows without writing code.</strong><br/>
   Drag-and-drop canvas · LLM & Agent nodes · RAG pipelines · Multi-agent orchestration · MCP support
 </p>
 
 <p align="center">
   <a href="https://heym.run">heym.run</a>
+</p>
+
+<p align="center">
+  <strong>Try locally:</strong> <code>git clone https://github.com/heymrun/heym.git && cd heym && ./run.sh</code><br/>
+  <a href="#-quick-start">Quick Start</a> ·
+  <a href="#deploy--call-workflows">Deploy & Call Workflows</a> ·
+  <a href="#extending-heym">Extending Heym</a> ·
+  <a href="SECURITY.md">Security</a>
 </p>
 
 <br/>
@@ -28,6 +36,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-Strict-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://typescriptlang.org)
 [![Bun](https://img.shields.io/badge/Bun-runtime-14151A?style=flat-square&logo=bun&logoColor=white)](https://bun.sh)
 [![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker&logoColor=white)](https://docker.com)
+[![Security](https://img.shields.io/badge/Security-policy-2A6F97?style=flat-square)](SECURITY.md)
 
 <br/>
 
@@ -46,6 +55,12 @@ Heym is an **AI-native automation platform** built from the ground up around LLM
 Unlike platforms that started as classic trigger-action automation and layered AI on later, in Heym **AI is the execution model**.
 
 Explore the product site at **[heym.run](https://heym.run)**.
+
+## Build, Observe, Call
+
+| Build | Observe | Call |
+|-------|---------|------|
+| Create workflows from a visual canvas, natural language, voice, templates, or Agent skills. | Inspect executions with run history, LLM traces, evals, logs, OpenTelemetry export, and real USD cost tracking. | Invoke the same workflow from the canvas, REST execution endpoints, SSE streaming, MCP clients, or a public Portal chat UI. |
 
 <div align="center">
 
@@ -301,6 +316,14 @@ Open the editor in your browser at port `4017` in either setup.
 For direct `docker run` setups, the `data/files` mount keeps Drive uploads and skill-generated files available across container restarts.
 The Docker socket mount supports Docker-based MCP stdio tools and grants broad host control. Docker log access remains disabled unless you also set `DOCKER_LOGS_ENABLED=true` and `DOCKER_LOGS_ALLOWED_EMAILS=admin@example.com` for trusted users. Create the trusted admin account before enabling Docker logs, or keep `ALLOW_REGISTER=false`, so an unverified self-registration cannot claim an allow-listed email.
 
+## Deploy & Call Workflows
+
+Heym workflows are not limited to the editor. Run them from the canvas, call them through `/execute`, stream progress through `/execute/stream`, expose them as MCP tools at `/api/mcp/sse`, or publish them as Portal chat apps at `/chat/{slug}`. The same workflow can serve people, backend services, and AI clients without rebuilding the automation.
+
+## Production Readiness
+
+Heym is built to be inspected and operated in your own infrastructure. Docker deployment, JWT auth, team controls, shared credentials, `SECURITY.md`, execution history, logs, LLM traces, OpenTelemetry export, evals, and per-model USD cost tracking all live in the core self-hostable product.
+
 <details>
 <summary><b>🐳 Docker Production Deployment</b></summary>
 
@@ -408,6 +431,19 @@ cp .env.example .env
 | **Integrations** | HTTP, Slack, Send Email, Redis, RabbitMQ Send, Grist, Drive.. |
 | **Automation** | Crawler, Playwright |
 | **Utilities** | Wait, Output, Console Log, Throw Error, Disable Node, Sticky Note |
+
+---
+
+## Extending Heym
+
+Extend Heym at the layer that matches the job. Add first-class canvas behavior with custom nodes, give agents portable capabilities with skills, connect outside tools through MCP, or expose a finished workflow as a callable tool for other apps and AI clients.
+
+| Extension path | Best for | How it works |
+|----------------|----------|--------------|
+| Custom nodes | Product-grade workflow steps and integrations | Add a typed node with editor configuration, execution behavior, and schema metadata. |
+| Agent skills | Portable agent abilities | Attach a `SKILL.md` file and optional Python tools to Agent nodes, or generate them with AI Build. |
+| MCP | External tools and AI clients | Agent nodes consume MCP servers, and Heym workflows can be exposed as MCP tools. |
+| Workflow as tool | Reusable automations | Call workflows through REST, SSE, Portal chat, or MCP without duplicating the logic. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,6 @@ The demos below illustrate an **agent–subagent** layout instead of a purely st
 
 You can still answer with **two separate LLM calls** (one per question) or run **several calls in sequence** and merge the results in a final step—those patterns work—but for this kind of multi-part ask they are usually **slower** than parallel subagents behind an orchestrator.
 
-### Watch Heym Tutorials
-
-<div align="center">
-
-<a href="https://www.youtube.com/playlist?list=PLPXd_ZbA4wgEHP5PXoaRqbsDJdat7OSd4">
-  <img src="./docs/readme-assets/tutorial-videos-playlist.png" width="100%" alt="Watch Heym tutorial videos on YouTube"/>
-</a>
-
-</div>
-
 ### Generate Workflows from Natural Language
 
 Describe the agents, orchestration pattern, and user-facing result you want; Heym builds the workflow on the canvas.
@@ -159,7 +149,7 @@ Turn a workflow into a chat experience so users can invoke the orchestration wit
 
 </div>
 
-- **Visual Workflow Editor** — Drag-and-drop canvas powered by Vue Flow with 30+ node types
+- **Visual Workflow Editor** — Drag-and-drop canvas powered by Vue Flow with a broad node library
 - **AI Assistant** — Describe what you want in natural language (or voice) and the assistant generates and wires nodes on the canvas automatically
 - **Chat with Docs** — Ask context-aware questions directly from the documentation header while the current article path is prioritized in the prompt
 - **AI Skill Builder** — Create new Agent skills or revise existing ones from a modal chat with live `SKILL.md` and Python file previews
@@ -407,7 +397,7 @@ cp .env.example .env
 
 ## 🧩 Node Library
 
-**30+ nodes** across six categories:
+**A broad node library** across workflow categories:
 
 | Category | Nodes |
 |----------|-------|
@@ -635,6 +625,18 @@ cd backend  && uv run ruff check . && uv run ruff format .
 This project is licensed under the **[MIT License](LICENSE)** with the **[Commons Clause](COMMONS-CLAUSE.md)** condition applied. In other words, Heym is **source-available** rather than OSI-open-source. See both files for details.
 
 **TL;DR:** You are free to use, modify, distribute, and self-host this software — but you may **not sell** it or offer it as a paid service. Commercial licensing is available for teams that need those rights.
+
+---
+
+## Watch Heym Tutorials
+
+<div align="center">
+
+<a href="https://www.youtube.com/playlist?list=PLPXd_ZbA4wgEHP5PXoaRqbsDJdat7OSd4">
+  <img src="./docs/readme-assets/tutorial-videos-playlist.png" width="100%" alt="Watch Heym tutorial videos on YouTube"/>
+</a>
+
+</div>
 
 ---
 

--- a/docs/readme-assets/full-feature-showcase.svg
+++ b/docs/readme-assets/full-feature-showcase.svg
@@ -4,23 +4,26 @@
     <style>
       .ff-orb-a { animation: ffOrbA 7s ease-in-out infinite; transform-origin: 200px 140px; }
       .ff-orb-b { animation: ffOrbB 8s ease-in-out infinite; transform-origin: 1080px 580px; }
-      .ff-progress { animation: ffProgress 80s linear infinite; }
-      .ff-scene { opacity: 0; animation: ffScene 80s linear infinite both; }
-      .ff-scene.s02 { animation-delay: -75s; }
-      .ff-scene.s03 { animation-delay: -70s; }
-      .ff-scene.s04 { animation-delay: -65s; }
-      .ff-scene.s05 { animation-delay: -60s; }
-      .ff-scene.s06 { animation-delay: -55s; }
-      .ff-scene.s07 { animation-delay: -50s; }
-      .ff-scene.s08 { animation-delay: -45s; }
-      .ff-scene.s09 { animation-delay: -40s; }
-      .ff-scene.s10 { animation-delay: -35s; }
-      .ff-scene.s11 { animation-delay: -30s; }
-      .ff-scene.s12 { animation-delay: -25s; }
-      .ff-scene.s13 { animation-delay: -20s; }
-      .ff-scene.s14 { animation-delay: -15s; }
-      .ff-scene.s15 { animation-delay: -10s; }
-      .ff-scene.s16 { animation-delay: -5s; }
+      .ff-progress { animation: ffProgress 95s linear infinite; }
+      .ff-scene { opacity: 0; animation: ffScene 95s linear infinite both; }
+      .ff-scene.s02 { animation-delay: -90s; }
+      .ff-scene.s03 { animation-delay: -85s; }
+      .ff-scene.s04 { animation-delay: -80s; }
+      .ff-scene.s05 { animation-delay: -75s; }
+      .ff-scene.s06 { animation-delay: -70s; }
+      .ff-scene.s07 { animation-delay: -65s; }
+      .ff-scene.s08 { animation-delay: -60s; }
+      .ff-scene.s09 { animation-delay: -55s; }
+      .ff-scene.s10 { animation-delay: -50s; }
+      .ff-scene.s11 { animation-delay: -45s; }
+      .ff-scene.s12 { animation-delay: -40s; }
+      .ff-scene.s13 { animation-delay: -35s; }
+      .ff-scene.s14 { animation-delay: -30s; }
+      .ff-scene.s15 { animation-delay: -25s; }
+      .ff-scene.s16 { animation-delay: -20s; }
+      .ff-scene.s17 { animation-delay: -15s; }
+      .ff-scene.s18 { animation-delay: -10s; }
+      .ff-scene.s19 { animation-delay: -5s; }
       .ff-flow { stroke-dasharray: 8 8; animation: ffDash 1.6s linear infinite; }
       .ff-blink { animation: ffBlink 1s steps(2, jump-none) infinite; }
       .ff-wave { animation: ffWave 1.2s ease-in-out infinite; }
@@ -42,9 +45,9 @@
       .ff-logo-tile { transform-origin: center; animation: ffLogoGlow 2.8s ease-in-out infinite; }
       .ff-logo-mark { stroke-dasharray: 10 6; animation: ffLogoDash 2.4s linear infinite; }
       @keyframes ffScene {
-        0%, 5.2% { opacity: 1; transform: translateY(0); }
-        6.25% { opacity: 0; transform: translateY(10px); }
-        6.26%, 100% { opacity: 0; transform: translateY(10px); }
+        0%, 4.6% { opacity: 1; transform: translateY(0); }
+        5.263% { opacity: 0; transform: translateY(10px); }
+        5.264%, 100% { opacity: 0; transform: translateY(10px); }
       }
       @keyframes ffProgress {
         0% { width: 0; fill: #A78BFA; }
@@ -124,7 +127,7 @@
 
   
   <g transform="translate(64,56)">
-    <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#6B7280" letter-spacing="3">FULL FEATURE SET · 16 PRIMITIVES</text>
+    <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#6B7280" letter-spacing="3">FULL FEATURE SET · CORE PRIMITIVES</text>
     <text y="36" font-size="32" font-weight="800" fill="url(#ff-title-grad)" letter-spacing="-1">Heym is a true AI-native workflow automation platform</text>
   </g>
   <g transform="translate(1146,44) scale(1.75)">
@@ -139,20 +142,23 @@
     
     <g fill="#374151">
       <circle cx="0" cy="1.5" r="3"></circle>
-      <circle cx="76.8" cy="1.5" r="3"></circle>
-      <circle cx="153.6" cy="1.5" r="3"></circle>
-      <circle cx="230.4" cy="1.5" r="3"></circle>
-      <circle cx="307.2" cy="1.5" r="3"></circle>
+      <circle cx="64" cy="1.5" r="3"></circle>
+      <circle cx="128" cy="1.5" r="3"></circle>
+      <circle cx="192" cy="1.5" r="3"></circle>
+      <circle cx="256" cy="1.5" r="3"></circle>
+      <circle cx="320" cy="1.5" r="3"></circle>
       <circle cx="384" cy="1.5" r="3"></circle>
-      <circle cx="460.8" cy="1.5" r="3"></circle>
-      <circle cx="537.6" cy="1.5" r="3"></circle>
-      <circle cx="614.4" cy="1.5" r="3"></circle>
-      <circle cx="691.2" cy="1.5" r="3"></circle>
+      <circle cx="448" cy="1.5" r="3"></circle>
+      <circle cx="512" cy="1.5" r="3"></circle>
+      <circle cx="576" cy="1.5" r="3"></circle>
+      <circle cx="640" cy="1.5" r="3"></circle>
+      <circle cx="704" cy="1.5" r="3"></circle>
       <circle cx="768" cy="1.5" r="3"></circle>
-      <circle cx="844.8" cy="1.5" r="3"></circle>
-      <circle cx="921.6" cy="1.5" r="3"></circle>
-      <circle cx="998.4" cy="1.5" r="3"></circle>
-      <circle cx="1075.2" cy="1.5" r="3"></circle>
+      <circle cx="832" cy="1.5" r="3"></circle>
+      <circle cx="896" cy="1.5" r="3"></circle>
+      <circle cx="960" cy="1.5" r="3"></circle>
+      <circle cx="1024" cy="1.5" r="3"></circle>
+      <circle cx="1088" cy="1.5" r="3"></circle>
       <circle cx="1152" cy="1.5" r="3"></circle>
     </g>
   </g>
@@ -165,7 +171,7 @@
       <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#7C3AED" letter-spacing="2">01 · VISUAL WORKFLOW EDITOR</text>
       <text y="64" font-size="64" font-weight="800" fill="#F3F4F6" letter-spacing="-2">Drag. Drop.</text>
       <text y="124" font-size="64" font-weight="800" fill="#A78BFA" letter-spacing="-2">It runs.</text>
-      <text y="172" font-size="16" fill="#9CA3AF">A visual canvas with 30+ node types — wire intent into execution.</text>
+      <text y="172" font-size="16" fill="#9CA3AF">A visual canvas with a broad node library — wire intent into execution.</text>
 
       
       <g transform="translate(640,30)">
@@ -487,7 +493,7 @@
       <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#22D3EE" letter-spacing="2">09 · BUILT-IN RAG</text>
       <text y="64" font-size="64" font-weight="800" fill="#F3F4F6" letter-spacing="-2">Drop docs.</text>
       <text y="124" font-size="64" font-weight="800" fill="#22D3EE" letter-spacing="-2">Search them.</text>
-      <text y="172" font-size="16" fill="#9CA3AF">Insert + semantic search on managed QDrant — two nodes, no glue code.</text>
+      <text y="172" font-size="16" fill="#9CA3AF">Insert + semantic search on Qdrant or psql — two nodes, no glue code.</text>
 
       <g transform="translate(660,40)">
         
@@ -500,7 +506,7 @@
           <ellipse cx="60" cy="0" rx="60" ry="14" fill="#0F1320" stroke="#22D3EE"></ellipse>
           <path d="M 0 0 L 0 80 C 0 90, 30 96, 60 96 C 90 96, 120 90, 120 80 L 120 0" fill="#0F1320" stroke="#22D3EE"></path>
           <ellipse cx="60" cy="40" rx="60" ry="14" fill="none" stroke="#22D3EE" stroke-opacity="0.4"></ellipse>
-          <text x="60" y="45" text-anchor="middle" font-size="11" fill="#22D3EE" font-family="&#39;JetBrains Mono&#39;,monospace">Qdrant</text>
+          <text x="60" y="45" text-anchor="middle" font-size="10.5" fill="#22D3EE" font-family="&#39;JetBrains Mono&#39;,monospace">Qdrant + psql</text>
         </g>
         
         <g transform="translate(340,80)">
@@ -539,19 +545,19 @@
           <g transform="translate(0,140)"><rect width="120" height="32" rx="8" fill="#0A0E1A" stroke="#22D3EE"></rect><text x="60" y="20" text-anchor="middle" fill="#22D3EE">stripe mcp</text></g>
         </g>
         
-        <g font-family="&#39;JetBrains Mono&#39;,monospace" font-size="11">
-          <g transform="translate(320,40)"><rect width="120" height="32" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect><text x="60" y="20" text-anchor="middle" fill="#10D9A0">claude desktop</text></g>
-          <g transform="translate(320,90)"><rect width="120" height="32" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect><text x="60" y="20" text-anchor="middle" fill="#10D9A0">cursor</text></g>
-          <g transform="translate(320,140)"><rect width="120" height="32" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect><text x="60" y="20" text-anchor="middle" fill="#10D9A0">your client</text></g>
+        <g font-family="&#39;JetBrains Mono&#39;,monospace" font-size="10">
+          <g transform="translate(300,40)"><rect width="160" height="32" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect><text x="80" y="20" text-anchor="middle" fill="#10D9A0">claude connector</text></g>
+          <g transform="translate(300,90)"><rect width="160" height="32" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect><text x="80" y="20" text-anchor="middle" fill="#10D9A0">cursor</text></g>
+          <g transform="translate(300,140)"><rect width="160" height="32" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect><text x="80" y="20" text-anchor="middle" fill="#10D9A0">chatgpt connector</text></g>
         </g>
         
         <g fill="none" stroke-width="1.5">
           <path d="M 120 56 L 160 130" stroke="#22D3EE" class="ff-flow"></path>
           <path d="M 120 106 L 160 140" stroke="#22D3EE" class="ff-flow"></path>
           <path d="M 120 156 L 160 150" stroke="#22D3EE" class="ff-flow"></path>
-          <path d="M 280 130 L 320 56" stroke="#10D9A0" class="ff-flow"></path>
-          <path d="M 280 140 L 320 106" stroke="#10D9A0" class="ff-flow"></path>
-          <path d="M 280 150 L 320 156" stroke="#10D9A0" class="ff-flow"></path>
+          <path d="M 280 130 L 300 56" stroke="#10D9A0" class="ff-flow"></path>
+          <path d="M 280 140 L 300 106" stroke="#10D9A0" class="ff-flow"></path>
+          <path d="M 280 150 L 300 156" stroke="#10D9A0" class="ff-flow"></path>
         </g>
         <text x="60" y="200" text-anchor="middle" font-size="10" fill="#22D3EE" font-family="&#39;JetBrains Mono&#39;,monospace">CLIENT MODE</text>
         <text x="380" y="200" text-anchor="middle" font-size="10" fill="#10D9A0" font-family="&#39;JetBrains Mono&#39;,monospace">SERVER MODE</text>
@@ -805,6 +811,155 @@
             <text y="48" fill="#9CA3AF">▸ new credential</text>
             <text y="72" fill="#9CA3AF">▸ go to evals</text>
           </g>
+        </g>
+      </g>
+    </g>
+
+
+    <g class="ff-scene s17">
+      <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#F59E0B" letter-spacing="2">17 · WORKFLOW ANALYZER</text>
+      <text y="64" font-size="64" font-weight="800" fill="#F3F4F6" letter-spacing="-2">Runs become</text>
+      <text y="124" font-size="64" font-weight="800" fill="#F59E0B" letter-spacing="-2">review notes.</text>
+      <text y="172" font-size="16" fill="#9CA3AF">Run-aware AI feedback writes purpose, step behavior, and improvement areas.</text>
+
+      <g transform="translate(660,30)">
+        <rect width="500" height="320" rx="14" fill="#0F1320" stroke="#1F2937"></rect>
+        <rect width="500" height="36" rx="14" fill="#151B2E"></rect>
+        <rect y="20" width="500" height="16" fill="#151B2E"></rect>
+        <text x="20" y="23" font-size="11" fill="#F59E0B" font-family="&#39;JetBrains Mono&#39;,monospace">workflow-analysis.md</text>
+        <circle cx="470" cy="18" r="5" fill="#F59E0B" class="ff-pulse"></circle>
+
+        <g transform="translate(22,60)" font-family="&#39;JetBrains Mono&#39;,monospace">
+          <text font-size="10" fill="#6B7280">RUN CONTEXT</text>
+          <g transform="translate(0,22)">
+            <rect width="88" height="34" rx="8" fill="#0A0E1A" stroke="#A78BFA"></rect>
+            <text x="44" y="21" text-anchor="middle" font-size="10" fill="#E5E7EB">Input</text>
+          </g>
+          <path d="M 88 39 L 124 39" stroke="#A78BFA" stroke-width="1.4" class="ff-flow" fill="none"></path>
+          <g transform="translate(124,22)">
+            <rect width="88" height="34" rx="8" fill="#0A0E1A" stroke="#22D3EE"></rect>
+            <text x="44" y="21" text-anchor="middle" font-size="10" fill="#E5E7EB">Agent</text>
+          </g>
+          <path d="M 212 39 L 248 39" stroke="#22D3EE" stroke-width="1.4" class="ff-flow" fill="none"></path>
+          <g transform="translate(248,22)">
+            <rect width="88" height="34" rx="8" fill="#0A0E1A" stroke="#10D9A0"></rect>
+            <text x="44" y="21" text-anchor="middle" font-size="10" fill="#E5E7EB">Output</text>
+          </g>
+        </g>
+
+        <g transform="translate(22,150)">
+          <rect width="456" height="138" rx="12" fill="#0A0E1A" stroke="#F59E0B" stroke-opacity="0.45"></rect>
+          <g font-family="&#39;JetBrains Mono&#39;,monospace" font-size="11">
+            <text x="18" y="30" fill="#F59E0B"># Analyzer Report</text>
+            <text x="18" y="58" fill="#10D9A0">- purpose: qualify inbound leads</text>
+            <text x="18" y="82" fill="#22D3EE">- steps: enrich, score, notify</text>
+            <text x="18" y="106" fill="#A78BFA">- improve: add retry around CRM</text>
+          </g>
+          <rect class="ff-fill" x="0" y="0" height="138" rx="12" fill="#F59E0B" fill-opacity="0.07"></rect>
+        </g>
+      </g>
+    </g>
+
+
+    <g class="ff-scene s18">
+      <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#10D9A0" letter-spacing="2">18 · DASHBOARDS · DATA TABLES · AI COMMANDS</text>
+      <text y="64" font-size="64" font-weight="800" fill="#F3F4F6" letter-spacing="-2">Ask for data.</text>
+      <text y="124" font-size="64" font-weight="800" fill="#10D9A0" letter-spacing="-2">Get a view.</text>
+      <text y="172" font-size="16" fill="#9CA3AF">Create datatables and dashboard widgets from natural-language commands.</text>
+
+      <g transform="translate(660,30)">
+        <rect width="500" height="320" rx="14" fill="#0F1320" stroke="#1F2937"></rect>
+        <g transform="translate(18,18)">
+          <rect width="464" height="52" rx="12" fill="#0A0E1A" stroke="#10D9A0" stroke-opacity="0.45"></rect>
+          <text x="16" y="32" font-size="12" fill="#9CA3AF" font-family="&#39;JetBrains Mono&#39;,monospace">▸ create a sales table and dashboard by region</text>
+          <rect x="410" y="18" width="2" height="18" fill="#10D9A0" class="ff-blink"></rect>
+        </g>
+
+        <g transform="translate(18,92)">
+          <rect width="220" height="200" rx="12" fill="#0A0E1A" stroke="#22D3EE" stroke-opacity="0.5"></rect>
+          <text x="14" y="26" font-size="10" fill="#6B7280" font-family="&#39;JetBrains Mono&#39;,monospace">datatable · sales_pipeline</text>
+          <line x1="0" y1="42" x2="220" y2="42" stroke="#1F2937"></line>
+          <g font-family="&#39;JetBrains Mono&#39;,monospace" font-size="10">
+            <text x="14" y="64" fill="#22D3EE">region</text>
+            <text x="90" y="64" fill="#22D3EE">mrr</text>
+            <text x="148" y="64" fill="#22D3EE">stage</text>
+            <text x="14" y="92" fill="#E5E7EB">eu</text>
+            <text x="90" y="92" fill="#10D9A0">$18.4k</text>
+            <text x="148" y="92" fill="#F59E0B">trial</text>
+            <text x="14" y="118" fill="#E5E7EB">us</text>
+            <text x="90" y="118" fill="#10D9A0">$32.1k</text>
+            <text x="148" y="118" fill="#A78BFA">won</text>
+            <text x="14" y="144" fill="#E5E7EB">apac</text>
+            <text x="90" y="144" fill="#10D9A0">$9.8k</text>
+            <text x="148" y="144" fill="#22D3EE">new</text>
+          </g>
+          <rect x="0" y="78" width="220" height="22" fill="#22D3EE" fill-opacity="0.08" class="ff-pulse"></rect>
+        </g>
+
+        <g transform="translate(260,92)">
+          <rect width="222" height="200" rx="12" fill="#0A0E1A" stroke="#10D9A0" stroke-opacity="0.5"></rect>
+          <text x="14" y="26" font-size="10" fill="#6B7280" font-family="&#39;JetBrains Mono&#39;,monospace">dashboard · generated</text>
+          <g transform="translate(20,164)">
+            <rect class="ff-bar" x="0" y="-60" width="28" height="60" rx="4" fill="#A78BFA"></rect>
+            <rect class="ff-bar b2" x="44" y="-104" width="28" height="104" rx="4" fill="#10D9A0"></rect>
+            <rect class="ff-bar b3" x="88" y="-78" width="28" height="78" rx="4" fill="#22D3EE"></rect>
+            <rect class="ff-bar b4" x="132" y="-126" width="28" height="126" rx="4" fill="#F59E0B"></rect>
+            <line x1="-2" y1="2" x2="180" y2="2" stroke="#374151"></line>
+          </g>
+          <text x="20" y="68" font-size="12" fill="#F3F4F6" font-weight="700">Revenue by region</text>
+          <text x="20" y="88" font-size="10" fill="#9CA3AF" font-family="&#39;JetBrains Mono&#39;,monospace">table + widgets wired</text>
+        </g>
+      </g>
+    </g>
+
+
+    <g class="ff-scene s19">
+      <text font-size="11" font-family="&#39;JetBrains Mono&#39;, monospace" fill="#22D3EE" letter-spacing="2">19 · LLM REAL COST · USD</text>
+      <text y="64" font-size="64" font-weight="800" fill="#F3F4F6" letter-spacing="-2">Tokens show</text>
+      <text y="124" font-size="64" font-weight="800" fill="#22D3EE" letter-spacing="-2">real cost.</text>
+      <text y="172" font-size="16" fill="#9CA3AF">Per-trace token counts become live USD spend by model and provider.</text>
+
+      <g transform="translate(660,30)">
+        <rect width="500" height="320" rx="14" fill="#0F1320" stroke="#1F2937"></rect>
+        <rect width="500" height="36" rx="14" fill="#151B2E"></rect>
+        <rect y="20" width="500" height="16" fill="#151B2E"></rect>
+        <text x="20" y="23" font-size="11" fill="#22D3EE" font-family="&#39;JetBrains Mono&#39;,monospace">llm cost · trace pricing</text>
+
+        <g transform="translate(24,62)" font-family="&#39;JetBrains Mono&#39;,monospace" font-size="11">
+          <text x="0" y="0" fill="#6B7280">model</text>
+          <text x="160" y="0" fill="#6B7280">input</text>
+          <text x="248" y="0" fill="#6B7280">output</text>
+          <text x="354" y="0" fill="#6B7280">usd</text>
+          <line x1="0" y1="16" x2="452" y2="16" stroke="#1F2937"></line>
+
+          <g transform="translate(0,42)">
+            <rect x="-12" y="-20" width="452" height="34" rx="8" fill="#22D3EE" fill-opacity="0.08"></rect>
+            <text fill="#E5E7EB">gpt-4.1-mini</text>
+            <text x="160" fill="#9CA3AF">12,440</text>
+            <text x="248" fill="#9CA3AF">2,080</text>
+            <text x="354" fill="#10D9A0">$0.0412</text>
+          </g>
+          <g transform="translate(0,86)">
+            <rect x="-12" y="-20" width="452" height="34" rx="8" fill="#A78BFA" fill-opacity="0.08"></rect>
+            <text fill="#E5E7EB">claude-sonnet</text>
+            <text x="160" fill="#9CA3AF">8,120</text>
+            <text x="248" fill="#9CA3AF">1,640</text>
+            <text x="354" fill="#10D9A0">$0.0728</text>
+          </g>
+          <g transform="translate(0,130)">
+            <rect x="-12" y="-20" width="452" height="34" rx="8" fill="#F59E0B" fill-opacity="0.08"></rect>
+            <text fill="#E5E7EB">gemini-flash</text>
+            <text x="160" fill="#9CA3AF">5,900</text>
+            <text x="248" fill="#9CA3AF">880</text>
+            <text x="354" fill="#10D9A0">$0.0064</text>
+          </g>
+        </g>
+
+        <g transform="translate(24,236)">
+          <rect width="452" height="54" rx="12" fill="#0A0E1A" stroke="#10D9A0" stroke-opacity="0.55"></rect>
+          <text x="18" y="24" font-size="10" fill="#6B7280" font-family="&#39;JetBrains Mono&#39;,monospace">RUN TOTAL</text>
+          <text x="434" y="35" text-anchor="end" font-size="26" fill="#10D9A0" font-weight="800">$0.1204</text>
+          <rect class="ff-fill" x="0" y="0" height="54" rx="12" fill="#10D9A0" fill-opacity="0.08"></rect>
         </g>
       </g>
     </g>


### PR DESCRIPTION
## Summary

- Updates the README feature showcase copy and animated full feature SVG.
- Moves tutorial videos closer to the community section and avoids stale fixed node counts.
- Adds concise onboarding sections for trying Heym locally, calling workflows, production readiness, and extension paths.

## Impact

This makes the README clearer for new users and developers by surfacing how to build, observe, call, and extend Heym from the first read.

## Validation

- Ran `git diff --check origin/main...HEAD`.
- Parsed the updated SVG with Python XML parsing.
- Rendered the SVG through Quick Look thumbnail generation during local verification.