### PR TITLE
Mask credentials in expression preview

### DIFF
--- a/backend/app/api/expressions.py
+++ b/backend/app/api/expressions.py
@@ -33,6 +33,7 @@ from app.services.workflow_dsl_prompt import (
     DASHBOARD_WIDGET_PROMPT_HINT,
     WORKFLOW_DSL_SYSTEM_PROMPT,
 )
+from app.services.workflow_executor import mask_credentials_context
 
 router = APIRouter()
 
@@ -328,12 +329,13 @@ async def evaluate_expression(
 
     credentials_owner_id = current_user.id if current_user else workflow.owner_id
     credentials_context = await get_credentials_context(db, credentials_owner_id)
+    preview_credentials_context = mask_credentials_context(credentials_context)
     global_variables_context = await get_global_variables_context(db, credentials_owner_id)
 
     service = ExpressionEvaluatorService(
         workflow_nodes=workflow_nodes,
         workflow_edges=workflow_edges,
-        credentials_context=credentials_context,
+        credentials_context=preview_credentials_context,
         global_variables_context=global_variables_context,
         vars_context=vars_context,
         workflow_id=workflow.id,

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -7643,6 +7643,22 @@ def mask_sensitive_output(output: dict, credentials_context: dict[str, str]) -> 
     return json.loads(output_str)
 
 
+def mask_credentials_context(credentials_context: dict[str, str] | None) -> dict[str, str]:
+    """Return a preview-safe credentials context with secret values masked."""
+    if not credentials_context:
+        return {}
+
+    masked_context: dict[str, str] = {}
+    for name, value in credentials_context.items():
+        if not value:
+            masked_context[name] = value
+        elif len(value) > 7:
+            masked_context[name] = value[:7] + "**"
+        else:
+            masked_context[name] = "**"
+    return masked_context
+
+
 def execute_workflow(
     workflow_id: uuid.UUID,
     nodes: list[dict],

--- a/backend/tests/test_expression_evaluator_api.py
+++ b/backend/tests/test_expression_evaluator_api.py
@@ -591,6 +591,30 @@ class ExpressionEvaluateApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.result, "second")
         self.assertEqual(response.result_type, "string")
 
+    async def test_credentials_context_is_masked_for_preview(self) -> None:
+        raw_secret = "sk-live-secret-key-value"
+        workflow = self._workflow()
+        request = self._request(expression="$credentials.MyToken")
+        with (
+            patch("app.api.expressions.get_workflow_by_id", AsyncMock(return_value=workflow)),
+            patch(
+                "app.api.expressions.get_credentials_context",
+                AsyncMock(return_value={"MyToken": raw_secret}),
+            ),
+            patch(
+                "app.api.expressions.get_global_variables_context",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            response = await evaluate_expression(
+                request, http_request=self._http_request(), db=self.db, current_user=self.user
+            )
+
+        self.assertEqual(response.result, "sk-live**")
+        self.assertNotEqual(response.result, raw_secret)
+        self.assertNotIn("secret-key-value", response.result)
+        self.assertEqual(response.result_type, "string")
+
     def test_request_rejects_expression_over_max_length(self) -> None:
         with self.assertRaises(ValidationError):
             ExpressionEvaluateRequest(

--- a/backend/tests/test_sse_streaming.py
+++ b/backend/tests/test_sse_streaming.py
@@ -14,6 +14,7 @@ from app.services.workflow_executor import (
     _wrap_value,
     build_node_start_message,
     execute_workflow_streaming,
+    mask_credentials_context,
     mask_sensitive_output,
 )
 
@@ -262,6 +263,24 @@ class NodeResultTimingMetadataTests(unittest.TestCase):
 
 
 class MaskSensitiveOutputTests(unittest.TestCase):
+    def test_mask_credentials_context_masks_values_for_preview(self) -> None:
+        masked = mask_credentials_context(
+            {
+                "LongToken": "sk-live-secret-key-value",
+                "ShortToken": "secret",
+                "EmptyToken": "",
+            }
+        )
+
+        self.assertEqual(
+            masked,
+            {
+                "LongToken": "sk-live**",
+                "ShortToken": "**",
+                "EmptyToken": "",
+            },
+        )
+
     def test_masks_dot_wrapped_outputs_without_json_serialization_error(self) -> None:
         output = {
             "value": _wrap_value(


### PR DESCRIPTION
Implemented credential masking for expression preview. Added `mask_credentials_context` in `backend/app/services/workflow_executor.py`, wired `backend/app/api/expressions.py` to pass masked credential values into `ExpressionEvaluatorService`, and added backend tests for the helper and preview API behavior.