### PR TITLE
fix: make plugin dependency locking cross-platform

### DIFF
--- a/backend/app/services/plugin_store.py
+++ b/backend/app/services/plugin_store.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import io
 import json
 import logging
+import os
 import shutil
 import subprocess
 import zipfile
 from pathlib import Path
+from typing import BinaryIO
 
 from app.models.plugin_schemas import PluginManifest
 
@@ -102,6 +104,36 @@ def _install_dependencies(dependencies: list[str]) -> None:
         raise PluginInstallError(f"Dependency install failed: {result.stderr.strip()}")
 
 
+def _lock_dependency_file(lock_file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+
+def _unlock_dependency_file(lock_file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
 def ensure_dependencies_installed(dependencies: list[str]) -> None:
     """Best-effort dependency install used on startup; never raises.
 
@@ -114,19 +146,18 @@ def ensure_dependencies_installed(dependencies: list[str]) -> None:
     # The release image runs uvicorn with multiple workers, so this can be called
     # from several processes at once against the same venv. Serialize with a file
     # lock so only one worker installs at a time (the rest then no-op quickly).
-    import fcntl
-
-    lock_path = plugins_root() / ".deps.lock"
     try:
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
+        lock_path = plugins_root() / ".deps.lock"
+        lock_path.touch(exist_ok=True)
+        with open(lock_path, "r+b") as lock_file:
+            _lock_dependency_file(lock_file)
             try:
                 _install_dependencies(dependencies)
             finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
+                _unlock_dependency_file(lock_file)
     except PluginInstallError as exc:
         logger.warning("Plugin dependency reinstall failed: %s", exc)
-    except OSError as exc:
+    except (ImportError, OSError) as exc:
         logger.warning("Plugin dependency reinstall could not acquire lock: %s", exc)
 
 

--- a/backend/tests/test_plugin_store.py
+++ b/backend/tests/test_plugin_store.py
@@ -1,9 +1,12 @@
+import builtins
 import io
+import sys
 import unittest
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from app.services import plugin_store
 from app.services.plugin_store import PluginInstallError
@@ -89,3 +92,64 @@ class PluginStoreTests(unittest.TestCase):
         (target / "handler.py").write_text("x")
         plugin_store.remove_plugin_dir("acme-crm", self.dir)
         self.assertFalse(target.exists())
+
+    def test_dependency_reinstall_noops_without_dependencies(self) -> None:
+        with (
+            patch.object(plugin_store, "plugins_root") as root,
+            patch.object(plugin_store, "_install_dependencies") as install,
+        ):
+            plugin_store.ensure_dependencies_installed([])
+
+        root.assert_not_called()
+        install.assert_not_called()
+
+    def test_dependency_reinstall_uses_windows_lock_without_fcntl(self) -> None:
+        real_import = builtins.__import__
+
+        def import_without_fcntl(name: str, *args, **kwargs):
+            if name == "fcntl":
+                raise AssertionError("fcntl must not be imported on Windows")
+            return real_import(name, *args, **kwargs)
+
+        fake_msvcrt = SimpleNamespace(LK_LOCK=1, LK_UNLCK=2, locking=Mock())
+
+        with (
+            patch.object(plugin_store.os, "name", "nt"),
+            patch.dict(sys.modules, {"msvcrt": fake_msvcrt}),
+            patch("builtins.__import__", side_effect=import_without_fcntl),
+            patch.object(plugin_store, "plugins_root", return_value=self.dir),
+            patch.object(plugin_store, "_install_dependencies") as install,
+        ):
+            plugin_store.ensure_dependencies_installed(["requests"])
+
+        install.assert_called_once_with(["requests"])
+        self.assertEqual(fake_msvcrt.locking.call_count, 2)
+        self.assertEqual(fake_msvcrt.locking.call_args_list[0].args[1], fake_msvcrt.LK_LOCK)
+        self.assertEqual(fake_msvcrt.locking.call_args_list[1].args[1], fake_msvcrt.LK_UNLCK)
+
+    def test_dependency_reinstall_logs_lock_failure_without_raising(self) -> None:
+        with (
+            patch.object(plugin_store, "plugins_root", return_value=self.dir),
+            patch.object(plugin_store, "_lock_dependency_file", side_effect=OSError("locked")),
+            patch.object(plugin_store, "_install_dependencies") as install,
+            self.assertLogs(plugin_store.logger, level="WARNING") as logs,
+        ):
+            plugin_store.ensure_dependencies_installed(["requests"])
+
+        install.assert_not_called()
+        self.assertIn("could not acquire lock", "\n".join(logs.output))
+
+    def test_dependency_reinstall_logs_install_failure_without_raising(self) -> None:
+        with (
+            patch.object(plugin_store, "plugins_root", return_value=self.dir),
+            patch.object(
+                plugin_store,
+                "_install_dependencies",
+                side_effect=PluginInstallError("pip failed"),
+            ) as install,
+            self.assertLogs(plugin_store.logger, level="WARNING") as logs,
+        ):
+            plugin_store.ensure_dependencies_installed(["requests"])
+
+        install.assert_called_once_with(["requests"])
+        self.assertIn("Plugin dependency reinstall failed", "\n".join(logs.output))


### PR DESCRIPTION
## Summary
- make startup plugin dependency reinstall locking work on Windows and POSIX
- keep `ensure_dependencies_installed()` best-effort by logging lock/import/install failures instead of raising
- add regression coverage for no-op empty deps, Windows `msvcrt` locking, lock failures, and dependency install failures

## Validation
- `cd backend && uv run pytest tests/test_plugin_store.py tests/test_plugin_loader.py tests/test_plugin_manifest.py tests/test_plugin_node.py tests/test_plugins_api.py -q` (`34 passed`)
- `cd backend && uv run ruff check app/services/plugin_store.py tests/test_plugin_store.py`
- `cd backend && uv run ruff format --check app/services/plugin_store.py tests/test_plugin_store.py`
- `./check.sh` (`1733 tests, 1733 passed`)

## Review
- Initial code review found missing install-failure coverage; fixed and amended.
- Final review reported no Critical, Important, or Minor findings.
