### PR TITLE
fix: make plugin path safety checks cross-platform

### DIFF
--- a/backend/app/api/plugins.py
+++ b/backend/app/api/plugins.py
@@ -53,7 +53,9 @@ def _safe_icon_path(plugin_id: str, filename: str) -> Path | None:
         return None
     package_root = (plugin_store.plugins_root() / plugin_id).resolve()
     candidate = (package_root / filename).resolve()
-    if candidate != package_root and not str(candidate).startswith(str(package_root) + "/"):
+    try:
+        candidate.relative_to(package_root)
+    except ValueError:
         return None
     return candidate if candidate.is_file() else None
 

--- a/backend/app/services/plugin_store.py
+++ b/backend/app/services/plugin_store.py
@@ -25,13 +25,15 @@ class PluginInstallError(Exception):
 def _safe_members(zf: zipfile.ZipFile, dest_root: Path) -> list[zipfile.ZipInfo]:
     members: list[zipfile.ZipInfo] = []
     total = 0
-    root_str = str(dest_root.resolve())
+    resolved_root = dest_root.resolve()
     for info in zf.infolist():
         name = info.filename
         if name.endswith("/"):
             continue
         target = (dest_root / name).resolve()
-        if target != dest_root.resolve() and not str(target).startswith(root_str + "/"):
+        try:
+            target.relative_to(resolved_root)
+        except ValueError:
             raise PluginInstallError(f"Unsafe path in zip: {name}")
         total += info.file_size
         if total > MAX_UNCOMPRESSED_BYTES:

--- a/backend/tests/test_plugin_store.py
+++ b/backend/tests/test_plugin_store.py
@@ -41,6 +41,20 @@ class PluginStoreTests(unittest.TestCase):
         # No dependencies in this manifest -> installer not called.
         deps.assert_not_called()
 
+    def test_extract_allows_nested_plugin_members(self) -> None:
+        data = _make_zip(
+            {
+                "plugin.json": _VALID_MANIFEST,
+                "handler.py": _HANDLER,
+                "assets/icon.svg": "<svg/>",
+            }
+        )
+
+        with patch.object(plugin_store, "_install_dependencies"):
+            plugin_store.extract_and_validate(data, self.dir)
+
+        self.assertEqual((self.dir / "acme-crm" / "assets" / "icon.svg").read_text(), "<svg/>")
+
     def test_rejects_zip_slip(self) -> None:
         data = _make_zip({"plugin.json": _VALID_MANIFEST, "../evil.py": "x"})
         with self.assertRaises(PluginInstallError):


### PR DESCRIPTION
## Summary
- replace Windows-fragile plugin path prefix checks with `Path.relative_to`
- keep plugin zip-slip and icon traversal protection intact
- add regression coverage for nested plugin archive members

## Root cause
The previous containment checks compared resolved paths as strings with a hard-coded `/` separator. On Windows, resolved paths use `\`, so valid plugin members could be reported as unsafe.

## Validation
- `python -m pytest tests/test_plugin_store.py tests/test_plugin_loader.py tests/test_plugin_manifest.py tests/test_plugin_dsl_prompt.py tests/test_plugin_node.py -q`
- `python -m ruff check app/services/plugin_store.py app/api/plugins.py tests/test_plugin_store.py`
- `python -m ruff format --check app/services/plugin_store.py app/api/plugins.py tests/test_plugin_store.py`
- `git diff --check`
- `bash ./check.sh` via Git Bash: 1729 tests, 1729 passed