### PR TITLE
feat: per-workflow timeout + run-level error in execution log

### DIFF
--- a/backend/alembic/versions/089_workflow_timeout.py
+++ b/backend/alembic/versions/089_workflow_timeout.py
@@ -1,0 +1,28 @@
+"""add workflow_timeout_seconds to workflows
+
+Revision ID: 089_workflow_timeout
+Revises: 088_error_wf_time_saved
+Create Date: 2026-06-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "089_workflow_timeout"
+down_revision: str | None = "088_error_wf_time_saved"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflows",
+        sa.Column("workflow_timeout_seconds", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workflows", "workflow_timeout_seconds")

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -86,6 +86,7 @@ from app.services.hitl_service import (
 from app.services.workflow_executor import (
     ExecutionResult,
     WorkflowCancelledError,
+    WorkflowTimeoutError,
     _serialize_sub_workflow_executions,
     _to_json_compatible,
     execute_workflow,
@@ -1162,6 +1163,12 @@ async def update_workflow(
     if workflow_data.minutes_saved_per_run is not None:
         workflow.minutes_saved_per_run = (
             workflow_data.minutes_saved_per_run if workflow_data.minutes_saved_per_run > 0 else None
+        )
+    if workflow_data.workflow_timeout_seconds is not None:
+        workflow.workflow_timeout_seconds = (
+            workflow_data.workflow_timeout_seconds
+            if workflow_data.workflow_timeout_seconds > 0
+            else None
         )
 
     # Keep the dashboard widget metadata/cache in sync when its hidden workflow
@@ -2396,6 +2403,7 @@ async def execute_workflow_endpoint(
             trace_user_id=trace_user_id,
             actor_user_id=credentials_owner_id,
             cancel_event=cancel_event,
+            timeout_seconds=getattr(workflow, "workflow_timeout_seconds", None),
         )
     except WorkflowCancelledError:
         if not test_run:
@@ -3031,6 +3039,7 @@ async def execute_workflow_stream(
                 executor_holder=executor_holder,
                 sse_node_config=workflow.sse_node_config or {},
                 public_base_url=public_base_url,
+                timeout_seconds=getattr(workflow, "workflow_timeout_seconds", None),
             ):
                 event_queue.put(event)
                 if event.get("type") == "execution_complete":
@@ -3047,6 +3056,21 @@ async def execute_workflow_stream(
                     final_result["sub_workflow_executions"] = existing + [
                         s for s in extra if s.get("workflow_id") not in seen
                     ]
+        except WorkflowTimeoutError as exc:
+            # Surface as a failed run: emit a final event (so the canvas shows the
+            # timeout) and set final_result so it is persisted with status "error".
+            timeout_event = {
+                "type": "execution_complete",
+                "workflow_id": str(workflow.id),
+                "status": "error",
+                "outputs": {"error": str(exc)},
+                "execution_time_ms": 0,
+                "node_results": [],
+                "sub_workflow_executions": [],
+            }
+            final_result = timeout_event
+            event_queue.put(timeout_event)
+            return
         except WorkflowCancelledError:
             was_cancelled = True
             return

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -286,6 +286,7 @@ class Workflow(Base):
         index=True,
     )
     minutes_saved_per_run: Mapped[float | None] = mapped_column(Float, nullable=True)
+    workflow_timeout_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
     scheduled_for_deletion: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -189,6 +189,7 @@ class WorkflowUpdate(BaseModel):
     auto_recover_runs: bool | None = None
     error_workflow_id: uuid.UUID | None = None
     minutes_saved_per_run: float | None = None
+    workflow_timeout_seconds: int | None = None
 
 
 class WorkflowShareRequest(BaseModel):
@@ -227,6 +228,7 @@ class WorkflowResponse(BaseModel):
     auto_recover_runs: bool = True
     error_workflow_id: uuid.UUID | None = None
     minutes_saved_per_run: float | None = None
+    workflow_timeout_seconds: int | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -198,6 +198,15 @@ class WorkflowCancelledError(Exception):
     """Raised when a running workflow execution is cancelled."""
 
 
+class WorkflowTimeoutError(WorkflowCancelledError):
+    """Raised when a workflow exceeds its configured timeout.
+
+    Subclasses ``WorkflowCancelledError`` so existing cancellation handling
+    (cooperative unwind at node boundaries, retry suppression) applies, while
+    callers that care can distinguish a timeout from a user cancel.
+    """
+
+
 def run_async(coro):
     try:
         loop = asyncio.get_event_loop()
@@ -1708,6 +1717,7 @@ class WorkflowExecutor:
         invoked_by_agent: bool = False,
         public_base_url: str = "",
         return_on_chart_output: bool = False,
+        timeout_seconds: float | None = None,
     ) -> None:
         self.nodes = {node["id"]: node for node in nodes}
         self.agent_progress_queue = agent_progress_queue
@@ -1739,6 +1749,10 @@ class WorkflowExecutor:
         self._base_url = public_base_url
         self.return_on_chart_output = return_on_chart_output
         self.cancel_event = cancel_event
+        # Cooperative timeout: a monotonic deadline checked at every node boundary
+        # via ``check_cancelled``. ``None`` (or non-positive timeout) disables it.
+        self.timeout_seconds = timeout_seconds
+        self._deadline: float | None = None
         self.hitl_resume_context: dict[str, dict] = {}
         self.error_handler_nodes = {
             node_id for node_id, node in self.nodes.items() if node.get("type") == "errorHandler"
@@ -2126,7 +2140,16 @@ class WorkflowExecutor:
             self.retry_node_results.append(retry_result)
         return retry_result
 
+    def _arm_deadline(self) -> None:
+        """Start the timeout clock. Call once at the beginning of a run."""
+        if self.timeout_seconds and self.timeout_seconds > 0:
+            self._deadline = time.monotonic() + self.timeout_seconds
+
     def check_cancelled(self) -> None:
+        if self._deadline is not None and time.monotonic() > self._deadline:
+            raise WorkflowTimeoutError(
+                f"Workflow timed out after {int(self.timeout_seconds or 0)} seconds"
+            )
         if self.cancel_event is not None and self.cancel_event.is_set():
             raise WorkflowCancelledError("Workflow execution cancelled")
 
@@ -7977,7 +8000,15 @@ class WorkflowExecutor:
 
             elif node_type == "wait":
                 duration_ms = node_data.get("duration", 1000)
-                time.sleep(duration_ms / 1000.0)
+                # Sleep in small slices so a workflow timeout (or cancel) interrupts
+                # a long wait promptly instead of blocking the whole duration.
+                remaining = duration_ms / 1000.0
+                while remaining > 0:
+                    self.check_cancelled()
+                    slice_s = min(0.1, remaining)
+                    time.sleep(slice_s)
+                    remaining -= slice_s
+                self.check_cancelled()
                 first_input = self._first_visible_input(inputs)
                 output = first_input if isinstance(first_input, dict) else {"value": first_input}
 
@@ -12301,6 +12332,7 @@ class WorkflowExecutor:
 
     def _execute_inner(self, workflow_id: uuid.UUID, initial_inputs: dict) -> ExecutionResult:
         start_time = time.time()
+        self._arm_deadline()
         self.check_cancelled()
         node_results: list[NodeResult] = []
         error_flow_nodes = self.get_error_flow_nodes()
@@ -12744,6 +12776,7 @@ def execute_workflow(
     cancel_event: Event | None = None,
     public_base_url: str = "",
     return_on_chart_output: bool = False,
+    timeout_seconds: float | None = None,
 ) -> ExecutionResult:
     executor = WorkflowExecutor(
         nodes,
@@ -12759,8 +12792,20 @@ def execute_workflow(
         cancel_event=cancel_event,
         public_base_url=public_base_url,
         return_on_chart_output=return_on_chart_output,
+        timeout_seconds=timeout_seconds,
     )
-    result = executor.execute(workflow_id, inputs)
+    try:
+        result = executor.execute(workflow_id, inputs)
+    except WorkflowTimeoutError as exc:
+        # A timeout unwinds the run; surface it as a failed result so every
+        # caller (API, triggers) records it like any other error.
+        return ExecutionResult(
+            workflow_id=workflow_id,
+            status="error",
+            outputs={"error": str(exc)},
+            execution_time_ms=0.0,
+            node_results=[],
+        )
 
     if credentials_context:
         result.outputs = mask_sensitive_output(result.outputs, credentials_context)
@@ -13855,6 +13900,7 @@ def _execute_workflow_streaming_impl(
     sse_node_config: dict | None = None,
     public_base_url: str = "",
     otel_root_context: object | None = None,
+    timeout_seconds: float | None = None,
 ):
     import queue
 
@@ -13873,7 +13919,9 @@ def _execute_workflow_streaming_impl(
         agent_progress_queue=event_queue,
         cancel_event=cancel_event,
         public_base_url=public_base_url,
+        timeout_seconds=timeout_seconds,
     )
+    wf_executor._arm_deadline()
     if executor_holder is not None:
         executor_holder["executor"] = wf_executor
     # Re-attach the streaming root span context so node spans (run in worker

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -15,7 +15,7 @@ class AlembicMigrationGraphTest(unittest.TestCase):
         self.script = ScriptDirectory.from_config(config)
 
     def test_revision_graph_has_one_head(self) -> None:
-        self.assertEqual(self.script.get_heads(), ["088_error_wf_time_saved"])
+        self.assertEqual(self.script.get_heads(), ["089_workflow_timeout"])
 
     def test_github_and_supabase_revisions_are_merged(self) -> None:
         merge_revision = self.script.get_revision("080_merge_github_supabase_heads")

--- a/backend/tests/test_retry_execution_logs.py
+++ b/backend/tests/test_retry_execution_logs.py
@@ -52,6 +52,7 @@ class _FakeRetryStreamingExecutor:
         agent_progress_queue: object | None = None,
         cancel_event: object | None = None,
         public_base_url: str = "",
+        timeout_seconds: float | None = None,
     ) -> None:
         del (
             workflow_cache,
@@ -64,6 +65,7 @@ class _FakeRetryStreamingExecutor:
             conversation_history,
             agent_progress_queue,
             public_base_url,
+            timeout_seconds,
         )
         self.nodes = {node["id"]: node for node in nodes}
         self.edges = list(edges)
@@ -77,6 +79,9 @@ class _FakeRetryStreamingExecutor:
         self.node_outputs: dict[str, dict] = {}
         self._cancel_event = cancel_event
         self._sequence = 0
+
+    def _arm_deadline(self) -> None:
+        return None
 
     def get_error_flow_nodes(self) -> set[str]:
         return set()

--- a/backend/tests/test_sse_streaming.py
+++ b/backend/tests/test_sse_streaming.py
@@ -86,8 +86,9 @@ class _FakeWorkflowExecutor:
         agent_progress_queue: object | None = None,
         cancel_event: object | None = None,
         public_base_url: str = "",  # noqa: ARG002
+        timeout_seconds: float | None = None,  # noqa: ARG002
     ) -> None:
-        del actor_user_id
+        del actor_user_id, timeout_seconds
         self.nodes = {node["id"]: node for node in nodes}
         self.edges = list(edges)
         self._active_edges = list(edges)
@@ -100,6 +101,9 @@ class _FakeWorkflowExecutor:
         self.node_outputs: dict[str, dict] = {}
         self._cancel_event = cancel_event
         self._sequence = 0
+
+    def _arm_deadline(self) -> None:
+        return None
 
     def get_error_flow_nodes(self) -> set[str]:
         return set()

--- a/backend/tests/test_workflow_timeout.py
+++ b/backend/tests/test_workflow_timeout.py
@@ -1,0 +1,75 @@
+import time
+import unittest
+import uuid
+
+from app.services.workflow_executor import (
+    WorkflowExecutor,
+    WorkflowTimeoutError,
+    execute_workflow,
+)
+
+
+class TestDeadlineCheck(unittest.TestCase):
+    def test_check_cancelled_raises_timeout_after_deadline(self) -> None:
+        ex = WorkflowExecutor(nodes=[], edges=[], timeout_seconds=0.01)
+        ex._arm_deadline()
+        time.sleep(0.03)
+        with self.assertRaises(WorkflowTimeoutError):
+            ex.check_cancelled()
+
+    def test_no_timeout_when_disabled(self) -> None:
+        ex = WorkflowExecutor(nodes=[], edges=[], timeout_seconds=0)
+        ex._arm_deadline()
+        ex.check_cancelled()  # must not raise
+
+    def test_no_timeout_before_deadline(self) -> None:
+        ex = WorkflowExecutor(nodes=[], edges=[], timeout_seconds=5)
+        ex._arm_deadline()
+        ex.check_cancelled()  # must not raise
+
+
+class TestExecuteWorkflowTimeout(unittest.TestCase):
+    def test_wait_node_workflow_times_out_to_error(self) -> None:
+        nodes = [
+            {
+                "id": "in",
+                "type": "textInput",
+                "position": {"x": 0, "y": 0},
+                "data": {"label": "in", "value": "hi"},
+            },
+            {
+                "id": "wait",
+                "type": "wait",
+                "position": {"x": 200, "y": 0},
+                "data": {"label": "wait", "duration": 3000},
+            },
+            {
+                "id": "out",
+                "type": "output",
+                "position": {"x": 400, "y": 0},
+                "data": {"label": "out", "message": "$wait"},
+            },
+        ]
+        edges = [
+            {"id": "e1", "source": "in", "target": "wait"},
+            {"id": "e2", "source": "wait", "target": "out"},
+        ]
+
+        started = time.time()
+        result = execute_workflow(
+            workflow_id=uuid.uuid4(),
+            nodes=nodes,
+            edges=edges,
+            inputs={"headers": {}, "query": {}, "body": {"text": "hi"}},
+            timeout_seconds=1,
+        )
+        elapsed = time.time() - started
+
+        self.assertEqual(result.status, "error")
+        self.assertIn("timed out", str(result.outputs).lower())
+        # The 3s wait is interrupted near the 1s deadline, not after the full wait.
+        self.assertLess(elapsed, 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/e2e/workflow-timeout.spec.ts
+++ b/frontend/e2e/workflow-timeout.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+import { createWorkflow, deleteWorkflow, prepareAuthenticatedPage } from "./support";
+
+test.beforeEach(async ({ page }) => {
+  await prepareAuthenticatedPage(page);
+});
+
+test("a workflow timeout shorter than a wait node fails the run", async ({ page }) => {
+  const workflow = await createWorkflow(
+    page,
+    `Timeout Wait ${Date.now()}`,
+    [
+      {
+        id: "in",
+        type: "textInput",
+        position: { x: 80, y: 160 },
+        data: { label: "start", value: "hi" },
+      },
+      {
+        id: "wait",
+        type: "wait",
+        position: { x: 340, y: 160 },
+        // 3s wait, but the workflow timeout below is only 1s.
+        data: { label: "longWait", duration: 3000 },
+      },
+      {
+        id: "out",
+        type: "output",
+        position: { x: 600, y: 160 },
+        data: { label: "done", message: "$longWait" },
+      },
+    ],
+    [
+      { id: "e1", source: "in", target: "wait" },
+      { id: "e2", source: "wait", target: "out" },
+    ],
+  );
+
+  // Set a 1-second workflow timeout.
+  const updateResponse = await page.request.put(`/api/workflows/${workflow.id}`, {
+    data: { workflow_timeout_seconds: 1 },
+  });
+  expect(updateResponse.ok()).toBeTruthy();
+
+  await page.goto(`/workflows/${workflow.id}`);
+  await expect(page.locator(".vue-flow__node")).toHaveCount(3);
+
+  const completionPromise = page.waitForResponse(
+    (candidate) =>
+      candidate.request().method() === "POST" &&
+      new URL(candidate.url()).pathname === `/api/workflows/${workflow.id}/execute/stream`,
+    { timeout: 30_000 },
+  );
+
+  const started = Date.now();
+  await page.getByRole("button", { name: "Run Workflow" }).click();
+
+  const response = await completionPromise;
+  const body = await response.text();
+  const elapsedMs = Date.now() - started;
+
+  // The run ended as an error because it exceeded the 1s timeout...
+  expect(body).toMatch(/"status":\s*"error"/);
+  expect(body.toLowerCase()).toContain("timed out");
+  // ...and it stopped near the 1s deadline rather than after the full 3s wait.
+  expect(elapsedMs).toBeLessThan(15_000);
+
+  // The timeout error is also visible in the canvas execution log (not only history).
+  await expect(page.getByText(/timed out/i)).toBeVisible();
+
+  await deleteWorkflow(page, workflow.id);
+});

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -55,6 +55,15 @@ const scrollContainer = ref<HTMLDivElement | null>(null);
 const executionResult = computed(() => workflowStore.executionResult);
 const nodeResults = computed(() => workflowStore.nodeResults);
 const isExecuting = computed(() => workflowStore.isExecuting);
+
+/** A run-level failure (e.g. a workflow timeout) that isn't tied to a single
+ *  node, so it would otherwise leave the log empty. */
+const workflowLevelError = computed<string | null>(() => {
+  const r = executionResult.value;
+  if (!r || r.status !== "error") return null;
+  const outputs = r.outputs as Record<string, unknown> | undefined;
+  return outputs && typeof outputs.error === "string" ? outputs.error : null;
+});
 const runningNodeId = computed(() => workflowStore.runningNodeId);
 const agentProgressLogs = computed(() => workflowStore.agentProgressLogs);
 const selectedNode = computed(() => workflowStore.selectedNode);
@@ -2580,9 +2589,19 @@ function renderContent(content: string): string {
 
       <div
         v-if="displayResults.length === 0 && !isExecuting && !fileUploadMint"
-        class="flex items-center justify-center h-full"
+        class="flex items-center justify-center h-full p-4"
       >
-        <p class="text-muted-foreground text-sm">
+        <div
+          v-if="workflowLevelError"
+          class="flex items-start gap-2 text-sm text-red-500 max-w-full"
+        >
+          <AlertCircle class="w-4 h-4 shrink-0 mt-0.5" />
+          <span class="font-mono break-words">{{ workflowLevelError }}</span>
+        </div>
+        <p
+          v-else
+          class="text-muted-foreground text-sm"
+        >
           Run the workflow to see execution results
         </p>
       </div>

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -2588,20 +2588,10 @@ function renderContent(content: string): string {
       </div>
 
       <div
-        v-if="displayResults.length === 0 && !isExecuting && !fileUploadMint"
+        v-if="displayResults.length === 0 && !isExecuting && !fileUploadMint && !workflowLevelError"
         class="flex items-center justify-center h-full p-4"
       >
-        <div
-          v-if="workflowLevelError"
-          class="flex items-start gap-2 text-sm text-red-500 max-w-full"
-        >
-          <AlertCircle class="w-4 h-4 shrink-0 mt-0.5" />
-          <span class="font-mono break-words">{{ workflowLevelError }}</span>
-        </div>
-        <p
-          v-else
-          class="text-muted-foreground text-sm"
-        >
+        <p class="text-muted-foreground text-sm">
           Run the workflow to see execution results
         </p>
       </div>
@@ -2610,6 +2600,13 @@ function renderContent(content: string): string {
         v-else
         class="space-y-2 text-sm font-mono"
       >
+        <div
+          v-if="workflowLevelError"
+          class="flex items-start gap-2 p-2 rounded-md bg-red-500/10 text-red-500"
+        >
+          <AlertCircle class="w-4 h-4 shrink-0 mt-0.5" />
+          <span class="break-words">{{ workflowLevelError }}</span>
+        </div>
         <div
           v-for="result in displayResults"
           :key="result.displayKey"

--- a/frontend/src/components/Panels/PropertiesPanel.vue
+++ b/frontend/src/components/Panels/PropertiesPanel.vue
@@ -390,6 +390,25 @@ async function onChangeMinutesSaved(raw: string): Promise<void> {
   }
 }
 
+const workflowTimeoutSeconds = computed(
+  () => workflowStore.currentWorkflow?.workflow_timeout_seconds ?? null,
+);
+
+async function onChangeWorkflowTimeout(raw: string): Promise<void> {
+  const wf = workflowStore.currentWorkflow;
+  if (!wf || !isWorkflowOwner.value) return;
+  const parsed = raw === "" ? null : Number(raw);
+  const next =
+    parsed !== null && Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+  const previous = wf.workflow_timeout_seconds;
+  wf.workflow_timeout_seconds = next;
+  try {
+    await workflowApi.update(wf.id, { workflow_timeout_seconds: next ?? 0 });
+  } catch {
+    wf.workflow_timeout_seconds = previous;
+  }
+}
+
 const showRunAnalyzer = computed(
   () =>
     workflowStore.nodes.length > 0 &&
@@ -7959,7 +7978,8 @@ onUnmounted(() => {
             </div>
             <p class="text-xs text-muted-foreground mt-2 leading-relaxed">
               Runs the selected workflow if this one fails — unless the canvas
-              already has an Error Handler node.
+              already has an Error Handler node. Not triggered on manual test
+              runs.
             </p>
           </div>
 
@@ -7981,6 +8001,27 @@ onUnmounted(() => {
             <p class="text-xs text-muted-foreground mt-2 leading-relaxed">
               Estimated minutes this automation saves per successful run.
               Surfaced as total Time Saved in Analytics.
+            </p>
+          </div>
+
+          <div class="border-t border-border/40 pt-4 pb-4">
+            <div class="flex items-center gap-2 mb-2">
+              <Clock class="w-4 h-4 text-muted-foreground shrink-0" />
+              <span class="text-sm font-medium">Workflow timeout (seconds)</span>
+            </div>
+            <input
+              type="number"
+              min="0"
+              step="1"
+              class="w-full text-sm rounded-md border border-border bg-background px-2 py-1.5 disabled:opacity-50"
+              :value="workflowTimeoutSeconds ?? ''"
+              :disabled="!isWorkflowOwner"
+              placeholder="0 = no timeout"
+              @change="onChangeWorkflowTimeout(($event.target as HTMLInputElement).value)"
+            >
+            <p class="text-xs text-muted-foreground mt-2 leading-relaxed">
+              Fail the run if it exceeds this many seconds. 0 disables the
+              timeout. Applies to manual, API, and triggered runs.
             </p>
           </div>
 

--- a/frontend/src/docs/content/reference/features.md
+++ b/frontend/src/docs/content/reference/features.md
@@ -525,7 +525,11 @@ See also [Execution History](./execution-history.md), [Workflow Structure](./wor
 
 ### Error Workflow
 
-A workflow can designate another workflow to run when it fails. Configure it in the workflow-level **Properties** panel (shown when no node is selected) under **On error, run workflow**. When a top-level run ends with an unhandled failure, the selected error workflow runs and receives the failure context (failed workflow id and name, run id, error message, failed node label and type, and a timestamp). If the canvas already contains an [Error Handler](../nodes/error-handler-node.md) node, the local handler takes precedence and the error workflow is **not** called. The error workflow itself runs directly, so it never triggers its own error workflow.
+A workflow can designate another workflow to run when it fails. Configure it in the workflow-level **Properties** panel (shown when no node is selected) under **On error, run workflow**. When a top-level run ends with an unhandled failure, the selected error workflow runs and receives the failure context (failed workflow id and name, run id, error message, failed node label and type, and a timestamp). If the canvas already contains an [Error Handler](../nodes/error-handler-node.md) node, the local handler takes precedence and the error workflow is **not** called. The error workflow itself runs directly, so it never triggers its own error workflow. It is **not** triggered by manual canvas test runs — only by API and triggered runs.
+
+### Workflow Timeout
+
+Each workflow can set a **workflow timeout** in seconds in the workflow-level **Properties** panel. `0` (the default) disables it. When set, a run that exceeds the limit is stopped at the next node boundary and recorded as a failed run with a "timed out" error. The timeout applies to manual, API, and triggered runs. Long [Wait](../nodes/wait-node.md) nodes are interrupted promptly rather than blocking for their full duration.
 
 ### Time Saved
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -514,6 +514,7 @@ export const workflowApi = {
         | "auto_recover_runs"
         | "error_workflow_id"
         | "minutes_saved_per_run"
+        | "workflow_timeout_seconds"
       >
     >,
   ): Promise<Workflow> => {

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -1252,7 +1252,13 @@ export const useWorkflowStore = defineStore("workflow", () => {
               return;
             }
 
-            const finalRows = (result.node_results || []) as NodeResult[];
+            // A run that fails without per-node results (e.g. a workflow timeout)
+            // sends an empty node_results; keep the rows we already streamed so the
+            // prior node history stays visible instead of being wiped.
+            const finalRows =
+              result.node_results && result.node_results.length > 0
+                ? (result.node_results as NodeResult[])
+                : nodeResults.value;
             timelinePickedNodeResultIndex.value = null;
             nodeResults.value = finalRows;
 

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -35,6 +35,7 @@ export interface Workflow {
   auto_recover_runs: boolean;
   error_workflow_id: string | null;
   minutes_saved_per_run: number | null;
+  workflow_timeout_seconds: number | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Add a per-workflow **timeout (seconds)** configured in the workflow-level Properties panel (default `0` = disabled). When a run exceeds the limit it is stopped at the next node boundary and recorded as a **failed** run with a "timed out" error.
- Enforced cooperatively via a deadline checked in `WorkflowExecutor.check_cancelled`, so it applies to **manual (streaming), API, and triggered** runs. `WorkflowTimeoutError` subclasses `WorkflowCancelledError` so existing unwind/retry handling is reused.
- Long **Wait** nodes now sleep in slices so a timeout interrupts them promptly instead of blocking the full duration.
- Surface run-level errors (e.g. a timeout, which has no per-node result) in the **canvas Execution Log** empty state — previously only the history dialogs showed it.
- Note in the Properties panel that the error workflow is **not** triggered on manual test runs.

## Changes
- DB: `workflows.workflow_timeout_seconds` column + migration `089_workflow_timeout`.
- Schemas + update endpoint persistence; threaded `timeout_seconds` into `execute_workflow` and `execute_workflow_streaming`; streaming endpoint converts a timeout into a failed `execution_complete`.
- Frontend: `Workflow` type, `workflowApi.update`, Properties panel input, DebugPanel run-level error display.
- Docs: Workflow Timeout section + manual-test-run note in `features.md`.

## Test Plan
- [x] Backend unit + integration tests (`tests/test_workflow_timeout.py`): deadline check, disabled timeout, and a 3s wait + 1s timeout returning an error result in <2.5s.
- [x] Updated streaming-executor test fakes for the new `timeout_seconds` / `_arm_deadline` interface; full `./check.sh` green (1 known-flaky chart test passes in isolation).
- [x] E2E (`e2e/workflow-timeout.spec.ts`): 3s wait + 1s timeout fails the run and the "timed out" error shows in the canvas execution log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)