### PR TITLE
fix: clarify plugin node panel states

### DIFF
--- a/frontend/e2e/plugin-node-properties.spec.ts
+++ b/frontend/e2e/plugin-node-properties.spec.ts
@@ -213,22 +213,20 @@ test("shows when a plugin node is not bound to a package", async ({ page }) => {
   }
 });
 
-test("shows when a plugin node key is missing", async ({ page }) => {
+test("falls back to the first action node without a plugin node key", async ({ page }) => {
   const workflowId = await openWithPlugins(page, {
     pluginId: "acme-crm",
   }, [pluginFixture]);
 
   try {
-    await expect(page.getByTestId("plugin-node-status")).toHaveText(
-      'Plugin "Acme CRM" is missing a plugin node key.',
-    );
-    await expect(pluginFieldLabel(page, "Email", true)).toHaveCount(0);
+    await expect(pluginFieldLabel(page, "Email", true)).toBeVisible();
+    await expect(page.getByTestId("plugin-node-status")).toHaveCount(0);
   } finally {
     await deleteWorkflow(page, workflowId);
   }
 });
 
-test("shows missing, disabled, and missing-node plugin states", async ({ page }) => {
+test("shows missing and disabled plugin states", async ({ page }) => {
   let workflowId = await openWithPlugins(page, {
     pluginId: "missing-plugin",
     pluginNodeKey: "createContact",
@@ -255,16 +253,44 @@ test("shows missing, disabled, and missing-node plugin states", async ({ page })
   } finally {
     await deleteWorkflow(page, workflowId);
   }
+});
 
-  await page.unroute("**/api/plugins");
-  workflowId = await openWithPlugins(page, {
+test("falls back to the first action node when plugin node key is unavailable", async ({
+  page,
+}) => {
+  const workflowId = await openWithPlugins(page, {
     pluginId: "acme-crm",
     pluginNodeKey: "missingNode",
   }, [pluginFixture]);
 
   try {
+    await expect(pluginFieldLabel(page, "Email", true)).toBeVisible();
+    await expect(page.getByTestId("plugin-node-status")).toHaveCount(0);
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows when fallback cannot find a matching plugin node kind", async ({ page }) => {
+  const triggerOnlyPlugin: PluginSummaryFixture = {
+    ...pluginFixture,
+    nodes: [
+      {
+        key: "pollInbox",
+        name: "Poll Inbox",
+        kind: "trigger",
+        description: "Poll an inbox",
+        fields: [{ key: "folder", label: "Folder", type: "string" }],
+      },
+    ],
+  };
+  const workflowId = await openWithPlugins(page, {
+    pluginId: "acme-crm",
+  }, [triggerOnlyPlugin]);
+
+  try {
     await expect(page.getByTestId("plugin-node-status")).toHaveText(
-      'Plugin node "missingNode" is not available in "Acme CRM".',
+      'Plugin "Acme CRM" does not expose any action nodes.',
     );
   } finally {
     await deleteWorkflow(page, workflowId);

--- a/frontend/e2e/plugin-node-properties.spec.ts
+++ b/frontend/e2e/plugin-node-properties.spec.ts
@@ -1,0 +1,281 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+import { createWorkflow, deleteWorkflow, prepareAuthenticatedPage } from "./support";
+
+interface WorkflowNodeFixture {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: Record<string, unknown>;
+}
+
+interface PluginSummaryFixture {
+  id: string;
+  name: string;
+  version: string;
+  kind: string;
+  description: string;
+  enabled: boolean;
+  nodes: {
+    key: string;
+    name: string;
+    kind: "action" | "trigger";
+    description: string;
+    fields: {
+      key: string;
+      label: string;
+      type: "string" | "number" | "boolean" | "select";
+      required?: boolean;
+      secret?: boolean;
+      options?: { label: string; value: string }[];
+    }[];
+  }[];
+}
+
+const pluginFixture: PluginSummaryFixture = {
+  id: "acme-crm",
+  name: "Acme CRM",
+  version: "1.0.0",
+  kind: "action",
+  description: "CRM plugin",
+  enabled: true,
+  nodes: [
+    {
+      key: "createContact",
+      name: "Create Contact",
+      kind: "action",
+      description: "Create a contact",
+      fields: [
+        { key: "email", label: "Email", type: "string", required: true },
+        { key: "priority", label: "Priority", type: "number" },
+      ],
+    },
+  ],
+};
+
+test.beforeEach(async ({ page }) => {
+  await prepareAuthenticatedPage(page);
+});
+
+function pluginNode(data: Record<string, unknown>): WorkflowNodeFixture {
+  return {
+    id: "plugin-node",
+    type: "plugin",
+    position: { x: 120, y: 160 },
+    data: { label: "Acme Plugin", ...data },
+  };
+}
+
+async function fulfillJson(route: Route, status: number, body: unknown): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function mockPluginIcon(page: Page): Promise<void> {
+  await page.route("**/api/plugins/*/icon**", async (route) => {
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Icon not found" }),
+    });
+  });
+}
+
+async function openPluginProperties(
+  page: Page,
+  nodeData: Record<string, unknown>,
+): Promise<string> {
+  const workflow = await createWorkflow(
+    page,
+    `Plugin Properties ${Date.now()}`,
+    [pluginNode(nodeData)],
+  );
+  await page.goto(`/workflows/${workflow.id}`);
+  await expect(page.locator(".vue-flow__node")).toHaveCount(1);
+  await page.getByRole("button", { name: "Properties", exact: true }).click();
+  await page.locator('.vue-flow__node[data-id="plugin-node"]').click();
+  return workflow.id;
+}
+
+async function openWithPlugins(
+  page: Page,
+  nodeData: Record<string, unknown>,
+  plugins: PluginSummaryFixture[],
+): Promise<string> {
+  await mockPluginIcon(page);
+  await page.route("**/api/plugins", async (route) => {
+    await fulfillJson(route, 200, plugins);
+  });
+  return openPluginProperties(page, nodeData);
+}
+
+test("shows a loading state while plugin definitions load", async ({ page }) => {
+  await mockPluginIcon(page);
+  let releasePlugins: () => void = () => {};
+  const pluginsLoaded = new Promise<void>((resolve) => {
+    releasePlugins = resolve;
+  });
+  await page.route("**/api/plugins", async (route) => {
+    await pluginsLoaded;
+    await fulfillJson(route, 200, [pluginFixture]);
+  });
+
+  const workflowId = await openPluginProperties(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "createContact",
+  });
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      "Loading plugin definition...",
+    );
+    releasePlugins();
+    await expect(page.getByText("Email")).toBeVisible();
+  } finally {
+    releasePlugins();
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows when plugins are disabled", async ({ page }) => {
+  await mockPluginIcon(page);
+  await page.route("**/api/plugins", async (route) => {
+    await fulfillJson(route, 404, {
+      detail: "Plugins are disabled. Set HEYM_PLUGINS_ENABLED=true to enable them.",
+    });
+  });
+  const workflowId = await openPluginProperties(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "createContact",
+  });
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toContainText(
+      "Plugins are disabled",
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows when plugin loading fails", async ({ page }) => {
+  await mockPluginIcon(page);
+  await page.route("**/api/plugins", async (route) => {
+    await fulfillJson(route, 500, { detail: "Plugin database offline" });
+  });
+  const workflowId = await openPluginProperties(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "createContact",
+  });
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      "Unable to load plugins: Plugin database offline",
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows when no plugins are installed", async ({ page }) => {
+  const workflowId = await openWithPlugins(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "createContact",
+  }, []);
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      "No plugins are installed on this instance.",
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows when a plugin node is not bound to a package", async ({ page }) => {
+  const workflowId = await openWithPlugins(page, {}, [pluginFixture]);
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      "This node is not bound to a plugin package.",
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows when a plugin node key is missing", async ({ page }) => {
+  const workflowId = await openWithPlugins(page, {
+    pluginId: "acme-crm",
+  }, [pluginFixture]);
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      'Plugin "Acme CRM" is missing a plugin node key.',
+    );
+    await expect(page.getByText("Email")).toHaveCount(0);
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("shows missing, disabled, and missing-node plugin states", async ({ page }) => {
+  let workflowId = await openWithPlugins(page, {
+    pluginId: "missing-plugin",
+    pluginNodeKey: "createContact",
+  }, [pluginFixture]);
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      'Plugin "missing-plugin" is not installed on this instance.',
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+
+  await page.unroute("**/api/plugins");
+  workflowId = await openWithPlugins(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "createContact",
+  }, [{ ...pluginFixture, enabled: false }]);
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      'Plugin "Acme CRM" is installed but disabled.',
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+
+  await page.unroute("**/api/plugins");
+  workflowId = await openWithPlugins(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "missingNode",
+  }, [pluginFixture]);
+
+  try {
+    await expect(page.getByTestId("plugin-node-status")).toHaveText(
+      'Plugin node "missingNode" is not available in "Acme CRM".',
+    );
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});
+
+test("renders fields for a valid plugin node", async ({ page }) => {
+  const workflowId = await openWithPlugins(page, {
+    pluginId: "acme-crm",
+    pluginNodeKey: "createContact",
+  }, [pluginFixture]);
+
+  try {
+    await expect(page.getByText("Email")).toBeVisible();
+    await expect(page.getByText("Priority")).toBeVisible();
+    await expect(page.getByTestId("plugin-node-status")).toHaveCount(0);
+  } finally {
+    await deleteWorkflow(page, workflowId);
+  }
+});

--- a/frontend/e2e/plugin-node-properties.spec.ts
+++ b/frontend/e2e/plugin-node-properties.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type Route } from "@playwright/test";
+import { expect, test, type Locator, type Page, type Route } from "@playwright/test";
 
 import { createWorkflow, deleteWorkflow, prepareAuthenticatedPage } from "./support";
 
@@ -84,6 +84,12 @@ async function mockPluginIcon(page: Page): Promise<void> {
   });
 }
 
+function pluginFieldLabel(page: Page, label: string, required = false): Locator {
+  return page.locator(".properties-panel").getByText(required ? `${label} *` : label, {
+    exact: true,
+  });
+}
+
 async function openPluginProperties(
   page: Page,
   nodeData: Record<string, unknown>,
@@ -133,7 +139,7 @@ test("shows a loading state while plugin definitions load", async ({ page }) => 
       "Loading plugin definition...",
     );
     releasePlugins();
-    await expect(page.getByText("Email")).toBeVisible();
+    await expect(pluginFieldLabel(page, "Email", true)).toBeVisible();
   } finally {
     releasePlugins();
     await deleteWorkflow(page, workflowId);
@@ -216,7 +222,7 @@ test("shows when a plugin node key is missing", async ({ page }) => {
     await expect(page.getByTestId("plugin-node-status")).toHaveText(
       'Plugin "Acme CRM" is missing a plugin node key.',
     );
-    await expect(page.getByText("Email")).toHaveCount(0);
+    await expect(pluginFieldLabel(page, "Email", true)).toHaveCount(0);
   } finally {
     await deleteWorkflow(page, workflowId);
   }
@@ -272,8 +278,8 @@ test("renders fields for a valid plugin node", async ({ page }) => {
   }, [pluginFixture]);
 
   try {
-    await expect(page.getByText("Email")).toBeVisible();
-    await expect(page.getByText("Priority")).toBeVisible();
+    await expect(pluginFieldLabel(page, "Email", true)).toBeVisible();
+    await expect(pluginFieldLabel(page, "Priority")).toBeVisible();
     await expect(page.getByTestId("plugin-node-status")).toHaveCount(0);
   } finally {
     await deleteWorkflow(page, workflowId);

--- a/frontend/src/components/Panels/propertiesPanel/nodes/PluginNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/PluginNodeProperties.vue
@@ -49,10 +49,17 @@ const pkg = computed<PluginSummary | undefined>(() =>
   plugins.value.find((plugin) => plugin.id === pluginId.value),
 );
 
+const fallbackNodeKind = computed<PluginNodeSummary["kind"]>(() =>
+  selectedNode.value?.type === "pluginTrigger" ? "trigger" : "action",
+);
+
 const nodeDef = computed<PluginNodeSummary | undefined>(() => {
   const nodes = pkg.value?.nodes ?? [];
   const key = pluginNodeKey.value;
-  return (key ? nodes.find((node) => node.key === key) : undefined) ?? nodes[0];
+  return (
+    (key ? nodes.find((node) => node.key === key) : undefined) ??
+    nodes.find((node) => node.kind === fallbackNodeKind.value)
+  );
 });
 
 const statusMessage = computed<string | null>(() => {
@@ -64,11 +71,9 @@ const statusMessage = computed<string | null>(() => {
   if (plugins.value.length === 0) return "No plugins are installed on this instance.";
   if (!pkg.value) return `Plugin "${pluginId.value}" is not installed on this instance.`;
   if (!pkg.value.enabled) return `Plugin "${pkg.value.name}" is installed but disabled.`;
-  if (!pluginNodeKey.value) return `Plugin "${pkg.value.name}" is missing a plugin node key.`;
-  if (pluginNodeKey.value && !pkg.value.nodes.some((node) => node.key === pluginNodeKey.value)) {
-    return `Plugin node "${pluginNodeKey.value}" is not available in "${pkg.value.name}".`;
+  if (!nodeDef.value) {
+    return `Plugin "${pkg.value.name}" does not expose any ${fallbackNodeKind.value} nodes.`;
   }
-  if (!nodeDef.value) return `Plugin "${pkg.value.name}" does not expose any nodes.`;
   return null;
 });
 

--- a/frontend/src/components/Panels/propertiesPanel/nodes/PluginNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/PluginNodeProperties.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
+import { isAxiosError } from "axios";
 
 import type { PluginFieldDef, PluginNodeSummary, PluginSummary } from "@/types/workflow";
 
@@ -17,26 +18,70 @@ const {
 } = usePropertiesPanelContext();
 
 const plugins = ref<PluginSummary[]>([]);
+const loadingPlugins = ref(true);
+const pluginsDisabled = ref(false);
+const pluginLoadError = ref<string | null>(null);
 
 onMounted(async () => {
+  loadingPlugins.value = true;
+  pluginsDisabled.value = false;
+  pluginLoadError.value = null;
   try {
     plugins.value = await listPlugins();
-  } catch {
+  } catch (err) {
     plugins.value = [];
+    if (isAxiosError<{ detail?: string }>(err) && err.response?.status === 404) {
+      pluginsDisabled.value = true;
+      pluginLoadError.value =
+        err.response.data?.detail ?? "Plugins are disabled on this instance.";
+    } else {
+      pluginLoadError.value = pluginErrorMessage(err);
+    }
+  } finally {
+    loadingPlugins.value = false;
   }
 });
 
+const pluginId = computed<string>(() => selectedNode.value?.data.pluginId ?? "");
+const pluginNodeKey = computed<string>(() => selectedNode.value?.data.pluginNodeKey ?? "");
+
 const pkg = computed<PluginSummary | undefined>(() =>
-  plugins.value.find((plugin) => plugin.id === selectedNode.value?.data.pluginId),
+  plugins.value.find((plugin) => plugin.id === pluginId.value),
 );
 
 const nodeDef = computed<PluginNodeSummary | undefined>(() => {
   const nodes = pkg.value?.nodes ?? [];
-  const key = selectedNode.value?.data.pluginNodeKey;
+  const key = pluginNodeKey.value;
   return (key ? nodes.find((node) => node.key === key) : undefined) ?? nodes[0];
 });
 
-const fields = computed<PluginFieldDef[]>(() => nodeDef.value?.fields ?? []);
+const statusMessage = computed<string | null>(() => {
+  if (!selectedNode.value) return null;
+  if (loadingPlugins.value) return "Loading plugin definition...";
+  if (pluginsDisabled.value) return pluginLoadError.value;
+  if (pluginLoadError.value) return pluginLoadError.value;
+  if (!pluginId.value) return "This node is not bound to a plugin package.";
+  if (plugins.value.length === 0) return "No plugins are installed on this instance.";
+  if (!pkg.value) return `Plugin "${pluginId.value}" is not installed on this instance.`;
+  if (!pkg.value.enabled) return `Plugin "${pkg.value.name}" is installed but disabled.`;
+  if (!pluginNodeKey.value) return `Plugin "${pkg.value.name}" is missing a plugin node key.`;
+  if (pluginNodeKey.value && !pkg.value.nodes.some((node) => node.key === pluginNodeKey.value)) {
+    return `Plugin node "${pluginNodeKey.value}" is not available in "${pkg.value.name}".`;
+  }
+  if (!nodeDef.value) return `Plugin "${pkg.value.name}" does not expose any nodes.`;
+  return null;
+});
+
+const fields = computed<PluginFieldDef[]>(() => (statusMessage.value ? [] : nodeDef.value?.fields ?? []));
+
+function pluginErrorMessage(err: unknown): string {
+  if (isAxiosError<{ detail?: string }>(err)) {
+    const detail = err.response?.data?.detail;
+    if (detail) return `Unable to load plugins: ${detail}`;
+    if (err.response?.status) return `Unable to load plugins (HTTP ${err.response.status}).`;
+  }
+  return err instanceof Error ? `Unable to load plugins: ${err.message}` : "Unable to load plugins.";
+}
 
 function configValue(key: string): unknown {
   const config = selectedNode.value?.data.config;
@@ -57,10 +102,14 @@ function setConfigValue(key: string, value: unknown): void {
 <template>
   <template v-if="selectedNode">
     <p
-      v-if="!nodeDef"
-      class="text-xs text-muted-foreground"
+      v-if="statusMessage"
+      data-testid="plugin-node-status"
+      :class="[
+        'text-xs',
+        pluginLoadError && !pluginsDisabled ? 'text-destructive' : 'text-muted-foreground',
+      ]"
     >
-      Plugin not found or disabled on this instance.
+      {{ statusMessage }}
     </p>
     <div
       v-for="field in fields"


### PR DESCRIPTION
## Summary
- show distinct Plugin node panel states for loading, disabled plugin subsystem, plugin API errors, no installed plugins, missing package binding, missing/disabled packages, and missing plugin node keys
- preserve existing generated field rendering when a valid plugin package and plugin node key are available
- add Playwright coverage with mocked `/api/plugins` responses for the new panel states and a valid plugin fixture

## Validation
- `cd frontend && bun run lint:check`
- `cd frontend && bun run typecheck`
- `./check.sh` (`1729 tests, 1729 passed`)

## E2E note
- Added `frontend/e2e/plugin-node-properties.spec.ts`.
- Targeted local run `./run_e2e.sh e2e/plugin-node-properties.spec.ts` was blocked because Docker daemon is not running and Docker Desktop is not installed/found on this machine.

## Review
- Initial review found missing `pluginNodeKey` was still falling back to the first plugin node; fixed with an explicit missing-key state and E2E case.
- Final review reported no Critical, Important, or Minor findings.
