### PR TITLE
impl/share-dialog-wordings

### DIFF
--- a/frontend/src/docs/content/reference/credentials-sharing.md
+++ b/frontend/src/docs/content/reference/credentials-sharing.md
@@ -16,6 +16,10 @@ You can also share credentials with [Teams](./teams.md):
 
 Shared credentials show an indicator in the [Credentials Tab](../tabs/credentials-tab.md) UI.
 
+## Sharing with Workflow Collaborators
+
+When you share a workflow, collaborators can open and run it but cannot use your credentials unless you share those credentials with them too. This applies to credentials in the main workflow and in any sub-workflows it calls. Share each credential with the same users or teams you invited to the workflow. Sub-workflows must also be shared separately from the child workflow's editor. See [Workflow Organization](./workflow-organization.md#sharing-workflows).
+
 ## Execution Context
 
 When a workflow runs, credentials are resolved for the **workflow owner** (or current user when running). `get_credentials_context()` merges:

--- a/frontend/src/docs/content/reference/workflow-organization.md
+++ b/frontend/src/docs/content/reference/workflow-organization.md
@@ -28,6 +28,17 @@ Folders form a tree. Each folder has:
 
 The tree response includes `children` and `workflows` per folder. Shared workflows can appear in a folder via `WorkflowShare.folder_id`.
 
+## Sharing Workflows
+
+Open **Share** in the workflow editor to invite users by email or share with a [team](./teams.md).
+
+Sharing a workflow grants access to the canvas, execution history, and analysis document. It does **not** automatically share:
+
+- **Credentials** referenced by nodes in the workflow
+- **Sub-workflows** called by [Execute](../nodes/execute-node.md) nodes or agents
+
+Recipients need those credentials and child workflows shared with them separately (same users or teams). Share credentials from the [Credentials tab](../tabs/credentials-tab.md); see [Credentials Sharing](./credentials-sharing.md). Share each sub-workflow from its own editor share dialog.
+
 ## Scheduled for Deletion
 
 Workflows can be scheduled for deletion instead of being removed immediately.
@@ -67,6 +78,8 @@ If any start node is still active, the workflow stays until the next run.
 ## Related
 
 - [Workflows Tab](../tabs/workflows-tab.md) – Create and manage workflows
+- [Credentials Sharing](./credentials-sharing.md) – Share credentials with workflow collaborators
+- [Teams](./teams.md) – Share workflows and credentials with teams
 - [Core Concepts](../getting-started/core-concepts.md) – Workflows, nodes, and execution
 - [Workflow Structure](./workflow-structure.md) – JSON format for workflows
 - [Triggers](./triggers.md) – Start nodes and entry points

--- a/frontend/src/docs/content/tabs/teams-tab.md
+++ b/frontend/src/docs/content/tabs/teams-tab.md
@@ -34,6 +34,8 @@ Share resources with teams from:
 
 When you share with a team, all team members gain access. See [Teams](../reference/teams.md) for details.
 
+When you share a workflow with a team, also share the credentials and sub-workflows that workflow depends on with the same team. Workflow access alone does not grant credential or child workflow access.
+
 ## Chat Integration
 
 The [Chat tab](./chat-tab.md) AI assistant can list your teams. Ask "my teams" to see which teams you belong to.

--- a/frontend/src/docs/content/tabs/workflows-tab.md
+++ b/frontend/src/docs/content/tabs/workflows-tab.md
@@ -34,6 +34,10 @@ Use the workflow search field beside **New Folder**, or press **Ctrl+F** (or **C
 
 Drag and drop a JSON workflow file onto the workflow area to create a new workflow. The imported nodes and edges are used to create the workflow; the name comes from the `name` field in the JSON or the filename. See [Download & Import](../reference/download-import.md) for the JSON format and import options.
 
+## Sharing
+
+Open a workflow in the editor and click **Share** to invite users by email or share with a [team](./teams-tab.md). Shared collaborators can view, edit, and run the workflow. Credentials and sub-workflows are not shared automatically; share those separately with the same users or teams. See [Workflow Organization](../reference/workflow-organization.md#sharing-workflows) and [Credentials Sharing](../reference/credentials-sharing.md).
+
 ## Editing and Deleting
 
 - **Edit** – Change workflow name and description from the card menu

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -1568,6 +1568,11 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
       @close="shareOpen = false"
     >
       <div class="space-y-6">
+        <p class="text-sm text-muted-foreground">
+          Sharing this workflow lets collaborators view, edit, and run it. Credentials and
+          sub-workflows used by this workflow are not shared automatically. Share each credential
+          and sub-workflow with the same users or teams so recipients can run the workflow.
+        </p>
         <div class="space-y-3">
           <div class="space-y-2">
             <Label>Invite by email</Label>


### PR DESCRIPTION
- Added sections on sharing workflows and credentials in the workflow editor documentation.
- Clarified that sharing a workflow does not automatically share credentials or sub-workflows; these must be shared separately.
- Updated related documentation links for better navigation.