### PR TITLE
feat(frontend): add searchable select input

### DIFF
--- a/frontend/e2e/canvas-workflow-executions.spec.ts
+++ b/frontend/e2e/canvas-workflow-executions.spec.ts
@@ -439,7 +439,7 @@ test("shows an error workflow when an HTTP API call fails", async ({ page }) => 
     [
       workflowNode("http_error", "http", 120, 160, {
         label: "fetchBrokenApi",
-        curl: "curl -X GET http://",
+        curl: "curl -X GET http://127.0.0.1:9/e2e-http-error",
       }),
       workflowNode("output_unreachable", "output", 380, 160, {
         label: "unreachableOutput",

--- a/frontend/e2e/canvas-workflow-executions.spec.ts
+++ b/frontend/e2e/canvas-workflow-executions.spec.ts
@@ -439,7 +439,7 @@ test("shows an error workflow when an HTTP API call fails", async ({ page }) => 
     [
       workflowNode("http_error", "http", 120, 160, {
         label: "fetchBrokenApi",
-        curl: "curl -X GET http://127.0.0.1:9/e2e-http-error",
+        curl: "curl -X GET http://",
       }),
       workflowNode("output_unreachable", "output", 380, 160, {
         label: "unreachableOutput",

--- a/frontend/e2e/support.ts
+++ b/frontend/e2e/support.ts
@@ -226,7 +226,11 @@ export async function selectSearchableOption(
   const combobox = field.getByRole("combobox");
   await combobox.click();
   await combobox.fill(optionLabel);
-  await page.getByRole("option", { name: optionLabel, exact: true }).click();
+  const listboxId = await combobox.getAttribute("aria-controls");
+  const listbox = listboxId
+    ? page.locator(`#${listboxId}`)
+    : page.getByRole("listbox").filter({ has: page.getByRole("option", { name: optionLabel }) });
+  await listbox.getByRole("option", { name: optionLabel, exact: true }).click();
 }
 
 export async function acceptNextDialog(

--- a/frontend/e2e/support.ts
+++ b/frontend/e2e/support.ts
@@ -218,6 +218,17 @@ export async function expectOk(response: APIResponse): Promise<void> {
   expect(response.ok(), await response.text()).toBeTruthy();
 }
 
+export async function selectSearchableOption(
+  page: Page,
+  field: import("@playwright/test").Locator,
+  optionLabel: string,
+): Promise<void> {
+  const combobox = field.getByRole("combobox");
+  await combobox.click();
+  await combobox.fill(optionLabel);
+  await page.getByRole("option", { name: optionLabel, exact: true }).click();
+}
+
 export async function acceptNextDialog(
   page: Page,
   action: () => Promise<void>,

--- a/frontend/e2e/tab-credentials.spec.ts
+++ b/frontend/e2e/tab-credentials.spec.ts
@@ -274,14 +274,15 @@ test("configures a Notion node with a saved credential and operation", async ({ 
     await expect(propertiesPanel.getByText("Notion", { exact: true })).toBeVisible();
     const selects = propertiesPanel.locator("select");
     await expect(selects.nth(0)).toHaveValue(credential.id);
-    await expect(propertiesPanel.getByRole("combobox")).toHaveValue("Search");
+    const operationField = page.getByTestId("notion-operation-field");
+    await expect(operationField.getByRole("combobox")).toHaveValue("Search");
     await expect(propertiesPanel.getByText("Search Query", { exact: true })).toBeVisible();
 
     await notionNode.dblclick();
     await expect(searchQueryDialogHeading).toBeVisible();
     await page.keyboard.press("Escape");
 
-    await selectSearchableOption(page, propertiesPanel, "Get Page");
+    await selectSearchableOption(page, operationField, "Get Page");
     await expect(propertiesPanel.getByText("Page ID", { exact: true })).toBeVisible();
     await notionNode.dblclick();
     await expect(page.getByRole("heading", { name: "notion – Page ID" })).toBeVisible();

--- a/frontend/e2e/tab-credentials.spec.ts
+++ b/frontend/e2e/tab-credentials.spec.ts
@@ -7,6 +7,7 @@ import {
   deleteWorkflow,
   expectOk,
   prepareAuthenticatedPage,
+  selectSearchableOption,
 } from "./support";
 
 test.beforeEach(async ({ page }) => {
@@ -273,14 +274,14 @@ test("configures a Notion node with a saved credential and operation", async ({ 
     await expect(propertiesPanel.getByText("Notion", { exact: true })).toBeVisible();
     const selects = propertiesPanel.locator("select");
     await expect(selects.nth(0)).toHaveValue(credential.id);
-    await expect(selects.nth(1)).toHaveValue("search");
+    await expect(propertiesPanel.getByRole("combobox")).toHaveValue("Search");
     await expect(propertiesPanel.getByText("Search Query", { exact: true })).toBeVisible();
 
     await notionNode.dblclick();
     await expect(searchQueryDialogHeading).toBeVisible();
     await page.keyboard.press("Escape");
 
-    await selects.nth(1).selectOption("getPage");
+    await selectSearchableOption(page, propertiesPanel, "Get Page");
     await expect(propertiesPanel.getByText("Page ID", { exact: true })).toBeVisible();
     await notionNode.dblclick();
     await expect(page.getByRole("heading", { name: "notion – Page ID" })).toBeVisible();

--- a/frontend/e2e/tab-workflows.spec.ts
+++ b/frontend/e2e/tab-workflows.spec.ts
@@ -7,6 +7,7 @@ import {
   deleteCredential,
   expectOk,
   prepareAuthenticatedPage,
+  selectSearchableOption,
 } from "./support";
 
 test.beforeEach(async ({ page }) => {
@@ -295,10 +296,7 @@ test("adds and configures a Linear node", async ({ page }) => {
       .getByTestId("linear-credential-field")
       .locator("select")
       .selectOption(credential.id);
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("getIssue");
+    await selectSearchableOption(page, page.getByTestId("linear-operation-field"), "Get Issue");
     await page
       .getByTestId("linear-issue-id-field")
       .locator("input")
@@ -313,22 +311,20 @@ test("adds and configures a Linear node", async ({ page }) => {
     await page.getByRole("button", { name: "Properties" }).click();
     await page.locator(".vue-flow__node").click();
     await expect(
-      page.getByTestId("linear-operation-field").locator("select"),
-    ).toHaveValue("getIssue");
+      page.getByTestId("linear-operation-field").getByRole("combobox"),
+    ).toHaveValue("Get Issue");
     await expect(
       page.getByTestId("linear-issue-id-field").locator("input"),
     ).toHaveValue("ENG-123");
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("listWorkflowStates");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "List Workflow States",
+    );
     await expect(page.getByTestId("linear-team-id-field")).toBeVisible();
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("listTeams");
+    await selectSearchableOption(page, page.getByTestId("linear-operation-field"), "List Teams");
     await expect(page.getByTestId("linear-after-field")).toBeVisible();
     await page
       .getByTestId("linear-after-field")
@@ -362,10 +358,11 @@ test("configures Linear listTeamMembers fields and persists after save", async (
       .getByTestId("linear-credential-field")
       .locator("select")
       .selectOption(credential.id);
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("listTeamMembers");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "List Team Members",
+    );
     await expect(page.getByTestId("linear-team-id-field")).toBeVisible();
     await expect(page.getByTestId("linear-limit-field")).toBeVisible();
     await expect(page.getByTestId("linear-after-field")).toBeVisible();
@@ -385,8 +382,8 @@ test("configures Linear listTeamMembers fields and persists after save", async (
     await page.locator(".vue-flow__node").click();
 
     await expect(
-      page.getByTestId("linear-operation-field").locator("select"),
-    ).toHaveValue("listTeamMembers");
+      page.getByTestId("linear-operation-field").getByRole("combobox"),
+    ).toHaveValue("List Team Members");
     await expect(page.getByTestId("linear-team-id-field").locator("input")).toHaveValue(
       "team-uuid-1",
     );
@@ -423,10 +420,11 @@ test("configures Linear comment operations and persists update comment fields", 
       .locator("select")
       .selectOption(credential.id);
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("listComments");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "List Comments",
+    );
     await expect(page.getByTestId("linear-issue-id-field")).toBeVisible();
     await expect(page.getByTestId("linear-limit-field")).toBeVisible();
     await expect(page.getByTestId("linear-after-field")).toBeVisible();
@@ -440,29 +438,33 @@ test("configures Linear comment operations and persists update comment fields", 
       .locator("input")
       .fill("$listComments.pageInfo.endCursor");
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("deleteComment");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "Delete Comment",
+    );
     await expect(page.getByTestId("linear-comment-id-field")).toBeVisible();
     await expect(page.getByTestId("linear-issue-id-field")).toBeHidden();
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("resolveComment");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "Resolve Comment",
+    );
     await expect(page.getByTestId("linear-comment-id-field")).toBeVisible();
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("unresolveComment");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "Unresolve Comment",
+    );
     await expect(page.getByTestId("linear-comment-id-field")).toBeVisible();
 
-    await page
-      .getByTestId("linear-operation-field")
-      .locator("select")
-      .selectOption("updateComment");
+    await selectSearchableOption(
+      page,
+      page.getByTestId("linear-operation-field"),
+      "Update Comment",
+    );
     await expect(page.getByTestId("linear-comment-id-field")).toBeVisible();
     await expect(page.getByTestId("linear-comment-body-field")).toBeVisible();
     await page
@@ -480,8 +482,8 @@ test("configures Linear comment operations and persists update comment fields", 
     await page.locator(".vue-flow__node").click();
 
     await expect(
-      page.getByTestId("linear-operation-field").locator("select"),
-    ).toHaveValue("updateComment");
+      page.getByTestId("linear-operation-field").getByRole("combobox"),
+    ).toHaveValue("Update Comment");
     await expect(page.getByTestId("linear-comment-id-field").locator("input")).toHaveValue(
       "comment-uuid-1",
     );

--- a/frontend/src/components/Panels/propertiesPanel/nodes/BigqueryNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/BigqueryNodeProperties.vue
@@ -4,6 +4,7 @@ import Button from "@/components/ui/Button.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -60,9 +61,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.bqOperation || ''"
         :options="bigQueryOperationOptions"
+        search-placeholder="Search BigQuery operations..."
         @update:model-value="updateNodeData('bqOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/nodes/ClickhouseNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/ClickhouseNodeProperties.vue
@@ -2,6 +2,7 @@
 import { AlertTriangle, Loader2 } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -27,7 +28,7 @@ const {
   updateClickhouseMappingValue,
   switchClickhouseToRaw,
   clickhouseCredentialOptions,
-  clickhouseOperationOptions,
+  clickhouseOperationGroups,
   updateNodeData,
 } = usePropertiesPanelContext();
 </script>
@@ -59,9 +60,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.clickhouseOperation || ''"
-        :options="clickhouseOperationOptions"
+        :groups="clickhouseOperationGroups"
+        search-placeholder="Search ClickHouse operations..."
         @update:model-value="updateNodeData('clickhouseOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/nodes/DataTableNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/DataTableNodeProperties.vue
@@ -3,6 +3,7 @@ import { AlertTriangle, ExternalLink } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -69,9 +70,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.dataTableOperation || ''"
         :options="dataTableOperationOptions"
+        search-placeholder="Search DataTable operations..."
         @update:model-value="updateNodeData('dataTableOperation', $event)"
       />
       <p

--- a/frontend/src/components/Panels/propertiesPanel/nodes/DriveNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/DriveNodeProperties.vue
@@ -3,6 +3,7 @@ import AgentFieldToggle from "@/components/ui/AgentFieldToggle.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -29,9 +30,10 @@ const {
   <template v-if="selectedNode">
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.driveOperation || ''"
         :options="driveOperationOptions"
+        search-placeholder="Search Drive operations..."
         @update:model-value="updateNodeData('driveOperation', $event || undefined)"
       />
       <p class="text-xs text-muted-foreground">

--- a/frontend/src/components/Panels/propertiesPanel/nodes/ExecuteNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/ExecuteNodeProperties.vue
@@ -3,7 +3,7 @@ import { AlertTriangle, ExternalLink } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Label from "@/components/ui/Label.vue";
-import Select from "@/components/ui/Select.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
 const {
@@ -18,6 +18,7 @@ const {
   onExecuteMappingRegisterFieldIndex,
   getExpressionWarning,
   updateNodeData,
+  updateExecuteWorkflowId,
   executeMappings,
   handleExecuteMappingNavigate,
   setExecuteMappingInputRef,
@@ -31,10 +32,12 @@ const {
   <template v-if="selectedNode">
     <div class="space-y-2">
       <Label>Target Workflow</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.executeWorkflowId || ''"
         :options="[{ value: '', label: 'Select a workflow...' }, ...workflowOptions]"
-        @update:model-value="updateNodeData('executeWorkflowId', $event)"
+        placeholder="Select a workflow..."
+        search-placeholder="Search workflows..."
+        @update:model-value="updateExecuteWorkflowId"
       />
       <p class="text-xs text-muted-foreground">
         Select which workflow to execute

--- a/frontend/src/components/Panels/propertiesPanel/nodes/GithubNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/GithubNodeProperties.vue
@@ -4,6 +4,7 @@ import AgentFieldToggle from "@/components/ui/AgentFieldToggle.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -43,7 +44,7 @@ const {
   handleGitHubExpressionFieldNavigate,
   onGitHubRegisterExpressionFieldIndex,
   githubCredentialOptions,
-  githubOperationOptions,
+  githubOperationGroups,
   githubStateOptions,
   githubIssueSortOptions,
   githubPullRequestSortOptions,
@@ -85,9 +86,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.githubOperation || 'getRepository'"
-        :options="githubOperationOptions"
+        :groups="githubOperationGroups"
+        search-placeholder="Search GitHub operations..."
         @update:model-value="updateNodeData('githubOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/nodes/GoogleSheetsNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/GoogleSheetsNodeProperties.vue
@@ -3,6 +3,7 @@ import { AlertTriangle } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import GoogleSheetsValuesInputPanel from "@/components/ui/GoogleSheetsValuesInputPanel.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -51,9 +52,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.gsOperation || ''"
         :options="googleSheetsOperationOptions"
+        search-placeholder="Search Google Sheets operations..."
         @update:model-value="updateNodeData('gsOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/nodes/GristNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/GristNodeProperties.vue
@@ -4,6 +4,7 @@ import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import JsonInputPanel from "@/components/ui/JsonInputPanel.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -55,9 +56,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.gristOperation || ''"
         :options="gristOperationOptions"
+        search-placeholder="Search Grist operations..."
         @update:model-value="updateNodeData('gristOperation', $event)"
       />
       <p

--- a/frontend/src/components/Panels/propertiesPanel/nodes/LinearNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/LinearNodeProperties.vue
@@ -2,6 +2,7 @@
 import { AlertTriangle } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -29,7 +30,7 @@ const {
   handleLinearExpressionFieldNavigate,
   onLinearRegisterExpressionFieldIndex,
   linearCredentialOptions,
-  linearOperationOptions,
+  linearOperationGroups,
   updateNodeData,
 } = usePropertiesPanelContext();
 </script>
@@ -60,9 +61,10 @@ const {
       data-testid="linear-operation-field"
     >
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.linearOperation || 'listIssues'"
-        :options="linearOperationOptions"
+        :groups="linearOperationGroups"
+        search-placeholder="Search Linear operations..."
         @update:model-value="updateNodeData('linearOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/nodes/NotionNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/NotionNodeProperties.vue
@@ -5,6 +5,7 @@ import Button from "@/components/ui/Button.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -43,7 +44,7 @@ const {
   handleNotionExpressionFieldNavigate,
   onNotionRegisterExpressionFieldIndex,
   notionCredentialOptions,
-  notionOperationOptions,
+  notionOperationGroups,
   notionDataSourceOptions,
   notionAppendPositionOptions,
   notionPageOptions,
@@ -71,9 +72,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.notionOperation || ''"
-        :options="notionOperationOptions"
+        :groups="notionOperationGroups"
+        search-placeholder="Search Notion operations..."
         @update:model-value="updateNodeData('notionOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/nodes/NotionNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/NotionNodeProperties.vue
@@ -73,6 +73,7 @@ const {
     <div class="space-y-2">
       <Label>Operation</Label>
       <SearchableSelect
+        data-testid="notion-operation-field"
         :model-value="selectedNode.data.notionOperation || ''"
         :groups="notionOperationGroups"
         search-placeholder="Search Notion operations..."

--- a/frontend/src/components/Panels/propertiesPanel/nodes/RabbitmqNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/RabbitmqNodeProperties.vue
@@ -3,6 +3,7 @@ import { AlertTriangle } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -49,9 +50,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.rabbitmqOperation || ''"
         :options="rabbitmqOperationOptions"
+        search-placeholder="Search RabbitMQ operations..."
         @update:model-value="updateNodeData('rabbitmqOperation', $event)"
       />
       <p

--- a/frontend/src/components/Panels/propertiesPanel/nodes/RagNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/RagNodeProperties.vue
@@ -3,6 +3,7 @@ import { AlertTriangle } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import Textarea from "@/components/ui/Textarea.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
@@ -63,9 +64,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.ragOperation || ''"
         :options="ragOperationOptions"
+        search-placeholder="Search RAG operations..."
         @update:model-value="updateNodeData('ragOperation', $event)"
       />
       <p

--- a/frontend/src/components/Panels/propertiesPanel/nodes/RedisNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/RedisNodeProperties.vue
@@ -3,6 +3,7 @@ import { AlertTriangle } from "lucide-vue-next";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -43,9 +44,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.redisOperation || ''"
         :options="redisOperationOptions"
+        search-placeholder="Search Redis operations..."
         @update:model-value="updateNodeData('redisOperation', $event)"
       />
       <p

--- a/frontend/src/components/Panels/propertiesPanel/nodes/S3NodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/S3NodeProperties.vue
@@ -4,6 +4,7 @@ import AgentFieldToggle from "@/components/ui/AgentFieldToggle.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -23,7 +24,7 @@ const {
   handleS3ExpressionFieldNavigate,
   onS3RegisterExpressionFieldIndex,
   s3CredentialOptions,
-  s3OperationOptions,
+  s3OperationGroups,
   s3MaxKeysWarning,
   updateNodeData,
   handleS3MaxKeysChange,
@@ -57,9 +58,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.s3Operation || 'putObject'"
-        :options="s3OperationOptions"
+        :groups="s3OperationGroups"
+        search-placeholder="Search Amazon S3 operations..."
         @update:model-value="updateNodeData('s3Operation', $event)"
       />
       <p

--- a/frontend/src/components/Panels/propertiesPanel/nodes/SupabaseNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/SupabaseNodeProperties.vue
@@ -5,6 +5,7 @@ import Button from "@/components/ui/Button.vue";
 import ExpressionInput from "@/components/ui/ExpressionInput.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
@@ -66,9 +67,10 @@ const {
 
     <div class="space-y-2">
       <Label>Operation</Label>
-      <Select
+      <SearchableSelect
         :model-value="selectedNode.data.supabaseOperation || ''"
         :options="supabaseOperationOptions"
+        search-placeholder="Search Supabase operations..."
         @update:model-value="updateNodeData('supabaseOperation', $event)"
       />
     </div>

--- a/frontend/src/components/Panels/propertiesPanel/operationOptions.ts
+++ b/frontend/src/components/Panels/propertiesPanel/operationOptions.ts
@@ -1,0 +1,322 @@
+export interface OperationOption {
+  value: string;
+  label: string;
+}
+
+export interface OperationOptionGroup {
+  label?: string;
+  options: OperationOption[];
+}
+
+function flattenOperationGroups(groups: OperationOptionGroup[]): OperationOption[] {
+  return groups.flatMap((group) => group.options);
+}
+
+export const ragOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation" },
+  { value: "insert", label: "Insert" },
+  { value: "search", label: "Search" },
+];
+
+export const redisOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "set", label: "Set Variable" },
+  { value: "get", label: "Get Variable" },
+  { value: "hasKey", label: "Has Key" },
+  { value: "deleteKey", label: "Delete Key" },
+];
+
+export const linearOperationGroups: OperationOptionGroup[] = [
+  {
+    label: "Workspace",
+    options: [
+      { value: "getViewer", label: "Get Viewer" },
+      { value: "listTeams", label: "List Teams" },
+      { value: "listProjects", label: "List Projects" },
+      { value: "listWorkflowStates", label: "List Workflow States" },
+      { value: "listTeamMembers", label: "List Team Members" },
+    ],
+  },
+  {
+    label: "Issues",
+    options: [
+      { value: "listIssues", label: "List Issues" },
+      { value: "getIssue", label: "Get Issue" },
+      { value: "createIssue", label: "Create Issue" },
+      { value: "updateIssue", label: "Update Issue" },
+      { value: "deleteIssue", label: "Delete Issue" },
+      { value: "addIssueLink", label: "Add Issue Link" },
+    ],
+  },
+  {
+    label: "Comments",
+    options: [
+      { value: "createComment", label: "Create Comment" },
+      { value: "listComments", label: "List Comments" },
+      { value: "updateComment", label: "Update Comment" },
+      { value: "deleteComment", label: "Delete Comment" },
+      { value: "resolveComment", label: "Resolve Comment" },
+      { value: "unresolveComment", label: "Unresolve Comment" },
+    ],
+  },
+];
+
+export const linearOperationOptions: OperationOption[] =
+  flattenOperationGroups(linearOperationGroups);
+
+export const githubOperationGroups: OperationOptionGroup[] = [
+  {
+    label: "Repository",
+    options: [
+      { value: "getRepository", label: "Get Repository" },
+      { value: "getRepositoryLicense", label: "Get Repository License" },
+      { value: "getRepositoryProfile", label: "Get Repository Profile" },
+      { value: "listPopularPaths", label: "List Popular Paths for Repository" },
+      { value: "listReferrers", label: "List Top Referrers for Repository" },
+    ],
+  },
+  {
+    label: "Users and Organizations",
+    options: [
+      { value: "listOrganizationRepositories", label: "List Organization Repositories" },
+      { value: "listUserRepositories", label: "List User Repositories" },
+      { value: "getUserRepositories", label: "Get User Repositories" },
+      { value: "getUserIssues", label: "Get User Issues" },
+      { value: "inviteUser", label: "Invite User" },
+    ],
+  },
+  {
+    label: "Issues",
+    options: [
+      { value: "createIssue", label: "Create Issue" },
+      { value: "getIssue", label: "Get Issue" },
+      { value: "listIssues", label: "List Issues" },
+      { value: "getRepositoryIssues", label: "Get Repository Issues" },
+      { value: "lockIssue", label: "Lock Issue" },
+      { value: "updateIssue", label: "Edit Issue" },
+      { value: "createComment", label: "Create Comment" },
+    ],
+  },
+  {
+    label: "Pull Requests and Reviews",
+    options: [
+      { value: "createPullRequest", label: "Create Pull Request" },
+      { value: "listPullRequests", label: "List Pull Requests" },
+      { value: "getRepositoryPullRequests", label: "Get Repository Pull Requests" },
+      { value: "createReview", label: "Create Review" },
+      { value: "getReview", label: "Get Review" },
+      { value: "listReviews", label: "List Reviews" },
+      { value: "updateReview", label: "Update Review" },
+    ],
+  },
+  {
+    label: "Releases",
+    options: [
+      { value: "createRelease", label: "Create Release" },
+      { value: "deleteRelease", label: "Delete Release" },
+      { value: "getRelease", label: "Get Release" },
+      { value: "listReleases", label: "List Releases" },
+      { value: "updateRelease", label: "Update Release" },
+    ],
+  },
+  {
+    label: "Actions Workflows",
+    options: [
+      { value: "dispatchWorkflow", label: "Dispatch Workflow" },
+      { value: "dispatchWorkflowAndWait", label: "Dispatch Workflow and Wait" },
+      { value: "disableWorkflow", label: "Disable Workflow" },
+      { value: "enableWorkflow", label: "Enable Workflow" },
+      { value: "getWorkflow", label: "Get Workflow" },
+      { value: "getWorkflowUsage", label: "Get Workflow Usage" },
+      { value: "listWorkflows", label: "List Workflows" },
+    ],
+  },
+  {
+    label: "Files",
+    options: [
+      { value: "upsertFile", label: "Create or Update File" },
+      { value: "deleteFile", label: "Delete File" },
+      { value: "getFile", label: "Get File" },
+      { value: "listFiles", label: "List Files" },
+    ],
+  },
+];
+
+export const githubOperationOptions: OperationOption[] =
+  flattenOperationGroups(githubOperationGroups);
+
+export const gristOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "getRecord", label: "Get Record" },
+  { value: "getRecords", label: "Get Records" },
+  { value: "createRecord", label: "Create Record" },
+  { value: "createRecords", label: "Create Records (Batch)" },
+  { value: "updateRecord", label: "Update Record" },
+  { value: "updateRecords", label: "Update Records (Batch)" },
+  { value: "deleteRecord", label: "Delete Record(s)" },
+  { value: "listTables", label: "List Tables" },
+  { value: "listColumns", label: "List Columns" },
+];
+
+export const googleSheetsOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "readRange", label: "Read" },
+  { value: "appendRows", label: "Append Rows" },
+  { value: "updateRange", label: "Update Rows" },
+  { value: "clearRange", label: "Clear Rows" },
+  { value: "getSheetInfo", label: "Get Sheet Info" },
+];
+
+export const bigQueryOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "query", label: "Run Query" },
+  { value: "insertRows", label: "Insert Rows" },
+];
+
+export const clickhouseOperationGroups: OperationOptionGroup[] = [
+  {
+    options: [
+      { value: "", label: "Select operation..." },
+      { value: "query", label: "Run SQL Query" },
+    ],
+  },
+  {
+    label: "Read",
+    options: [
+      { value: "find", label: "Find Rows" },
+      { value: "getAll", label: "Get All Rows" },
+      { value: "count", label: "Count Rows" },
+      { value: "getById", label: "Get By ID" },
+    ],
+  },
+  {
+    label: "Write",
+    options: [
+      { value: "insert", label: "Insert Rows" },
+      { value: "update", label: "Update Rows" },
+      { value: "remove", label: "Remove Rows" },
+      { value: "upsert", label: "Upsert Rows" },
+    ],
+  },
+];
+
+export const clickhouseOperationOptions: OperationOption[] =
+  flattenOperationGroups(clickhouseOperationGroups);
+
+export const supabaseOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "select", label: "Select Rows" },
+  { value: "insert", label: "Insert Rows" },
+  { value: "update", label: "Update Rows" },
+  { value: "upsert", label: "Upsert Rows" },
+  { value: "delete", label: "Delete Rows" },
+];
+
+export const notionOperationGroups: OperationOptionGroup[] = [
+  {
+    options: [
+      { value: "", label: "Select operation..." },
+      { value: "search", label: "Search" },
+    ],
+  },
+  {
+    label: "Pages",
+    options: [
+      { value: "getPage", label: "Get Page" },
+      { value: "createPage", label: "Create Page" },
+      { value: "updatePage", label: "Update Page" },
+      { value: "trashPage", label: "Move Page to Trash" },
+      { value: "restorePage", label: "Restore Page" },
+    ],
+  },
+  {
+    label: "Databases",
+    options: [
+      { value: "createDatabase", label: "Create Database" },
+      { value: "retrieveDatabase", label: "Retrieve Database" },
+      { value: "updateDatabase", label: "Update Database" },
+    ],
+  },
+  {
+    label: "Data Sources",
+    options: [
+      { value: "createDataSource", label: "Create Data Source" },
+      { value: "retrieveDataSource", label: "Retrieve Data Source" },
+      { value: "updateDataSource", label: "Update Data Source" },
+      { value: "queryDataSource", label: "Query Data Source" },
+    ],
+  },
+  {
+    label: "Blocks",
+    options: [
+      { value: "getBlockChildren", label: "Get Block Children" },
+      { value: "updateBlock", label: "Update Block" },
+      { value: "deleteBlock", label: "Delete Block" },
+      { value: "appendBlocks", label: "Append Blocks" },
+    ],
+  },
+];
+
+export const notionOperationOptions: OperationOption[] =
+  flattenOperationGroups(notionOperationGroups);
+
+export const s3OperationGroups: OperationOptionGroup[] = [
+  {
+    label: "Buckets",
+    options: [
+      { value: "createBucket", label: "Create Bucket" },
+      { value: "deleteBucket", label: "Delete Bucket" },
+      { value: "listBuckets", label: "List Buckets" },
+    ],
+  },
+  {
+    label: "Folders",
+    options: [
+      { value: "createFolder", label: "Create Folder" },
+      { value: "deleteFolder", label: "Delete Folder" },
+      { value: "getAllFolder", label: "Get All in Folder" },
+    ],
+  },
+  {
+    label: "Objects",
+    options: [
+      { value: "copyObject", label: "Copy Object" },
+      { value: "deleteObject", label: "Delete Object" },
+      { value: "getObject", label: "Get Object" },
+      { value: "listObjects", label: "List Objects" },
+      { value: "putObject", label: "Upload Object" },
+    ],
+  },
+];
+
+export const s3OperationOptions: OperationOption[] = flattenOperationGroups(s3OperationGroups);
+
+export const dataTableOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "find", label: "Find Rows" },
+  { value: "getAll", label: "Get All Rows" },
+  { value: "count", label: "Count Rows" },
+  { value: "getById", label: "Get Row by ID" },
+  { value: "insert", label: "Insert Row" },
+  { value: "update", label: "Update Row" },
+  { value: "remove", label: "Remove Row" },
+  { value: "upsert", label: "Upsert Row" },
+];
+
+export const driveOperationOptions: OperationOption[] = [
+  { value: "get", label: "Get File" },
+  { value: "getAll", label: "Get All Files" },
+  { value: "downloadUrl", label: "Download from URL" },
+  { value: "save", label: "Save from Base64" },
+  { value: "convertFile", label: "Convert File" },
+  { value: "delete", label: "Delete File" },
+  { value: "setPassword", label: "Set Password" },
+  { value: "setTtl", label: "Set TTL (Expiry)" },
+  { value: "setMaxDownloads", label: "Set Max Downloads" },
+];
+
+export const rabbitmqOperationOptions: OperationOption[] = [
+  { value: "", label: "Select operation..." },
+  { value: "send", label: "Send Message" },
+  { value: "receive", label: "Receive Message (Trigger)" },
+];

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -5073,6 +5073,41 @@ export function usePropertiesPanelController() {
     { value: "unresolveComment", label: "Unresolve Comment" },
   ];
 
+  const linearOperationGroups = [
+    {
+      label: "Workspace",
+      options: [
+        { value: "getViewer", label: "Get Viewer" },
+        { value: "listTeams", label: "List Teams" },
+        { value: "listProjects", label: "List Projects" },
+        { value: "listWorkflowStates", label: "List Workflow States" },
+        { value: "listTeamMembers", label: "List Team Members" },
+      ],
+    },
+    {
+      label: "Issues",
+      options: [
+        { value: "listIssues", label: "List Issues" },
+        { value: "getIssue", label: "Get Issue" },
+        { value: "createIssue", label: "Create Issue" },
+        { value: "updateIssue", label: "Update Issue" },
+        { value: "deleteIssue", label: "Delete Issue" },
+        { value: "addIssueLink", label: "Add Issue Link" },
+      ],
+    },
+    {
+      label: "Comments",
+      options: [
+        { value: "createComment", label: "Create Comment" },
+        { value: "listComments", label: "List Comments" },
+        { value: "updateComment", label: "Update Comment" },
+        { value: "deleteComment", label: "Delete Comment" },
+        { value: "resolveComment", label: "Resolve Comment" },
+        { value: "unresolveComment", label: "Unresolve Comment" },
+      ],
+    },
+  ];
+
   const githubOperationOptions = [
     { value: "getRepository", label: "Get Repository" },
     { value: "getRepositoryLicense", label: "Get Repository License" },
@@ -5114,6 +5149,84 @@ export function usePropertiesPanelController() {
     { value: "deleteFile", label: "Delete File" },
     { value: "getFile", label: "Get File" },
     { value: "listFiles", label: "List Files" },
+  ];
+
+  const githubOperationGroups = [
+    {
+      label: "Repository",
+      options: [
+        { value: "getRepository", label: "Get Repository" },
+        { value: "getRepositoryLicense", label: "Get Repository License" },
+        { value: "getRepositoryProfile", label: "Get Repository Profile" },
+        { value: "listPopularPaths", label: "List Popular Paths for Repository" },
+        { value: "listReferrers", label: "List Top Referrers for Repository" },
+      ],
+    },
+    {
+      label: "Users and Organizations",
+      options: [
+        { value: "listOrganizationRepositories", label: "List Organization Repositories" },
+        { value: "listUserRepositories", label: "List User Repositories" },
+        { value: "getUserRepositories", label: "Get User Repositories" },
+        { value: "getUserIssues", label: "Get User Issues" },
+        { value: "inviteUser", label: "Invite User" },
+      ],
+    },
+    {
+      label: "Issues",
+      options: [
+        { value: "createIssue", label: "Create Issue" },
+        { value: "getIssue", label: "Get Issue" },
+        { value: "listIssues", label: "List Issues" },
+        { value: "getRepositoryIssues", label: "Get Repository Issues" },
+        { value: "lockIssue", label: "Lock Issue" },
+        { value: "updateIssue", label: "Edit Issue" },
+        { value: "createComment", label: "Create Comment" },
+      ],
+    },
+    {
+      label: "Pull Requests and Reviews",
+      options: [
+        { value: "createPullRequest", label: "Create Pull Request" },
+        { value: "listPullRequests", label: "List Pull Requests" },
+        { value: "getRepositoryPullRequests", label: "Get Repository Pull Requests" },
+        { value: "createReview", label: "Create Review" },
+        { value: "getReview", label: "Get Review" },
+        { value: "listReviews", label: "List Reviews" },
+        { value: "updateReview", label: "Update Review" },
+      ],
+    },
+    {
+      label: "Releases",
+      options: [
+        { value: "createRelease", label: "Create Release" },
+        { value: "deleteRelease", label: "Delete Release" },
+        { value: "getRelease", label: "Get Release" },
+        { value: "listReleases", label: "List Releases" },
+        { value: "updateRelease", label: "Update Release" },
+      ],
+    },
+    {
+      label: "Actions Workflows",
+      options: [
+        { value: "dispatchWorkflow", label: "Dispatch Workflow" },
+        { value: "dispatchWorkflowAndWait", label: "Dispatch Workflow and Wait" },
+        { value: "disableWorkflow", label: "Disable Workflow" },
+        { value: "enableWorkflow", label: "Enable Workflow" },
+        { value: "getWorkflow", label: "Get Workflow" },
+        { value: "getWorkflowUsage", label: "Get Workflow Usage" },
+        { value: "listWorkflows", label: "List Workflows" },
+      ],
+    },
+    {
+      label: "Files",
+      options: [
+        { value: "upsertFile", label: "Create or Update File" },
+        { value: "deleteFile", label: "Delete File" },
+        { value: "getFile", label: "Get File" },
+        { value: "listFiles", label: "List Files" },
+      ],
+    },
   ];
 
   const githubStateOptions = [
@@ -5328,6 +5441,33 @@ export function usePropertiesPanelController() {
     { value: "upsert", label: "Upsert Rows" },
   ];
 
+  const clickhouseOperationGroups = [
+    {
+      options: [
+        { value: "", label: "Select operation..." },
+        { value: "query", label: "Run SQL Query" },
+      ],
+    },
+    {
+      label: "Read",
+      options: [
+        { value: "find", label: "Find Rows" },
+        { value: "getAll", label: "Get All Rows" },
+        { value: "count", label: "Count Rows" },
+        { value: "getById", label: "Get By ID" },
+      ],
+    },
+    {
+      label: "Write",
+      options: [
+        { value: "insert", label: "Insert Rows" },
+        { value: "update", label: "Update Rows" },
+        { value: "remove", label: "Remove Rows" },
+        { value: "upsert", label: "Upsert Rows" },
+      ],
+    },
+  ];
+
   const supabaseCredentialOptions = computed(() => {
     const node = selectedNode.value;
     const selectedCredentialId =
@@ -5386,6 +5526,51 @@ export function usePropertiesPanelController() {
     { value: "updateBlock", label: "Update Block" },
     { value: "deleteBlock", label: "Delete Block" },
     { value: "appendBlocks", label: "Append Blocks" },
+  ];
+
+  const notionOperationGroups = [
+    {
+      options: [
+        { value: "", label: "Select operation..." },
+        { value: "search", label: "Search" },
+      ],
+    },
+    {
+      label: "Pages",
+      options: [
+        { value: "getPage", label: "Get Page" },
+        { value: "createPage", label: "Create Page" },
+        { value: "updatePage", label: "Update Page" },
+        { value: "trashPage", label: "Move Page to Trash" },
+        { value: "restorePage", label: "Restore Page" },
+      ],
+    },
+    {
+      label: "Databases",
+      options: [
+        { value: "createDatabase", label: "Create Database" },
+        { value: "retrieveDatabase", label: "Retrieve Database" },
+        { value: "updateDatabase", label: "Update Database" },
+      ],
+    },
+    {
+      label: "Data Sources",
+      options: [
+        { value: "createDataSource", label: "Create Data Source" },
+        { value: "retrieveDataSource", label: "Retrieve Data Source" },
+        { value: "updateDataSource", label: "Update Data Source" },
+        { value: "queryDataSource", label: "Query Data Source" },
+      ],
+    },
+    {
+      label: "Blocks",
+      options: [
+        { value: "getBlockChildren", label: "Get Block Children" },
+        { value: "updateBlock", label: "Update Block" },
+        { value: "deleteBlock", label: "Delete Block" },
+        { value: "appendBlocks", label: "Append Blocks" },
+      ],
+    },
   ];
 
   const notionDataSourceOptions = computed(() => {
@@ -5504,6 +5689,35 @@ export function usePropertiesPanelController() {
     { value: "listObjects", label: "List Objects" },
     { value: "putObject", label: "Upload Object" },
 
+  ];
+
+  const s3OperationGroups = [
+    {
+      label: "Buckets",
+      options: [
+        { value: "createBucket", label: "Create Bucket" },
+        { value: "deleteBucket", label: "Delete Bucket" },
+        { value: "listBuckets", label: "List Buckets" },
+      ],
+    },
+    {
+      label: "Folders",
+      options: [
+        { value: "createFolder", label: "Create Folder" },
+        { value: "deleteFolder", label: "Delete Folder" },
+        { value: "getAllFolder", label: "Get All in Folder" },
+      ],
+    },
+    {
+      label: "Objects",
+      options: [
+        { value: "copyObject", label: "Copy Object" },
+        { value: "deleteObject", label: "Delete Object" },
+        { value: "getObject", label: "Get Object" },
+        { value: "listObjects", label: "List Objects" },
+        { value: "putObject", label: "Upload Object" },
+      ],
+    },
   ];
 
   const S3_LIST_OBJECTS_MAX_KEYS = 1000;
@@ -8126,7 +8340,9 @@ export function usePropertiesPanelController() {
     githubCredentialOptions,
     linearCredentialOptions,
     linearOperationOptions,
+    linearOperationGroups,
     githubOperationOptions,
+    githubOperationGroups,
     githubStateOptions,
     githubIssueSortOptions,
     githubPullRequestSortOptions,
@@ -8147,10 +8363,12 @@ export function usePropertiesPanelController() {
     bigQueryOperationOptions,
     clickhouseCredentialOptions,
     clickhouseOperationOptions,
+    clickhouseOperationGroups,
     supabaseCredentialOptions,
     supabaseOperationOptions,
     notionCredentialOptions,
     notionOperationOptions,
+    notionOperationGroups,
     notionDataSourceOptions,
     notionAppendPositionOptions,
     notionPageOptions,
@@ -8160,6 +8378,7 @@ export function usePropertiesPanelController() {
     useAllDiscoveredSupabaseColumns,
     s3CredentialOptions,
     s3OperationOptions,
+    s3OperationGroups,
     s3MaxKeysWarning,
     dataTableOperationOptions,
     driveOperationOptions,

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -1,4 +1,15 @@
-import { computed, nextTick, onMounted, onUnmounted, ref, watch, type ComponentPublicInstance } from "vue";
+import {
+  computed,
+  inject,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  provide,
+  ref,
+  watch,
+  type ComponentPublicInstance,
+  type InjectionKey,
+} from "vue";
 import { useRouter } from "vue-router";
 import { AlertTriangle, Ban, BarChart3, Bot, Braces, Brain, Bug, CalendarClock, Clock, Database, FileJson, FileText, GitBranch, GitMerge, Github, Globe, HardDrive, Inbox, ListTodo, Mail, MessageSquare, MonitorPlay, Play, Plug, Puzzle, Rabbit, Radio, Repeat, Search, Send, Server, Settings2, Sheet, Shuffle, StickyNote, Table2, Terminal, Type, Upload, Variable, XCircle } from "lucide-vue-next";
 import type { ClickHouseColumn, CredentialListItem, LLMModel, NotionDataSourceItem, NotionPageItem } from "@/types/credential";
@@ -23,7 +34,27 @@ import { useRunbookPlayer } from "@/features/runbook/useRunbookPlayer";
 import type { NodeType } from "@/types/workflow";
 import type { WebSocketTriggerEventName } from "@/types/workflow";
 import { NODE_DEFINITIONS } from "@/types/node";
-import { inject, provide, type InjectionKey } from "vue";
+import {
+  bigQueryOperationOptions,
+  clickhouseOperationGroups,
+  clickhouseOperationOptions,
+  dataTableOperationOptions,
+  driveOperationOptions,
+  githubOperationGroups,
+  githubOperationOptions,
+  googleSheetsOperationOptions,
+  gristOperationOptions,
+  linearOperationGroups,
+  linearOperationOptions,
+  notionOperationGroups,
+  notionOperationOptions,
+  rabbitmqOperationOptions,
+  ragOperationOptions,
+  redisOperationOptions,
+  s3OperationGroups,
+  s3OperationOptions,
+  supabaseOperationOptions,
+} from "./operationOptions";
 
 interface ExpandableFieldRef {
   openExpandDialog(localIndex?: number): void;
@@ -1438,6 +1469,16 @@ export function usePropertiesPanelController() {
     if (node?.type !== "execute") return null;
     return node.data.executeWorkflowId || null;
   });
+
+  function updateExecuteWorkflowId(value: string | undefined): void {
+    const workflowId = value || "";
+    updateNodeData("executeWorkflowId", workflowId);
+    if (!workflowId) {
+      updateNodeData("targetWorkflowInputFields", []);
+      updateNodeData("targetWorkflowName", "");
+      updateNodeData("executeInputMappings", []);
+    }
+  }
 
   watch(
     executeWorkflowId,
@@ -4994,20 +5035,6 @@ export function usePropertiesPanelController() {
     { value: "pgvector", label: "Postgres (pgvector)" },
   ];
 
-  const ragOperationOptions = [
-    { value: "", label: "Select operation" },
-    { value: "insert", label: "Insert" },
-    { value: "search", label: "Search" },
-  ];
-
-  const redisOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "set", label: "Set Variable" },
-    { value: "get", label: "Get Variable" },
-    { value: "hasKey", label: "Has Key" },
-    { value: "deleteKey", label: "Delete Key" },
-  ];
-
   const gristCredentialOptions = computed(() => {
     const node = selectedNode.value;
     const selectedCredentialId =
@@ -5052,182 +5079,6 @@ export function usePropertiesPanelController() {
       "Shared Linear credential (from owner)",
     );
   });
-
-  const linearOperationOptions = [
-    { value: "getViewer", label: "Get Viewer" },
-    { value: "listTeams", label: "List Teams" },
-    { value: "listProjects", label: "List Projects" },
-    { value: "listIssues", label: "List Issues" },
-    { value: "listWorkflowStates", label: "List Workflow States" },
-    { value: "listTeamMembers", label: "List Team Members" },
-    { value: "getIssue", label: "Get Issue" },
-    { value: "createIssue", label: "Create Issue" },
-    { value: "updateIssue", label: "Update Issue" },
-    { value: "deleteIssue", label: "Delete Issue" },
-    { value: "addIssueLink", label: "Add Issue Link" },
-    { value: "createComment", label: "Create Comment" },
-    { value: "listComments", label: "List Comments" },
-    { value: "updateComment", label: "Update Comment" },
-    { value: "deleteComment", label: "Delete Comment" },
-    { value: "resolveComment", label: "Resolve Comment" },
-    { value: "unresolveComment", label: "Unresolve Comment" },
-  ];
-
-  const linearOperationGroups = [
-    {
-      label: "Workspace",
-      options: [
-        { value: "getViewer", label: "Get Viewer" },
-        { value: "listTeams", label: "List Teams" },
-        { value: "listProjects", label: "List Projects" },
-        { value: "listWorkflowStates", label: "List Workflow States" },
-        { value: "listTeamMembers", label: "List Team Members" },
-      ],
-    },
-    {
-      label: "Issues",
-      options: [
-        { value: "listIssues", label: "List Issues" },
-        { value: "getIssue", label: "Get Issue" },
-        { value: "createIssue", label: "Create Issue" },
-        { value: "updateIssue", label: "Update Issue" },
-        { value: "deleteIssue", label: "Delete Issue" },
-        { value: "addIssueLink", label: "Add Issue Link" },
-      ],
-    },
-    {
-      label: "Comments",
-      options: [
-        { value: "createComment", label: "Create Comment" },
-        { value: "listComments", label: "List Comments" },
-        { value: "updateComment", label: "Update Comment" },
-        { value: "deleteComment", label: "Delete Comment" },
-        { value: "resolveComment", label: "Resolve Comment" },
-        { value: "unresolveComment", label: "Unresolve Comment" },
-      ],
-    },
-  ];
-
-  const githubOperationOptions = [
-    { value: "getRepository", label: "Get Repository" },
-    { value: "getRepositoryLicense", label: "Get Repository License" },
-    { value: "getRepositoryProfile", label: "Get Repository Profile" },
-    { value: "listPopularPaths", label: "List Popular Paths for Repository" },
-    { value: "listReferrers", label: "List Top Referrers for Repository" },
-    { value: "listOrganizationRepositories", label: "List Organization Repositories" },
-    { value: "listUserRepositories", label: "List User Repositories" },
-    { value: "getUserRepositories", label: "Get User Repositories" },
-    { value: "getUserIssues", label: "Get User Issues" },
-    { value: "inviteUser", label: "Invite User" },
-    { value: "createIssue", label: "Create Issue" },
-    { value: "getIssue", label: "Get Issue" },
-    { value: "listIssues", label: "List Issues" },
-    { value: "getRepositoryIssues", label: "Get Repository Issues" },
-    { value: "lockIssue", label: "Lock Issue" },
-    { value: "updateIssue", label: "Edit Issue" },
-    { value: "createComment", label: "Create Comment" },
-    { value: "createPullRequest", label: "Create Pull Request" },
-    { value: "listPullRequests", label: "List Pull Requests" },
-    { value: "getRepositoryPullRequests", label: "Get Repository Pull Requests" },
-    { value: "createReview", label: "Create Review" },
-    { value: "getReview", label: "Get Review" },
-    { value: "listReviews", label: "List Reviews" },
-    { value: "updateReview", label: "Update Review" },
-    { value: "createRelease", label: "Create Release" },
-    { value: "deleteRelease", label: "Delete Release" },
-    { value: "getRelease", label: "Get Release" },
-    { value: "listReleases", label: "List Releases" },
-    { value: "updateRelease", label: "Update Release" },
-    { value: "dispatchWorkflow", label: "Dispatch Workflow" },
-    { value: "dispatchWorkflowAndWait", label: "Dispatch Workflow and Wait" },
-    { value: "disableWorkflow", label: "Disable Workflow" },
-    { value: "enableWorkflow", label: "Enable Workflow" },
-    { value: "getWorkflow", label: "Get Workflow" },
-    { value: "getWorkflowUsage", label: "Get Workflow Usage" },
-    { value: "listWorkflows", label: "List Workflows" },
-    { value: "upsertFile", label: "Create or Update File" },
-    { value: "deleteFile", label: "Delete File" },
-    { value: "getFile", label: "Get File" },
-    { value: "listFiles", label: "List Files" },
-  ];
-
-  const githubOperationGroups = [
-    {
-      label: "Repository",
-      options: [
-        { value: "getRepository", label: "Get Repository" },
-        { value: "getRepositoryLicense", label: "Get Repository License" },
-        { value: "getRepositoryProfile", label: "Get Repository Profile" },
-        { value: "listPopularPaths", label: "List Popular Paths for Repository" },
-        { value: "listReferrers", label: "List Top Referrers for Repository" },
-      ],
-    },
-    {
-      label: "Users and Organizations",
-      options: [
-        { value: "listOrganizationRepositories", label: "List Organization Repositories" },
-        { value: "listUserRepositories", label: "List User Repositories" },
-        { value: "getUserRepositories", label: "Get User Repositories" },
-        { value: "getUserIssues", label: "Get User Issues" },
-        { value: "inviteUser", label: "Invite User" },
-      ],
-    },
-    {
-      label: "Issues",
-      options: [
-        { value: "createIssue", label: "Create Issue" },
-        { value: "getIssue", label: "Get Issue" },
-        { value: "listIssues", label: "List Issues" },
-        { value: "getRepositoryIssues", label: "Get Repository Issues" },
-        { value: "lockIssue", label: "Lock Issue" },
-        { value: "updateIssue", label: "Edit Issue" },
-        { value: "createComment", label: "Create Comment" },
-      ],
-    },
-    {
-      label: "Pull Requests and Reviews",
-      options: [
-        { value: "createPullRequest", label: "Create Pull Request" },
-        { value: "listPullRequests", label: "List Pull Requests" },
-        { value: "getRepositoryPullRequests", label: "Get Repository Pull Requests" },
-        { value: "createReview", label: "Create Review" },
-        { value: "getReview", label: "Get Review" },
-        { value: "listReviews", label: "List Reviews" },
-        { value: "updateReview", label: "Update Review" },
-      ],
-    },
-    {
-      label: "Releases",
-      options: [
-        { value: "createRelease", label: "Create Release" },
-        { value: "deleteRelease", label: "Delete Release" },
-        { value: "getRelease", label: "Get Release" },
-        { value: "listReleases", label: "List Releases" },
-        { value: "updateRelease", label: "Update Release" },
-      ],
-    },
-    {
-      label: "Actions Workflows",
-      options: [
-        { value: "dispatchWorkflow", label: "Dispatch Workflow" },
-        { value: "dispatchWorkflowAndWait", label: "Dispatch Workflow and Wait" },
-        { value: "disableWorkflow", label: "Disable Workflow" },
-        { value: "enableWorkflow", label: "Enable Workflow" },
-        { value: "getWorkflow", label: "Get Workflow" },
-        { value: "getWorkflowUsage", label: "Get Workflow Usage" },
-        { value: "listWorkflows", label: "List Workflows" },
-      ],
-    },
-    {
-      label: "Files",
-      options: [
-        { value: "upsertFile", label: "Create or Update File" },
-        { value: "deleteFile", label: "Delete File" },
-        { value: "getFile", label: "Get File" },
-        { value: "listFiles", label: "List Files" },
-      ],
-    },
-  ];
 
   const githubStateOptions = [
     { value: "open", label: "Open" },
@@ -5365,28 +5216,6 @@ export function usePropertiesPanelController() {
     return options;
   });
 
-  const gristOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "getRecord", label: "Get Record" },
-    { value: "getRecords", label: "Get Records" },
-    { value: "createRecord", label: "Create Record" },
-    { value: "createRecords", label: "Create Records (Batch)" },
-    { value: "updateRecord", label: "Update Record" },
-    { value: "updateRecords", label: "Update Records (Batch)" },
-    { value: "deleteRecord", label: "Delete Record(s)" },
-    { value: "listTables", label: "List Tables" },
-    { value: "listColumns", label: "List Columns" },
-  ];
-
-  const googleSheetsOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "readRange", label: "Read" },
-    { value: "appendRows", label: "Append Rows" },
-    { value: "updateRange", label: "Update Rows" },
-    { value: "clearRange", label: "Clear Rows" },
-    { value: "getSheetInfo", label: "Get Sheet Info" },
-  ];
-
   const googleSheetsAppendPlacementOptions = [
     { value: "append", label: "Bottom (after last row)" },
     { value: "prepend", label: "Top (below row 1)" },
@@ -5407,12 +5236,6 @@ export function usePropertiesPanelController() {
     );
   });
 
-  const bigQueryOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "query", label: "Run Query" },
-    { value: "insertRows", label: "Insert Rows" },
-  ];
-
   const clickhouseCredentialOptions = computed(() => {
     const node = selectedNode.value;
     const selectedCredentialId =
@@ -5427,46 +5250,6 @@ export function usePropertiesPanelController() {
       "Shared ClickHouse credential (from owner)",
     );
   });
-
-  const clickhouseOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "query", label: "Run SQL Query" },
-    { value: "find", label: "Find Rows" },
-    { value: "getAll", label: "Get All Rows" },
-    { value: "count", label: "Count Rows" },
-    { value: "getById", label: "Get By ID" },
-    { value: "insert", label: "Insert Rows" },
-    { value: "update", label: "Update Rows" },
-    { value: "remove", label: "Remove Rows" },
-    { value: "upsert", label: "Upsert Rows" },
-  ];
-
-  const clickhouseOperationGroups = [
-    {
-      options: [
-        { value: "", label: "Select operation..." },
-        { value: "query", label: "Run SQL Query" },
-      ],
-    },
-    {
-      label: "Read",
-      options: [
-        { value: "find", label: "Find Rows" },
-        { value: "getAll", label: "Get All Rows" },
-        { value: "count", label: "Count Rows" },
-        { value: "getById", label: "Get By ID" },
-      ],
-    },
-    {
-      label: "Write",
-      options: [
-        { value: "insert", label: "Insert Rows" },
-        { value: "update", label: "Update Rows" },
-        { value: "remove", label: "Remove Rows" },
-        { value: "upsert", label: "Upsert Rows" },
-      ],
-    },
-  ];
 
   const supabaseCredentialOptions = computed(() => {
     const node = selectedNode.value;
@@ -5483,15 +5266,6 @@ export function usePropertiesPanelController() {
     );
   });
 
-  const supabaseOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "select", label: "Select Rows" },
-    { value: "insert", label: "Insert Rows" },
-    { value: "update", label: "Update Rows" },
-    { value: "upsert", label: "Upsert Rows" },
-    { value: "delete", label: "Delete Rows" },
-  ];
-
   const notionCredentialOptions = computed(() => {
     const node = selectedNode.value;
     const selectedCredentialId =
@@ -5506,72 +5280,6 @@ export function usePropertiesPanelController() {
       "Shared Notion credential (from owner)",
     );
   });
-
-  const notionOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "search", label: "Search" },
-    { value: "getPage", label: "Get Page" },
-    { value: "createPage", label: "Create Page" },
-    { value: "updatePage", label: "Update Page" },
-    { value: "trashPage", label: "Move Page to Trash" },
-    { value: "restorePage", label: "Restore Page" },
-    { value: "createDatabase", label: "Create Database" },
-    { value: "retrieveDatabase", label: "Retrieve Database" },
-    { value: "updateDatabase", label: "Update Database" },
-    { value: "createDataSource", label: "Create Data Source" },
-    { value: "retrieveDataSource", label: "Retrieve Data Source" },
-    { value: "updateDataSource", label: "Update Data Source" },
-    { value: "queryDataSource", label: "Query Data Source" },
-    { value: "getBlockChildren", label: "Get Block Children" },
-    { value: "updateBlock", label: "Update Block" },
-    { value: "deleteBlock", label: "Delete Block" },
-    { value: "appendBlocks", label: "Append Blocks" },
-  ];
-
-  const notionOperationGroups = [
-    {
-      options: [
-        { value: "", label: "Select operation..." },
-        { value: "search", label: "Search" },
-      ],
-    },
-    {
-      label: "Pages",
-      options: [
-        { value: "getPage", label: "Get Page" },
-        { value: "createPage", label: "Create Page" },
-        { value: "updatePage", label: "Update Page" },
-        { value: "trashPage", label: "Move Page to Trash" },
-        { value: "restorePage", label: "Restore Page" },
-      ],
-    },
-    {
-      label: "Databases",
-      options: [
-        { value: "createDatabase", label: "Create Database" },
-        { value: "retrieveDatabase", label: "Retrieve Database" },
-        { value: "updateDatabase", label: "Update Database" },
-      ],
-    },
-    {
-      label: "Data Sources",
-      options: [
-        { value: "createDataSource", label: "Create Data Source" },
-        { value: "retrieveDataSource", label: "Retrieve Data Source" },
-        { value: "updateDataSource", label: "Update Data Source" },
-        { value: "queryDataSource", label: "Query Data Source" },
-      ],
-    },
-    {
-      label: "Blocks",
-      options: [
-        { value: "getBlockChildren", label: "Get Block Children" },
-        { value: "updateBlock", label: "Update Block" },
-        { value: "deleteBlock", label: "Delete Block" },
-        { value: "appendBlocks", label: "Append Blocks" },
-      ],
-    },
-  ];
 
   const notionDataSourceOptions = computed(() => {
     const selectedId =
@@ -5676,76 +5384,8 @@ export function usePropertiesPanelController() {
     );
   });
 
-  const s3OperationOptions = [
-    { value: "createBucket", label: "Create Bucket" },
-    { value: "deleteBucket", label: "Delete Bucket" },
-    { value: "listBuckets", label: "List Buckets" },
-    { value: "createFolder", label: "Create Folder" },
-    { value: "deleteFolder", label: "Delete Folder" },
-    { value: "getAllFolder", label: "Get All in Folder" },
-    { value: "copyObject", label: "Copy Object" },
-    { value: "deleteObject", label: "Delete Object" },
-    { value: "getObject", label: "Get Object" },
-    { value: "listObjects", label: "List Objects" },
-    { value: "putObject", label: "Upload Object" },
-
-  ];
-
-  const s3OperationGroups = [
-    {
-      label: "Buckets",
-      options: [
-        { value: "createBucket", label: "Create Bucket" },
-        { value: "deleteBucket", label: "Delete Bucket" },
-        { value: "listBuckets", label: "List Buckets" },
-      ],
-    },
-    {
-      label: "Folders",
-      options: [
-        { value: "createFolder", label: "Create Folder" },
-        { value: "deleteFolder", label: "Delete Folder" },
-        { value: "getAllFolder", label: "Get All in Folder" },
-      ],
-    },
-    {
-      label: "Objects",
-      options: [
-        { value: "copyObject", label: "Copy Object" },
-        { value: "deleteObject", label: "Delete Object" },
-        { value: "getObject", label: "Get Object" },
-        { value: "listObjects", label: "List Objects" },
-        { value: "putObject", label: "Upload Object" },
-      ],
-    },
-  ];
-
   const S3_LIST_OBJECTS_MAX_KEYS = 1000;
   const s3MaxKeysWarning = ref("");
-
-  const dataTableOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "find", label: "Find Rows" },
-    { value: "getAll", label: "Get All Rows" },
-    { value: "count", label: "Count Rows" },
-    { value: "getById", label: "Get Row by ID" },
-    { value: "insert", label: "Insert Row" },
-    { value: "update", label: "Update Row" },
-    { value: "remove", label: "Remove Row" },
-    { value: "upsert", label: "Upsert Row" },
-  ];
-
-  const driveOperationOptions = [
-    { value: "get", label: "Get File" },
-    { value: "getAll", label: "Get All Files" },
-    { value: "downloadUrl", label: "Download from URL" },
-    { value: "save", label: "Save from Base64" },
-    { value: "convertFile", label: "Convert File" },
-    { value: "delete", label: "Delete File" },
-    { value: "setPassword", label: "Set Password" },
-    { value: "setTtl", label: "Set TTL (Expiry)" },
-    { value: "setMaxDownloads", label: "Set Max Downloads" },
-  ];
 
   const driveConvertFormatOptions = [
     { value: "pdf", label: "PDF (.pdf)" },
@@ -5829,12 +5469,6 @@ export function usePropertiesPanelController() {
       "Shared RabbitMQ credential (from owner)",
     );
   });
-
-  const rabbitmqOperationOptions = [
-    { value: "", label: "Select operation..." },
-    { value: "send", label: "Send Message" },
-    { value: "receive", label: "Receive Message (Trigger)" },
-  ];
 
   const crawlerCredentialOptions = computed(() => {
     const node = selectedNode.value;
@@ -8539,6 +8173,7 @@ export function usePropertiesPanelController() {
     copyOutput,
     canVisitWorkflow,
     visitWorkflow,
+    updateExecuteWorkflowId,
     updateExecuteMapping,
   };
 }

--- a/frontend/src/components/ui/SearchableSelect.vue
+++ b/frontend/src/components/ui/SearchableSelect.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import {
+  ComboboxAnchor,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemIndicator,
+  ComboboxLabel,
+  ComboboxRoot,
+  ComboboxTrigger,
+  ComboboxViewport,
+} from "radix-vue";
+import { Check, ChevronDown, Search, X } from "lucide-vue-next";
+
+import { cn } from "@/lib/utils";
+
+interface Option {
+  value: string | undefined;
+  label: string;
+}
+
+interface InternalOption extends Option {
+  key: string;
+}
+
+interface OptionGroup {
+  label?: string;
+  options: Option[];
+}
+
+interface InternalOptionGroup {
+  key: string;
+  label?: string;
+  options: InternalOption[];
+}
+
+interface Props {
+  modelValue?: string | undefined;
+  options?: Option[];
+  groups?: OptionGroup[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  clearable?: boolean;
+  clearAriaLabel?: string;
+  class?: string;
+  selectClass?: string;
+  contentClass?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: "",
+  options: () => [],
+  groups: undefined,
+  placeholder: "Select...",
+  searchPlaceholder: "Search...",
+  emptyText: "No results found.",
+  disabled: false,
+  clearable: false,
+  clearAriaLabel: "Clear selection",
+  class: undefined,
+  selectClass: undefined,
+  contentClass: undefined,
+});
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string | undefined): void;
+}>();
+
+const open = ref(false);
+const searchTerm = ref("");
+const selectedKey = ref<string>("");
+
+const optionGroups = computed<InternalOptionGroup[]>(() => {
+  const groups = props.groups && props.groups.length > 0
+    ? props.groups
+    : [{ options: props.options }];
+
+  return groups.map((group, groupIndex) => ({
+    key: `group-${groupIndex}`,
+    label: group.label,
+    options: group.options.map((option, optionIndex) => ({
+      ...option,
+      key: `group-${groupIndex}-option-${optionIndex}`,
+    })),
+  })).filter((group) => group.options.length > 0);
+});
+
+const internalOptions = computed<InternalOption[]>(() =>
+  optionGroups.value.flatMap((group) => group.options)
+);
+
+const selectedOption = computed<InternalOption | undefined>(() => {
+  return internalOptions.value.find((option) => {
+    const value = option.value ?? "";
+    return value === (props.modelValue ?? "");
+  });
+});
+
+const hasValue = computed<boolean>(() => {
+  return typeof props.modelValue === "string" && props.modelValue.length > 0;
+});
+
+const wrapperClass = computed(() =>
+  cn("relative group min-w-0 w-full", props.class)
+);
+
+const anchorClass = computed(() =>
+  cn(
+    "flex h-11 min-h-[44px] md:h-10 w-full items-center rounded-xl border border-border bg-background text-sm",
+    "focus-within:outline-none focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/15",
+    "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted/50",
+    "transition-all duration-200 shadow-sm hover:border-border/80",
+    props.disabled && "cursor-not-allowed opacity-50 bg-muted/50",
+    props.selectClass
+  )
+);
+
+const contentClass = computed(() =>
+  cn(
+    "z-50 mt-1 max-h-72 min-w-[var(--radix-combobox-trigger-width)] overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-lg",
+    "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+    props.contentClass
+  )
+);
+
+watch(
+  [selectedOption, internalOptions],
+  () => {
+    selectedKey.value = selectedOption.value?.key ?? "";
+  },
+  { immediate: true }
+);
+
+watch(open, (isOpen) => {
+  if (isOpen) {
+    searchTerm.value = "";
+  }
+});
+
+function displayValue(key: string): string {
+  const option = internalOptions.value.find((item) => item.key === key);
+  return option?.label ?? "";
+}
+
+function filterOptions(keys: string[], term: string): string[] {
+  const normalizedTerm = term.trim().toLowerCase();
+  if (!normalizedTerm) {
+    return keys;
+  }
+
+  return keys.filter((key) => {
+    const option = internalOptions.value.find((item) => item.key === key);
+    if (!option) {
+      return false;
+    }
+
+    return [option.label, option.value ?? ""].some((text) =>
+      text.toLowerCase().includes(normalizedTerm)
+    );
+  });
+}
+
+function openOptions(): void {
+  if (!props.disabled) {
+    open.value = true;
+  }
+}
+
+function handleUpdateSelectedKey(key: string): void {
+  selectedKey.value = key;
+  const option = internalOptions.value.find((item) => item.key === key);
+  const value = option?.value;
+  emit("update:modelValue", value && value.length > 0 ? value : undefined);
+}
+
+function clearValue(): void {
+  selectedKey.value = "";
+  searchTerm.value = "";
+  emit("update:modelValue", undefined);
+}
+</script>
+
+<template>
+  <ComboboxRoot
+    v-model="selectedKey"
+    v-model:open="open"
+    v-model:search-term="searchTerm"
+    :disabled="disabled"
+    :display-value="displayValue"
+    :filter-function="filterOptions"
+    :reset-search-term-on-blur="false"
+    class="relative w-full"
+    @update:model-value="handleUpdateSelectedKey"
+  >
+    <ComboboxAnchor :class="wrapperClass">
+      <div
+        :class="anchorClass"
+        @click="openOptions"
+      >
+        <Search class="ml-3.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <ComboboxInput
+          class="h-full min-w-0 flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground/60 disabled:cursor-not-allowed"
+          :placeholder="open ? searchPlaceholder : placeholder"
+          :disabled="disabled"
+        />
+        <button
+          v-if="clearable && hasValue && !disabled"
+          type="button"
+          :aria-label="clearAriaLabel"
+          class="mr-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 pointer-events-none transition-all hover:bg-muted hover:text-foreground group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+          @mousedown.prevent.stop
+          @click.prevent.stop="clearValue"
+        >
+          <X class="h-3.5 w-3.5" />
+        </button>
+        <ComboboxTrigger
+          class="mr-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed"
+          :class="clearable && hasValue ? 'group-hover:opacity-0 group-focus-within:opacity-0' : ''"
+          :disabled="disabled"
+          aria-label="Toggle options"
+        >
+          <ChevronDown class="h-4 w-4" />
+        </ComboboxTrigger>
+      </div>
+    </ComboboxAnchor>
+
+    <ComboboxContent
+      position="popper"
+      side="bottom"
+      align="start"
+      :side-offset="4"
+      :class="contentClass"
+    >
+      <ComboboxViewport class="max-h-72 overflow-y-auto p-1">
+        <ComboboxEmpty class="px-3 py-6 text-center text-sm text-muted-foreground">
+          {{ emptyText }}
+        </ComboboxEmpty>
+        <ComboboxGroup
+          v-for="group in optionGroups"
+          :key="group.key"
+          class="py-1"
+        >
+          <ComboboxLabel
+            v-if="group.label"
+            class="px-3 pb-1 pt-2 text-xs font-medium text-muted-foreground"
+          >
+            {{ group.label }}
+          </ComboboxLabel>
+          <ComboboxItem
+            v-for="option in group.options"
+            :key="option.key"
+            :value="option.key"
+            class="relative flex min-h-9 cursor-pointer select-none items-center rounded-lg py-2 pl-8 pr-3 text-sm outline-none transition-colors data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+          >
+            <ComboboxItemIndicator class="absolute left-2 flex h-4 w-4 items-center justify-center">
+              <Check class="h-4 w-4" />
+            </ComboboxItemIndicator>
+            <span class="truncate">{{ option.label }}</span>
+          </ComboboxItem>
+        </ComboboxGroup>
+      </ComboboxViewport>
+    </ComboboxContent>
+  </ComboboxRoot>
+</template>


### PR DESCRIPTION
# Summary

Convert node operation dropdowns to the shared searchable select UI across the remaining E2E-covered node property panels. Which can help user find the operation, especially when the operation list is too long. 

UI is in following the pictures:

<img width="594" height="698" alt="0272d8622643e521ae842ffe03132b35" src="https://github.com/user-attachments/assets/04887a5c-519d-45a4-a371-e590243261d9" />
