### PR TITLE
Add per-file skill attachment context

### DIFF
--- a/backend/app/api/skill_builder.py
+++ b/backend/app/api/skill_builder.py
@@ -1,10 +1,15 @@
 """Skill Builder SSE endpoint for creating and editing Heym skills."""
 
+import base64
+import binascii
+import io
 import json
 import logging
 import time
 import uuid
 from typing import Any, AsyncGenerator, Literal
+from xml.etree import ElementTree
+from zipfile import BadZipFile, ZipFile
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
@@ -38,6 +43,7 @@ class SkillBuilderAttachment(BaseModel):
     encoding: Literal["text", "base64"] = "text"
     mime_type: str | None = None
     size_bytes: int | None = None
+    content: str | None = None
 
 
 class SkillBuilderSkill(BaseModel):
@@ -263,6 +269,14 @@ MAX_SKILL_BUILDER_ROUNDS = 6
 ALLOWED_SKILL_BUILDER_EXTENSIONS = (".md", ".py")
 MACOS_METADATA_DIR = "__MACOSX"
 MACOS_METADATA_FILENAMES = {".DS_Store"}
+ATTACHMENT_CONTEXT_MAX_BYTES = 2 * 1024 * 1024
+ATTACHMENT_TEXT_CONTEXT_MAX_CHARS = 12_000
+DOCX_CONTEXT_MAX_TABLES = 12
+DOCX_CONTEXT_MAX_ROWS = 30
+DOCX_CONTEXT_MAX_CELLS = 8
+DOCX_CONTEXT_MAX_CELL_CHARS = 120
+DOCX_CONTEXT_MAX_PARAGRAPHS = 20
+DOCX_XML_NS = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
 
 
 def _normalize_skill_builder_path(path: str) -> str:
@@ -295,6 +309,159 @@ def _is_allowed_skill_builder_file(path: str) -> bool:
 
     normalized_path = _normalize_skill_builder_path(path).lower()
     return normalized_path.endswith(ALLOWED_SKILL_BUILDER_EXTENSIONS)
+
+
+def _append_limited_line(lines: list[str], line: str, max_chars: int) -> bool:
+    """Append a line unless doing so would exceed max_chars."""
+
+    current_chars = sum(len(existing) + 1 for existing in lines)
+    if current_chars + len(line) + 1 > max_chars:
+        lines.append("... truncated ...")
+        return False
+    lines.append(line)
+    return True
+
+
+def _truncate_text(value: str, max_chars: int) -> str:
+    """Return value capped to max_chars, preserving a truncation marker."""
+
+    if len(value) <= max_chars:
+        return value
+    return value[: max_chars - 3] + "..."
+
+
+def _decode_attachment_bytes(attachment: SkillBuilderAttachment) -> bytes | None:
+    """Decode attachment content into bytes when the caller opted into context."""
+
+    if not attachment.content:
+        return None
+    if attachment.encoding == "base64":
+        try:
+            return base64.b64decode(attachment.content, validate=True)
+        except (binascii.Error, ValueError):
+            return None
+    return attachment.content.encode("utf-8", errors="replace")
+
+
+def _docx_node_text(node: ElementTree.Element) -> str:
+    """Extract visible text from a DOCX XML node."""
+
+    return "".join(text.text or "" for text in node.findall(".//w:t", DOCX_XML_NS)).strip()
+
+
+def _summarize_docx_context(data: bytes) -> str:
+    """Return a compact, LLM-readable summary of a DOCX document."""
+
+    try:
+        with ZipFile(io.BytesIO(data)) as docx:
+            document_xml = docx.read("word/document.xml")
+    except (BadZipFile, KeyError):
+        return "DOCX summary unavailable: document.xml could not be read."
+
+    try:
+        root = ElementTree.fromstring(document_xml)
+    except ElementTree.ParseError:
+        return "DOCX summary unavailable: document.xml is not valid XML."
+
+    lines: list[str] = [
+        "DOCX structure summary:",
+        "Use this to compare Python placeholder logic with the actual template layout.",
+    ]
+
+    body = root.find(".//w:body", DOCX_XML_NS)
+    if body is not None:
+        paragraph_texts = [
+            _docx_node_text(paragraph)
+            for paragraph in body.findall("./w:p", DOCX_XML_NS)
+            if _docx_node_text(paragraph)
+        ][:DOCX_CONTEXT_MAX_PARAGRAPHS]
+        if paragraph_texts:
+            lines.append("Top-level paragraphs:")
+            for index, text in enumerate(paragraph_texts, start=1):
+                if not _append_limited_line(
+                    lines,
+                    f"- Paragraph {index}: {_truncate_text(text, DOCX_CONTEXT_MAX_CELL_CHARS)}",
+                    ATTACHMENT_TEXT_CONTEXT_MAX_CHARS,
+                ):
+                    return "\n".join(lines)
+
+    label_value_candidates: list[str] = []
+    tables = root.findall(".//w:tbl", DOCX_XML_NS)
+    if tables:
+        lines.append("Tables:")
+
+    for table_index, table in enumerate(tables[:DOCX_CONTEXT_MAX_TABLES], start=1):
+        if not _append_limited_line(
+            lines, f"Table {table_index}:", ATTACHMENT_TEXT_CONTEXT_MAX_CHARS
+        ):
+            return "\n".join(lines)
+        rows = table.findall("./w:tr", DOCX_XML_NS)
+        for row_index, row in enumerate(rows[:DOCX_CONTEXT_MAX_ROWS], start=1):
+            cells: list[str] = []
+            raw_cell_texts: list[str] = []
+            for cell in row.findall("./w:tc", DOCX_XML_NS)[:DOCX_CONTEXT_MAX_CELLS]:
+                text = _docx_node_text(cell)
+                raw_cell_texts.append(text)
+                if text:
+                    cells.append(_truncate_text(text, DOCX_CONTEXT_MAX_CELL_CHARS))
+                    continue
+                run_count = len(cell.findall(".//w:r", DOCX_XML_NS))
+                cells.append(f"<EMPTY runs={run_count}>")
+            if len(raw_cell_texts) >= 2 and raw_cell_texts[0] and not raw_cell_texts[1]:
+                label_value_candidates.append(
+                    f"Table {table_index} row {row_index}: `{raw_cell_texts[0]}` -> adjacent empty cell"
+                )
+            if not _append_limited_line(
+                lines,
+                f"  Row {row_index}: {' | '.join(cells)}",
+                ATTACHMENT_TEXT_CONTEXT_MAX_CHARS,
+            ):
+                return "\n".join(lines)
+
+    if label_value_candidates:
+        lines.append("Detected label/value table candidates:")
+        for candidate in label_value_candidates[:20]:
+            if not _append_limited_line(lines, f"- {candidate}", ATTACHMENT_TEXT_CONTEXT_MAX_CHARS):
+                return "\n".join(lines)
+        lines.append(
+            "If Python code replaces text in the label cell, update it to write the value into "
+            "the adjacent empty cell instead."
+        )
+
+    return "\n".join(lines)
+
+
+def _summarize_text_attachment(data: bytes) -> str:
+    """Return a capped UTF-8 text summary for included text attachments."""
+
+    text = data.decode("utf-8", errors="replace")
+    return _truncate_text(text, ATTACHMENT_TEXT_CONTEXT_MAX_CHARS)
+
+
+def _build_attachment_context(
+    normalized_path: str, attachment: SkillBuilderAttachment
+) -> str | None:
+    """Build optional attachment content context for the skill builder prompt."""
+
+    data = _decode_attachment_bytes(attachment)
+    if data is None:
+        return None
+    if len(data) > ATTACHMENT_CONTEXT_MAX_BYTES:
+        return (
+            "Content context omitted because the attachment is larger than "
+            f"{ATTACHMENT_CONTEXT_MAX_BYTES // (1024 * 1024)} MB."
+        )
+
+    lower_path = normalized_path.lower()
+    mime_type = (attachment.mime_type or "").lower()
+    if lower_path.endswith(".docx") or mime_type.endswith(
+        "officedocument.wordprocessingml.document"
+    ):
+        return _summarize_docx_context(data)
+    if attachment.encoding == "text" or mime_type.startswith("text/"):
+        return _summarize_text_attachment(data)
+
+    return None
 
 
 def build_skill_builder_prompt(existing_skill: SkillBuilderSkill | None) -> str:
@@ -353,6 +520,21 @@ def build_skill_builder_prompt(existing_skill: SkillBuilderSkill | None) -> str:
                 "code and `SKILL.md` so the relative path still points to the asset in "
                 "the final ZIP layout.\n\n"
             )
+            attachment_contexts: list[str] = []
+            for normalized_path, attachment in attachments:
+                context = _build_attachment_context(normalized_path, attachment)
+                if context:
+                    attachment_contexts.append(f"### {normalized_path}\n\n{context}")
+            if attachment_contexts:
+                base += (
+                    "## Included Attachment Context\n\n"
+                    "The user explicitly selected these binary/non-editable files for context. "
+                    "Use these extracted summaries to diagnose mismatches between the "
+                    "Python code and bundled templates, then update only editable `.md` "
+                    "and `.py` files.\n\n"
+                )
+                base += "\n\n".join(attachment_contexts)
+                base += "\n\n"
         base += (
             "When you update files, always call `set_skill_files` with ALL editable "
             "`.md`/`.py` files, including unchanged editable files.\n"

--- a/backend/app/api/skill_builder.py
+++ b/backend/app/api/skill_builder.py
@@ -31,11 +31,21 @@ class SkillBuilderFile(BaseModel):
     encoding: Literal["text"] = "text"
 
 
+class SkillBuilderAttachment(BaseModel):
+    """A non-editable file attached to the skill bundle."""
+
+    path: str
+    encoding: Literal["text", "base64"] = "text"
+    mime_type: str | None = None
+    size_bytes: int | None = None
+
+
 class SkillBuilderSkill(BaseModel):
     """Existing skill context passed to the assistant when editing."""
 
     name: str
     files: list[SkillBuilderFile] = Field(default_factory=list)
+    attachments: list[SkillBuilderAttachment] = Field(default_factory=list)
 
 
 class SkillBuilderConversationMessage(BaseModel):
@@ -60,16 +70,16 @@ SET_SKILL_FILES_TOOL: dict[str, Any] = {
     "function": {
         "name": "set_skill_files",
         "description": (
-            "Set the complete current skill file contents. "
-            "Call this whenever you create or update any file. "
-            "Always include ALL files in a single call."
+            "Set the complete current editable skill file contents. "
+            "Call this whenever you create or update any Markdown or Python file. "
+            "Always include ALL editable .md and .py files in a single call."
         ),
         "parameters": {
             "type": "object",
             "properties": {
                 "files": {
                     "type": "array",
-                    "description": "All files that currently make up the skill.",
+                    "description": "All editable .md and .py files that currently make up the skill.",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -92,7 +102,8 @@ A Heym skill is a ZIP bundle containing:
 - `SKILL.md` describing when and how the skill should be used
 - `main.py` implementing `execute(params, files) -> dict`
 - Optional extra `.py` or `.md` helper files
-- No binary files in the generated output
+- Optional bundled asset files that existing skills may reference
+- No binary files in generated Skill Builder output
 
 ### Required SKILL.md format
 
@@ -239,21 +250,50 @@ def execute(params: dict, files: dict) -> dict:
 2. Every `main.py` MUST import `json` and `sys` and include the `if __name__ == "__main__":` block shown above. Without it the script produces no output and the skill silently fails.
 3. NEVER embed fonts as Python strings or base64. Use reportlab built-in fonts: `Helvetica`, `Times-Roman`, `Courier`, and their bold/italic variants.
 4. NEVER embed image bytes as Python constants or base64. Ask the user to pass images as input files.
-5. Always call `set_skill_files` with the COMPLETE file set every time you create or modify files.
+5. Always call `set_skill_files` with the COMPLETE editable `.md`/`.py` file set every time you create or modify files.
 6. Keep `SKILL.md` accurate because the LLM reads it to decide when to call the skill.
 7. `execute()` must remain a top-level function in `main.py`.
 8. Only generate or update `.md` and `.py` files.
 9. Use English only for all natural language content, parameter names, descriptions, comments, docstrings, and user-facing strings.
+10. Preserve existing file paths unless the user explicitly asks to reorganize them. If you rename or move a Python file, update imports, relative file reads/writes, and `SKILL.md` so the final ZIP layout still works.
+11. When reading bundled assets, prefer paths based on `pathlib.Path(__file__).resolve().parent` so the code remains correct when the script lives in a subdirectory.
 """
 
 MAX_SKILL_BUILDER_ROUNDS = 6
 ALLOWED_SKILL_BUILDER_EXTENSIONS = (".md", ".py")
+MACOS_METADATA_DIR = "__MACOSX"
+MACOS_METADATA_FILENAMES = {".DS_Store"}
+
+
+def _normalize_skill_builder_path(path: str) -> str:
+    """Normalize a skill file path for prompt and tool use."""
+
+    normalized = path.replace("\\", "/").lstrip("/")
+    parts = [part for part in normalized.split("/") if part and part not in {".", ".."}]
+    return "/".join(parts)
+
+
+def _is_ignored_skill_builder_path(path: str) -> bool:
+    """Return whether a path is generated OS metadata that should be skipped."""
+
+    normalized = _normalize_skill_builder_path(path)
+    if not normalized:
+        return True
+
+    parts = normalized.split("/")
+    return any(
+        part == MACOS_METADATA_DIR or part in MACOS_METADATA_FILENAMES or part.startswith("._")
+        for part in parts
+    )
 
 
 def _is_allowed_skill_builder_file(path: str) -> bool:
     """Return whether the skill builder may generate or edit the given file path."""
 
-    normalized_path = path.lower()
+    if _is_ignored_skill_builder_path(path):
+        return False
+
+    normalized_path = _normalize_skill_builder_path(path).lower()
     return normalized_path.endswith(ALLOWED_SKILL_BUILDER_EXTENSIONS)
 
 
@@ -265,6 +305,8 @@ def build_skill_builder_prompt(existing_skill: SkillBuilderSkill | None) -> str:
         "You help users create and edit skills for the Heym AI workflow platform. "
         "A skill is a Python-backed tool bundle for Agent nodes. "
         "Generate and edit only `.md` and `.py` files. "
+        "Existing non-editable attachments may be referenced by path, but you must not "
+        "generate placeholders for them. "
         "All natural language content must be English only, including parameter names, "
         "descriptions, output names, output descriptions, comments, docstrings, "
         "and user-facing strings.\n\n"
@@ -278,7 +320,8 @@ def build_skill_builder_prompt(existing_skill: SkillBuilderSkill | None) -> str:
             file for file in existing_skill.files if _is_allowed_skill_builder_file(file.path)
         ]
         for file in editable_files:
-            base += f"### {file.path}\n\n```\n{file.content}\n```\n\n"
+            normalized_path = _normalize_skill_builder_path(file.path)
+            base += f"### {normalized_path}\n\n```\n{file.content}\n```\n\n"
         skipped_files_count = len(existing_skill.files) - len(editable_files)
         if skipped_files_count > 0:
             base += (
@@ -286,9 +329,33 @@ def build_skill_builder_prompt(existing_skill: SkillBuilderSkill | None) -> str:
                 "context because only `.md` and `.py` files are editable here. "
                 "Those excluded files must remain untouched.\n\n"
             )
+        attachments = [
+            (_normalize_skill_builder_path(attachment.path), attachment)
+            for attachment in existing_skill.attachments
+            if _normalize_skill_builder_path(attachment.path)
+            and not _is_ignored_skill_builder_path(attachment.path)
+        ]
+        if attachments:
+            base += (
+                "Non-editable files attached to the final ZIP bundle. Their contents are "
+                "not shown, but their paths are real and must stay valid:\n"
+            )
+            for normalized_path, attachment in attachments:
+                details = [attachment.encoding]
+                if attachment.mime_type:
+                    details.append(attachment.mime_type)
+                if attachment.size_bytes is not None:
+                    details.append(f"{attachment.size_bytes} bytes")
+                base += f"- `{normalized_path}` ({', '.join(details)})\n"
+            base += (
+                "\nDo not include these non-editable files in `set_skill_files`. "
+                "If you move a Python file that reads one of these paths, update the "
+                "code and `SKILL.md` so the relative path still points to the asset in "
+                "the final ZIP layout.\n\n"
+            )
         base += (
-            "When you update files, always call `set_skill_files` with ALL files, "
-            "including unchanged ones.\n"
+            "When you update files, always call `set_skill_files` with ALL editable "
+            "`.md`/`.py` files, including unchanged editable files.\n"
         )
     else:
         base += (
@@ -332,10 +399,11 @@ def _normalize_skill_files(raw_files: list[Any]) -> tuple[list[dict[str, str]], 
         content = raw_file.get("content")
         if not isinstance(path, str) or not isinstance(content, str):
             continue
-        if not _is_allowed_skill_builder_file(path):
+        normalized_path = _normalize_skill_builder_path(path)
+        if not _is_allowed_skill_builder_file(normalized_path):
             rejected_paths.append(path)
             continue
-        files.append({"path": path, "content": content})
+        files.append({"path": normalized_path, "content": content})
     return files, rejected_paths
 
 

--- a/backend/tests/test_skill_builder.py
+++ b/backend/tests/test_skill_builder.py
@@ -1,10 +1,13 @@
 """Unit tests for Skill Builder prompt and SSE behavior."""
 
+import base64
+import io
 import json
 import unittest
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from zipfile import ZipFile
 
 from app.api.skill_builder import (
     SkillBuilderAttachment,
@@ -15,6 +18,15 @@ from app.api.skill_builder import (
     run_skill_builder,
 )
 from app.services.llm_trace import LLMTraceContext
+
+
+def _make_docx_base64(document_xml: str) -> str:
+    """Build a minimal DOCX-like zip containing word/document.xml."""
+
+    buf = io.BytesIO()
+    with ZipFile(buf, mode="w") as docx:
+        docx.writestr("word/document.xml", document_xml)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
 class BuildSkillBuilderPromptTests(unittest.TestCase):
@@ -103,6 +115,53 @@ class BuildSkillBuilderPromptTests(unittest.TestCase):
         self.assertIn("application/pdf", prompt)
         self.assertIn("Do not include these non-editable files", prompt)
         self.assertIn("If you move a Python file", prompt)
+
+    def test_edit_skill_prompt_includes_docx_table_context_when_content_is_present(self) -> None:
+        document_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:tbl>
+      <w:tr>
+        <w:tc><w:p><w:r><w:t>Name</w:t></w:r></w:p></w:tc>
+        <w:tc><w:p><w:r/></w:p></w:tc>
+      </w:tr>
+      <w:tr>
+        <w:tc><w:p><w:r><w:t>Surname</w:t></w:r></w:p></w:tc>
+        <w:tc><w:p><w:r/></w:p></w:tc>
+      </w:tr>
+    </w:tbl>
+  </w:body>
+</w:document>
+"""
+        skill = SkillBuilderSkill(
+            name="docx-form-filler",
+            files=[
+                SkillBuilderFile(path="SKILL.md", content="---\nname: docx-form-filler\n---"),
+                SkillBuilderFile(
+                    path="main.py",
+                    content="def execute(params, files):\n    return {}\n",
+                ),
+            ],
+            attachments=[
+                SkillBuilderAttachment(
+                    path="fill.docx",
+                    encoding="base64",
+                    mime_type=(
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                    ),
+                    size_bytes=512,
+                    content=_make_docx_base64(document_xml),
+                )
+            ],
+        )
+
+        prompt = build_skill_builder_prompt(skill)
+
+        self.assertIn("Included Attachment Context", prompt)
+        self.assertIn("Table 1:", prompt)
+        self.assertIn("Row 1: Name | <EMPTY runs=1>", prompt)
+        self.assertIn("`Name` -> adjacent empty cell", prompt)
+        self.assertIn("update it to write the value into the adjacent empty cell", prompt)
 
 
 class RunSkillBuilderTests(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_skill_builder.py
+++ b/backend/tests/test_skill_builder.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from app.api.skill_builder import (
+    SkillBuilderAttachment,
     SkillBuilderFile,
     SkillBuilderRequest,
     SkillBuilderSkill,
@@ -70,6 +71,38 @@ class BuildSkillBuilderPromptTests(unittest.TestCase):
         self.assertIn("main.py", prompt)
         self.assertNotIn("notes.txt", prompt)
         self.assertIn("excluded from the AI editing context", prompt)
+
+    def test_edit_skill_prompt_lists_non_editable_attachment_paths(self) -> None:
+        skill = SkillBuilderSkill(
+            name="pdf-reader",
+            files=[
+                SkillBuilderFile(path="SKILL.md", content="---\nname: pdf-reader\n---"),
+                SkillBuilderFile(
+                    path="assets/main.py",
+                    content=(
+                        "from pathlib import Path\n"
+                        "def execute(params, files):\n"
+                        "    return {'size': (Path(__file__).parent / 'hello.pdf').stat().st_size}\n"
+                    ),
+                ),
+            ],
+            attachments=[
+                SkillBuilderAttachment(
+                    path="assets/hello.pdf",
+                    encoding="base64",
+                    mime_type="application/pdf",
+                    size_bytes=128,
+                )
+            ],
+        )
+
+        prompt = build_skill_builder_prompt(skill)
+
+        self.assertIn("assets/main.py", prompt)
+        self.assertIn("assets/hello.pdf", prompt)
+        self.assertIn("application/pdf", prompt)
+        self.assertIn("Do not include these non-editable files", prompt)
+        self.assertIn("If you move a Python file", prompt)
 
 
 class RunSkillBuilderTests(unittest.IsolatedAsyncioTestCase):
@@ -250,3 +283,56 @@ class RunSkillBuilderTests(unittest.IsolatedAsyncioTestCase):
         ]
         self.assertEqual(second_call_messages[-1]["role"], "tool")
         self.assertIn("only accepts `.md` and `.py` files", second_call_messages[-1]["content"])
+
+    async def test_ignores_macos_metadata_tool_files(self) -> None:
+        files_payload = [
+            {"path": "SKILL.md", "content": "---\nname: hello-skill\n---"},
+            {"path": "__MACOSX/._main.py", "content": "ignore me"},
+            {"path": ".DS_Store", "content": "ignore me"},
+            {
+                "path": "nested/../main.py",
+                "content": "def execute(params, files):\n    return {'msg': 'hi'}\n",
+            },
+        ]
+        tool_call = SimpleNamespace(
+            id="tool-call-1",
+            function=SimpleNamespace(
+                name="set_skill_files",
+                arguments=json.dumps({"files": files_payload}),
+            ),
+        )
+        first_response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tool_call]))
+            ],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=5, total_tokens=10),
+        )
+        second_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Done.", tool_calls=None))],
+            usage=SimpleNamespace(prompt_tokens=5, completion_tokens=5, total_tokens=10),
+        )
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.side_effect = [first_response, second_response]
+
+        request = SkillBuilderRequest(
+            credential_id=uuid.uuid4(),
+            model="gpt-4o",
+            message="Build a hello skill.",
+        )
+
+        with patch("app.api.skill_builder.record_llm_trace"):
+            events = await self._collect_events(
+                run_skill_builder(fake_client, request, self._make_trace_context(), "OpenAI")
+            )
+
+        update_event = next(event for event in events if event["type"] == "skill_files_update")
+        self.assertEqual(
+            update_event["files"],
+            [
+                {"path": "SKILL.md", "content": "---\nname: hello-skill\n---"},
+                {
+                    "path": "nested/main.py",
+                    "content": "def execute(params, files):\n    return {'msg': 'hi'}\n",
+                },
+            ],
+        )

--- a/frontend/src/components/Panels/AgentSkillCard.vue
+++ b/frontend/src/components/Panels/AgentSkillCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import {
   ChevronDown,
   ChevronRight,
@@ -7,6 +8,7 @@ import {
   Loader2,
   Sparkles,
   Trash2,
+  Upload,
 } from "lucide-vue-next";
 
 import Button from "@/components/ui/Button.vue";
@@ -35,8 +37,12 @@ const emit = defineEmits<{
   (e: "update:timeout-seconds", value: number): void;
   (e: "update:content", value: string): void;
   (e: "update:file-content", fileIndex: number, value: string): void;
+  (e: "add-files", files: File[]): void;
   (e: "remove-file", fileIndex: number): void;
 }>();
+
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const isFileDragActive = ref(false);
 
 function isTextSkillFile(file: AgentSkillFile): boolean {
   return !file.encoding || file.encoding === "text";
@@ -52,6 +58,53 @@ function getSkillFilePreviewSrc(file: AgentSkillFile): string {
   }
   const mimeType = file.mimeType || "image/png";
   return `data:${mimeType};base64,${file.content}`;
+}
+
+function openFilePicker(): void {
+  fileInputRef.value?.click();
+}
+
+function emitFiles(fileList: FileList | null | undefined): void {
+  const files = Array.from(fileList ?? []);
+  if (files.length === 0) {
+    return;
+  }
+  emit("add-files", files);
+}
+
+function handleFileInputChange(event: Event): void {
+  const input = event.target;
+  if (!(input instanceof HTMLInputElement)) {
+    return;
+  }
+
+  emitFiles(input.files);
+  input.value = "";
+}
+
+function handleFileDragOver(event: DragEvent): void {
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = "copy";
+  }
+  isFileDragActive.value = true;
+}
+
+function handleFileDragLeave(event: DragEvent): void {
+  const currentTarget = event.currentTarget;
+  const relatedTarget = event.relatedTarget;
+  if (
+    currentTarget instanceof HTMLElement &&
+    relatedTarget instanceof Node &&
+    currentTarget.contains(relatedTarget)
+  ) {
+    return;
+  }
+  isFileDragActive.value = false;
+}
+
+function handleFileDrop(event: DragEvent): void {
+  isFileDragActive.value = false;
+  emitFiles(event.dataTransfer?.files);
 }
 </script>
 
@@ -156,6 +209,40 @@ function getSkillFilePreviewSrc(file: AgentSkillFile): string {
           class="font-mono text-xs"
           @update:model-value="emit('update:content', $event)"
         />
+      </div>
+      <div class="py-2">
+        <div
+          :class="[
+            'rounded border border-dashed p-3 text-xs transition-colors',
+            isFileDragActive ? 'border-primary bg-primary/5' : 'border-border bg-muted/10',
+          ]"
+          @dragenter.stop.prevent="isFileDragActive = true"
+          @dragover.stop.prevent="handleFileDragOver"
+          @dragleave.stop.prevent="handleFileDragLeave"
+          @drop.stop.prevent="handleFileDrop"
+        >
+          <input
+            ref="fileInputRef"
+            type="file"
+            class="sr-only"
+            multiple
+            @change="handleFileInputChange"
+          >
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <p class="text-muted-foreground">
+              Drop files here to attach them to this skill.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              class="gap-1"
+              @click="openFilePicker"
+            >
+              <Upload class="w-3.5 h-3.5" />
+              Add files
+            </Button>
+          </div>
+        </div>
       </div>
       <div
         v-if="skill.files?.length"

--- a/frontend/src/components/Panels/SkillBuilderModal.vue
+++ b/frontend/src/components/Panels/SkillBuilderModal.vue
@@ -27,6 +27,10 @@ interface CustomScrollbarState {
   thumbTop: number;
 }
 
+interface SkillBuilderPreviewFile extends SkillBuilderFile {
+  previewable: boolean;
+}
+
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
@@ -73,8 +77,20 @@ function getFileExtension(path: string): string {
   return lastDot >= 0 ? normalizedPath.slice(lastDot + 1) : "";
 }
 
-function getFileSizeBytes(content: string): number {
+function getTextSizeBytes(content: string): number {
   return new TextEncoder().encode(content).length;
+}
+
+function getBase64SizeBytes(content: string): number {
+  const padding = content.endsWith("==") ? 2 : content.endsWith("=") ? 1 : 0;
+  return Math.max(Math.floor((content.length * 3) / 4) - padding, 0);
+}
+
+function getSkillFileSizeBytes(file: AgentSkillFile): number {
+  if ((file.encoding ?? "text") === "base64") {
+    return getBase64SizeBytes(file.content);
+  }
+  return getTextSizeBytes(file.content);
 }
 
 function canSendFileToSkillBuilder(file: AgentSkillFile): boolean {
@@ -86,7 +102,7 @@ function canSendFileToSkillBuilder(file: AgentSkillFile): boolean {
     return false;
   }
 
-  return getFileSizeBytes(file.content) <= SKILL_BUILDER_MAX_FILE_BYTES;
+  return getTextSizeBytes(file.content) <= SKILL_BUILDER_MAX_FILE_BYTES;
 }
 
 const existingSkillFiles = computed<AgentSkillFile[]>(() => {
@@ -120,6 +136,12 @@ const existingSkillForApi = computed<SkillBuilderExistingSkill | undefined>(() =
   return {
     name: props.existingSkill.name,
     files: editableFiles,
+    attachments: preservedSkillFiles.value.map((file) => ({
+      path: file.path,
+      encoding: file.encoding ?? "text",
+      mime_type: file.mimeType,
+      size_bytes: getSkillFileSizeBytes(file),
+    })),
   };
 });
 
@@ -127,18 +149,15 @@ const preservedSkillFiles = computed<AgentSkillFile[]>(() =>
   existingSkillFiles.value.filter((file) => !canSendFileToSkillBuilder(file)),
 );
 
-const previewFiles = computed<SkillBuilderFile[]>(() => {
-  const mergedFiles = new Map<string, SkillBuilderFile>();
+const previewFiles = computed<SkillBuilderPreviewFile[]>(() => {
+  const mergedFiles = new Map<string, SkillBuilderPreviewFile>();
 
   preservedSkillFiles.value.forEach((file) => {
-    if ((file.encoding ?? "text") !== "text") {
-      return;
-    }
-    mergedFiles.set(file.path, { path: file.path, content: file.content });
+    mergedFiles.set(file.path, { path: file.path, content: "", previewable: false });
   });
 
   currentFiles.value.forEach((file) => {
-    mergedFiles.set(file.path, file);
+    mergedFiles.set(file.path, { ...file, previewable: true });
   });
 
   return Array.from(mergedFiles.values());
@@ -158,9 +177,16 @@ const modalTitle = computed(() => {
   return generatedName || props.existingSkill?.name || "New Skill";
 });
 
-const activeFile = computed<SkillBuilderFile | null>(
+const activeFile = computed<SkillBuilderPreviewFile | null>(
   () => previewFiles.value[activeFileIndex.value] ?? null,
 );
+
+const activeFileContent = computed(() => {
+  if (!activeFile.value?.previewable) {
+    return null;
+  }
+  return activeFile.value.content;
+});
 
 const canPrompt = computed(
   () =>
@@ -589,7 +615,7 @@ onUnmounted(() => {
                 Files
               </p>
               <p class="text-xs text-muted-foreground">
-                Read-only preview of generated skill files
+                Generated and attached skill files
               </p>
             </div>
 
@@ -608,7 +634,7 @@ onUnmounted(() => {
                       :class="[
                         'flex w-full min-w-0 items-center justify-start gap-1.5 rounded-full border px-3 py-1.5 text-left text-xs transition-colors',
                         index === activeFileIndex
-                          ? 'border-primary/40 bg-primary/10 text-primary'
+                          ? 'border-violet-500/70 bg-violet-50 text-violet-700 shadow-[0_0_0_1px_rgba(139,92,246,0.18)] dark:border-violet-500/80 dark:bg-violet-950/45 dark:text-violet-300 dark:shadow-[0_0_18px_rgba(124,58,237,0.18)]'
                           : 'border-border/60 bg-background text-muted-foreground hover:border-primary/30 hover:text-foreground',
                       ]"
                       @click="activeFileIndex = index"
@@ -639,9 +665,15 @@ onUnmounted(() => {
                   @scroll="scheduleCustomScrollbarUpdate"
                 >
                   <pre
-                    v-if="activeFile"
+                    v-if="activeFileContent !== null"
                     class="whitespace-pre-wrap break-words text-xs leading-5 text-foreground"
-                  >{{ activeFile.content }}</pre>
+                  >{{ activeFileContent }}</pre>
+                  <p
+                    v-else-if="activeFile"
+                    class="text-xs text-muted-foreground"
+                  >
+                    {{ activeFile.path }} is attached to the skill but is not editable in Skill Builder.
+                  </p>
                   <p
                     v-else
                     class="text-xs text-muted-foreground"

--- a/frontend/src/components/Panels/SkillBuilderModal.vue
+++ b/frontend/src/components/Panels/SkillBuilderModal.vue
@@ -51,6 +51,7 @@ const {
 
 const activeFileIndex = ref(0);
 const inputText = ref("");
+const includedAttachmentPaths = ref<Set<string>>(new Set());
 const isDownloading = ref(false);
 const isSaving = ref(false);
 const localError = ref<string | null>(null);
@@ -62,6 +63,7 @@ const keydownCaptureOptions = { capture: true } as const;
 const customScrollbarTrackInset = 16;
 const customScrollbarMinThumbHeight = 24;
 const SKILL_BUILDER_MAX_FILE_BYTES = 75 * 1024;
+const SKILL_BUILDER_MAX_ATTACHMENT_CONTEXT_BYTES = 2 * 1024 * 1024;
 const SKILL_BUILDER_TEXT_EXTENSIONS = new Set([
   "md",
   "py",
@@ -105,6 +107,34 @@ function canSendFileToSkillBuilder(file: AgentSkillFile): boolean {
   return getTextSizeBytes(file.content) <= SKILL_BUILDER_MAX_FILE_BYTES;
 }
 
+function canIncludeAttachmentContent(file: AgentSkillFile): boolean {
+  return getSkillFileSizeBytes(file) <= SKILL_BUILDER_MAX_ATTACHMENT_CONTEXT_BYTES;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function isAttachmentIncluded(path: string): boolean {
+  return includedAttachmentPaths.value.has(path);
+}
+
+function setAttachmentIncluded(path: string, included: boolean): void {
+  const next = new Set(includedAttachmentPaths.value);
+  if (included) {
+    next.add(path);
+  } else {
+    next.delete(path);
+  }
+  includedAttachmentPaths.value = next;
+}
+
 const existingSkillFiles = computed<AgentSkillFile[]>(() => {
   if (!props.existingSkill) {
     return [];
@@ -141,6 +171,10 @@ const existingSkillForApi = computed<SkillBuilderExistingSkill | undefined>(() =
       encoding: file.encoding ?? "text",
       mime_type: file.mimeType,
       size_bytes: getSkillFileSizeBytes(file),
+      content:
+        isAttachmentIncluded(file.path) && canIncludeAttachmentContent(file)
+          ? file.content
+          : undefined,
     })),
   };
 });
@@ -168,7 +202,13 @@ const preservedFileNote = computed(() => {
   if (preservedCount === 0) {
     return null;
   }
-  return `${preservedCount} non-editable, large, or non-text file(s) will stay attached to the skill but will not be sent to AI. Skill Builder only edits English Markdown and Python files.`;
+  const includedCount = preservedSkillFiles.value.filter(
+    (file) => isAttachmentIncluded(file.path) && canIncludeAttachmentContent(file),
+  ).length;
+  if (includedCount > 0) {
+    return `${preservedCount} non-editable, large, or non-text file(s) will stay attached. ${includedCount} selected file(s) will also be sent as AI context.`;
+  }
+  return `${preservedCount} non-editable, large, or non-text file(s) will stay attached. Select individual files on the right to include them as AI context.`;
 });
 
 const modalTitle = computed(() => {
@@ -180,6 +220,33 @@ const modalTitle = computed(() => {
 const activeFile = computed<SkillBuilderPreviewFile | null>(
   () => previewFiles.value[activeFileIndex.value] ?? null,
 );
+
+const activeAttachment = computed<AgentSkillFile | null>(() => {
+  const path = activeFile.value?.path;
+  if (!path) {
+    return null;
+  }
+  return preservedSkillFiles.value.find((file) => file.path === path) ?? null;
+});
+
+const activeAttachmentSize = computed(() =>
+  activeAttachment.value ? getSkillFileSizeBytes(activeAttachment.value) : 0,
+);
+
+const activeAttachmentCanInclude = computed(() =>
+  activeAttachment.value ? canIncludeAttachmentContent(activeAttachment.value) : false,
+);
+
+const activeAttachmentIncluded = computed(() =>
+  activeAttachment.value ? isAttachmentIncluded(activeAttachment.value.path) : false,
+);
+
+function handleActiveAttachmentIncludedChange(event: Event): void {
+  if (!activeAttachment.value || !(event.target instanceof HTMLInputElement)) {
+    return;
+  }
+  setAttachmentIncluded(activeAttachment.value.path, event.target.checked);
+}
 
 const activeFileContent = computed(() => {
   if (!activeFile.value?.previewable) {
@@ -441,6 +508,7 @@ watch(
       window.addEventListener("keydown", handleWindowKeydown, keydownCaptureOptions);
       reset();
       inputText.value = "";
+      includedAttachmentPaths.value = new Set();
       localError.value = null;
       activeFileIndex.value = 0;
       initialize(getGreeting(), existingSkillForApi.value?.files ?? []);
@@ -457,6 +525,7 @@ watch(
     customScrollbarResizeObserver = null;
     reset();
     inputText.value = "";
+    includedAttachmentPaths.value = new Set();
     localError.value = null;
     activeFileIndex.value = 0;
   },
@@ -594,7 +663,7 @@ onUnmounted(() => {
                 @keydown="handleInputKeydown"
               />
               <div class="mt-2 flex min-h-11 items-center justify-between gap-3">
-                <p class="text-xs leading-none text-muted-foreground">
+                <p class="min-w-0 flex-1 text-xs leading-snug text-muted-foreground">
                   {{ preservedFileNote ?? (credentialId && model ? "Press Enter to send, Shift+Enter for a new line." : "Select an agent credential and model to use AI Build.") }}
                 </p>
                 <Button
@@ -644,6 +713,12 @@ onUnmounted(() => {
                         class="h-3.5 w-3.5 shrink-0"
                       />
                       <span class="min-w-0 break-all">{{ file.path }}</span>
+                      <span
+                        v-if="!file.previewable && isAttachmentIncluded(file.path)"
+                        class="ml-auto shrink-0 rounded-full bg-violet-500/15 px-1.5 py-0.5 text-[10px] font-medium text-violet-500 dark:text-violet-300"
+                      >
+                        AI
+                      </span>
                     </button>
                   </div>
                 </div>
@@ -668,12 +743,53 @@ onUnmounted(() => {
                     v-if="activeFileContent !== null"
                     class="whitespace-pre-wrap break-words text-xs leading-5 text-foreground"
                   >{{ activeFileContent }}</pre>
-                  <p
+                  <div
                     v-else-if="activeFile"
-                    class="text-xs text-muted-foreground"
+                    class="space-y-3 text-xs text-muted-foreground"
                   >
-                    {{ activeFile.path }} is attached to the skill but is not editable in Skill Builder.
-                  </p>
+                    <p>
+                      {{ activeFile.path }} is attached to the skill but is not editable in Skill Builder.
+                    </p>
+                    <div
+                      v-if="activeAttachment"
+                      class="min-w-0 rounded-lg border border-border/60 bg-background/60 p-3"
+                    >
+                      <div class="space-y-1 pb-3">
+                        <p class="break-all font-medium text-foreground">
+                          {{ activeAttachment.path }}
+                        </p>
+                        <p class="break-all leading-snug">
+                          {{ activeAttachment.mimeType || "application/octet-stream" }} · {{ formatFileSize(activeAttachmentSize) }}
+                        </p>
+                      </div>
+                      <label class="flex items-start gap-2 border-t border-border/60 pt-3">
+                        <input
+                          type="checkbox"
+                          class="mt-0.5 h-3.5 w-3.5 rounded border-border bg-background"
+                          :checked="activeAttachmentIncluded"
+                          :disabled="!activeAttachmentCanInclude || isStreaming || isDownloading || isSaving"
+                          @change="handleActiveAttachmentIncludedChange"
+                        >
+                        <span class="min-w-0">
+                          <span class="block font-medium text-foreground">
+                            Include this file in AI context
+                          </span>
+                          <span
+                            v-if="activeAttachmentCanInclude"
+                            class="block leading-snug"
+                          >
+                            Sends only this attachment to AI. DOCX files are summarized with tables, rows, and empty value cells.
+                          </span>
+                          <span
+                            v-else
+                            class="block leading-snug text-destructive"
+                          >
+                            This file is larger than 2 MB and stays metadata-only.
+                          </span>
+                        </span>
+                      </label>
+                    </div>
+                  </div>
                   <p
                     v-else
                     class="text-xs text-muted-foreground"

--- a/frontend/src/components/Panels/propertiesPanel/nodes/AgentNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/AgentNodeProperties.vue
@@ -64,6 +64,7 @@ const {
   updateAgentSkill,
   updateAgentSkillFile,
   removeAgentSkillFile,
+  addAgentSkillFiles,
   skillZipLoading,
   skillZipError,
   skillDownloadLoadingId,
@@ -737,6 +738,7 @@ const {
         @update:timeout-seconds="updateAgentSkill(idx, 'timeoutSeconds', $event)"
         @update:content="updateAgentSkill(idx, 'content', $event)"
         @update:file-content="(fileIndex, value) => updateAgentSkillFile(idx, fileIndex, 'content', value)"
+        @add-files="addAgentSkillFiles(idx, $event)"
         @remove-file="removeAgentSkillFile(idx, $event)"
       />
       <p class="text-xs text-muted-foreground">

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -14,7 +14,12 @@ import { useRouter } from "vue-router";
 import { AlertTriangle, Ban, BarChart3, Bot, Braces, Brain, Bug, CalendarClock, Clock, Database, FileJson, FileText, GitBranch, GitMerge, Github, Globe, HardDrive, Inbox, ListTodo, Mail, MessageSquare, MonitorPlay, Play, Plug, Puzzle, Rabbit, Radio, Repeat, Search, Send, Server, Settings2, Sheet, ShieldAlert, Shuffle, StickyNote, Table2, Terminal, Type, Upload, Variable, XCircle } from "lucide-vue-next";
 import type { ClickHouseColumn, CredentialListItem, LLMModel, NotionDataSourceItem, NotionPageItem } from "@/types/credential";
 import type { AgentMCPConnection, AgentSkill, AgentSkillFile, ExecuteInputMapping, GuardrailCategory, InputField, MappingField, MCPTransportType, OutputSchemaField, PlaywrightStep, PlaywrightStepAction, WorkflowListItem } from "@/types/workflow";
-import { createAgentSkillZipBlob, getSkillZipFileName, parseSkillZip } from "@/lib/skillZipParser";
+import {
+  createAgentSkillZipBlob,
+  getSkillZipFileName,
+  parseSkillAssetFile,
+  parseSkillZip,
+} from "@/lib/skillZipParser";
 import { isRetryAttemptNodeResult } from "@/lib/executionLog";
 import { findEnclosingLoopIdForListSize, findNodeResultIndexForLoopIteration, mapNodeResultsToEnclosingLoopIterations, selectedLoopIterationIndexForNode } from "@/lib/loopNodeDisplay";
 import { getGitHubExpressionFields, type GitHubExpressionFieldKey } from "@/lib/githubExpressionFields";
@@ -7042,6 +7047,62 @@ export function usePropertiesPanelController() {
     );
   }
 
+  async function addAgentSkillFiles(skillIndex: number, files: File[]): Promise<void> {
+    if (!selectedNode.value || files.length === 0) return;
+
+    const skills = [...(selectedNode.value.data.skills || [])];
+    const skill = skills[skillIndex];
+    if (!skill) return;
+
+    const parsedFiles: AgentSkillFile[] = [];
+    for (const file of files) {
+      const parsedFile = await parseSkillAssetFile(file);
+      if (parsedFile) {
+        parsedFiles.push(parsedFile);
+      }
+    }
+
+    if (parsedFiles.length === 0) {
+      showToast("No usable skill files found", "error");
+      return;
+    }
+
+    let nextContent = skill.content;
+    let skillContentUpdated = false;
+    const filesByPath = new Map<string, AgentSkillFile>();
+    (skill.files ?? []).forEach((file) => {
+      filesByPath.set(file.path, file);
+    });
+
+    parsedFiles.forEach((file) => {
+      if (file.path.toLowerCase() === "skill.md" && (file.encoding ?? "text") === "text") {
+        nextContent = file.content;
+        skillContentUpdated = true;
+        return;
+      }
+      filesByPath.set(file.path, file);
+    });
+
+    const nextFiles = Array.from(filesByPath.values());
+    skills[skillIndex] = {
+      ...skill,
+      content: nextContent,
+      files: nextFiles,
+    };
+    updateNodeData("skills", skills);
+
+    const attachedCount = parsedFiles.length - (skillContentUpdated ? 1 : 0);
+    if (skillContentUpdated && attachedCount === 0) {
+      showToast("SKILL.md updated", "success");
+      return;
+    }
+    if (skillContentUpdated) {
+      showToast(`SKILL.md updated and ${attachedCount} file(s) attached`, "success");
+      return;
+    }
+    showToast(`${attachedCount} file(s) attached`, "success");
+  }
+
   const skillZipLoading = ref(false);
   const skillZipError = ref("");
   const skillDownloadLoadingId = ref<string | null>(null);
@@ -8546,6 +8607,7 @@ export function usePropertiesPanelController() {
     updateAgentSkill,
     updateAgentSkillFile,
     removeAgentSkillFile,
+    addAgentSkillFiles,
     skillZipLoading,
     skillZipError,
     skillDownloadLoadingId,

--- a/frontend/src/docs/content/nodes/agent-node.md
+++ b/frontend/src/docs/content/nodes/agent-node.md
@@ -264,16 +264,17 @@ Example — Slack MCP:
 
 ## Skills
 
-Skills are SKILL.md instructions plus optional Python files. They extend the agent's system context and can add Python tools.
+Skills are SKILL.md instructions plus optional Python files and bundled assets. They extend the agent's system context and can add Python tools.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | string | Skill name |
 | `content` | string | SKILL.md content (instructions) |
 | `timeoutSeconds` | number | Timeout for skill Python execution (default: 30) |
-| `files` | array | Optional `{ path, content }` entries (e.g. `.py` scripts) |
+| `files` | array | Optional `{ path, content, encoding, mimeType }` entries (e.g. `.py` scripts or binary assets stored as base64) |
 
 Skills can be added by dropping a `.zip` or `.md` file onto the Skills area.
+After expanding a skill card, drop any file onto that skill to attach or replace a bundled file, including binary assets such as PDFs and images.
 Use the download button on a skill card to export that skill as a `.zip` archive for backup or reuse in another workflow.
 
 Each skill card has four actions on the row below the title:
@@ -306,7 +307,7 @@ The Skills section also includes **AI Build**:
 - **Download ZIP** exports the current preview without adding it to the node
 - **Save & Add** saves the generated files back through the same ZIP parsing flow used by manual uploads
 
-When editing with AI, Heym only sends text `.md` and `.py` skill files to the builder. Binary files are not included; if a skill needs images or other binary inputs, pass them as workflow inputs instead of embedding them inside Python source.
+When editing with AI, Heym only sends text `.md` and `.py` skill files to the builder. Binary and other non-editable attachments are preserved and shared with the builder as path metadata so generated Python code can keep relative file references correct.
 
 ## Guardrails
 

--- a/frontend/src/docs/content/nodes/agent-node.md
+++ b/frontend/src/docs/content/nodes/agent-node.md
@@ -308,6 +308,7 @@ The Skills section also includes **AI Build**:
 - **Save & Add** saves the generated files back through the same ZIP parsing flow used by manual uploads
 
 When editing with AI, Heym only sends text `.md` and `.py` skill files to the builder. Binary and other non-editable attachments are preserved and shared with the builder as path metadata so generated Python code can keep relative file references correct.
+Select an attached file in the right panel and enable **Include this file in AI context** when the AI needs to inspect a bundled template. Supported attachments such as DOCX files are summarized for the AI, including table rows and empty value cells, while oversized files stay metadata-only.
 
 ## Guardrails
 

--- a/frontend/src/lib/skillZipParser.test.ts
+++ b/frontend/src/lib/skillZipParser.test.ts
@@ -1,0 +1,57 @@
+import JSZip from "jszip";
+import { describe, expect, it } from "vitest";
+
+import {
+  parseSkillAssetFile,
+  parseSkillZip,
+  shouldIgnoreSkillArchivePath,
+} from "@/lib/skillZipParser";
+
+async function makeZipFile(entries: Record<string, string | Uint8Array>): Promise<File> {
+  const zip = new JSZip();
+  Object.entries(entries).forEach(([path, content]) => {
+    zip.file(path, content);
+  });
+  const blob = await zip.generateAsync({ type: "blob" });
+  return new File([blob], "skill.zip", { type: "application/zip" });
+}
+
+describe("skillZipParser", () => {
+  it("skips macOS metadata files when importing a skill zip", async () => {
+    const file = await makeZipFile({
+      "SKILL.md": "---\nname: useful-skill\n---",
+      "main.py": "def execute(params, files):\n    return {}\n",
+      ".DS_Store": "metadata",
+      "__MACOSX/SKILL.md": "---\nname: ignored\n---",
+      "__MACOSX/._main.py": "metadata",
+      "assets/._hello.pdf": "metadata",
+    });
+
+    const skills = await parseSkillZip(file);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.name).toBe("useful-skill");
+    expect(skills[0]?.files?.map((skillFile) => skillFile.path)).toEqual(["main.py"]);
+  });
+
+  it("parses a dropped binary file as a base64 skill attachment", async () => {
+    const file = new File([new Uint8Array([0, 1, 2, 3])], "hello.pdf", {
+      type: "application/pdf",
+    });
+
+    const parsed = await parseSkillAssetFile(file);
+
+    expect(parsed).toEqual({
+      path: "hello.pdf",
+      content: "AAECAw==",
+      encoding: "base64",
+      mimeType: "application/pdf",
+    });
+  });
+
+  it("marks macOS archive metadata paths as ignored", () => {
+    expect(shouldIgnoreSkillArchivePath("__MACOSX/._main.py")).toBe(true);
+    expect(shouldIgnoreSkillArchivePath("assets/.DS_Store")).toBe(true);
+    expect(shouldIgnoreSkillArchivePath("assets/main.py")).toBe(false);
+  });
+});

--- a/frontend/src/lib/skillZipParser.ts
+++ b/frontend/src/lib/skillZipParser.ts
@@ -4,6 +4,8 @@ import type { AgentSkill, AgentSkillFile } from "@/types/workflow";
 
 const SKILL_MD_PATTERN = /SKILL\.md$/i;
 const ROOT_SKILL_FILE = "SKILL.md";
+const MACOSX_METADATA_DIR = "__MACOSX";
+const MACOS_METADATA_FILE_NAMES = new Set([".DS_Store"]);
 const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   gif: "image/gif",
   jpeg: "image/jpeg",
@@ -11,6 +13,17 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   png: "image/png",
   svg: "image/svg+xml",
   webp: "image/webp",
+};
+const ASSET_MIME_BY_EXTENSION: Record<string, string> = {
+  ...IMAGE_MIME_BY_EXTENSION,
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  epub: "application/epub+zip",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+  pdf: "application/pdf",
+  pptx: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  zip: "application/zip",
 };
 const TEXT_FILE_EXTENSIONS = new Set([
   "c",
@@ -56,7 +69,7 @@ function normalizePath(p: string): string {
   return p.replace(/\\/g, "/").replace(/\/+/g, "/");
 }
 
-function normalizeArchivePath(path: string): string {
+export function normalizeSkillArchivePath(path: string): string {
   const normalized = normalizePath(path).replace(/^\/+/, "");
   const parts = normalized
     .split("/")
@@ -64,9 +77,22 @@ function normalizeArchivePath(path: string): string {
   return parts.join("/");
 }
 
+export function shouldIgnoreSkillArchivePath(path: string): boolean {
+  const normalized = normalizeSkillArchivePath(path);
+  if (!normalized) return true;
+
+  const parts = normalized.split("/");
+  return parts.some(
+    (part) =>
+      part === MACOSX_METADATA_DIR ||
+      MACOS_METADATA_FILE_NAMES.has(part) ||
+      part.startsWith("._"),
+  );
+}
+
 function addSkillFileToZip(zip: JSZip, file: AgentSkillFile): void {
-  const path = normalizeArchivePath(file.path);
-  if (!path) return;
+  const path = normalizeSkillArchivePath(file.path);
+  if (!path || shouldIgnoreSkillArchivePath(path)) return;
 
   if ((file.encoding ?? "text") === "base64") {
     zip.file(path, file.content, { base64: true });
@@ -96,7 +122,7 @@ export async function createAgentSkillZipBlob(skill: AgentSkill): Promise<Blob> 
   zip.file(ROOT_SKILL_FILE, skill.content);
 
   (skill.files ?? []).forEach((file) => {
-    if (normalizeArchivePath(file.path).toLowerCase() === ROOT_SKILL_FILE.toLowerCase()) {
+    if (normalizeSkillArchivePath(file.path).toLowerCase() === ROOT_SKILL_FILE.toLowerCase()) {
       return;
     }
 
@@ -127,8 +153,9 @@ function getExtension(path: string): string {
 
 function inferMimeType(path: string): string {
   const extension = getExtension(path);
-  if (extension in IMAGE_MIME_BY_EXTENSION) {
-    return IMAGE_MIME_BY_EXTENSION[extension];
+  const assetMimeType = ASSET_MIME_BY_EXTENSION[extension];
+  if (assetMimeType) {
+    return assetMimeType;
   }
   if (extension === "md") return "text/markdown";
   if (extension === "json") return "application/json";
@@ -203,6 +230,30 @@ function parseZipFile(path: string, bytes: Uint8Array): ParsedSkillZipFile {
   };
 }
 
+function getBrowserFilePath(file: File): string {
+  const webkitRelativePath = "webkitRelativePath" in file ? file.webkitRelativePath : "";
+  return webkitRelativePath || file.name;
+}
+
+export async function parseSkillAssetFile(
+  file: File,
+  path = getBrowserFilePath(file),
+): Promise<AgentSkillFile | null> {
+  const archivePath = normalizeSkillArchivePath(path);
+  if (!archivePath || shouldIgnoreSkillArchivePath(archivePath)) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const parsed = parseZipFile(archivePath, bytes);
+  return {
+    path: parsed.path,
+    content: parsed.content,
+    encoding: parsed.encoding,
+    mimeType: parsed.mimeType,
+  };
+}
+
 /**
  * Assign each file to the skill with the longest matching directory prefix.
  */
@@ -255,14 +306,16 @@ export async function parseSkillZip(file: File): Promise<AgentSkill[]> {
 
   const fileEntries: ParsedSkillZipFile[] = [];
 
-  const fileNames = Object.keys(zip.files).filter((n) => !zip.files[n].dir);
+  const fileNames = Object.keys(zip.files).filter(
+    (n) => !zip.files[n].dir && !shouldIgnoreSkillArchivePath(n),
+  );
 
   for (const path of fileNames) {
     const entry = zip.files[path];
     if (!entry || entry.dir) continue;
     try {
       const bytes = await entry.async("uint8array");
-      fileEntries.push(parseZipFile(path, bytes));
+      fileEntries.push(parseZipFile(normalizeSkillArchivePath(path), bytes));
     } catch {
       // Skip unreadable files
     }

--- a/frontend/src/services/skillBuilderApi.ts
+++ b/frontend/src/services/skillBuilderApi.ts
@@ -15,6 +15,7 @@ export interface SkillBuilderAttachment {
   encoding: "text" | "base64";
   mime_type?: string;
   size_bytes?: number;
+  content?: string;
 }
 
 export interface SkillBuilderExistingSkill {

--- a/frontend/src/services/skillBuilderApi.ts
+++ b/frontend/src/services/skillBuilderApi.ts
@@ -10,9 +10,17 @@ export interface SkillBuilderFile {
   content: string;
 }
 
+export interface SkillBuilderAttachment {
+  path: string;
+  encoding: "text" | "base64";
+  mime_type?: string;
+  size_bytes?: number;
+}
+
 export interface SkillBuilderExistingSkill {
   name: string;
   files: SkillBuilderFile[];
+  attachments?: SkillBuilderAttachment[];
 }
 
 export interface SkillBuilderRequest {


### PR DESCRIPTION
## Summary
- Add per-file AI context selection for Skill Builder attachments so only chosen non-editable/binary files are sent.
- Summarize selected DOCX attachments with tables, rows, and empty value cells to help AI diagnose template/code mismatches.
- Keep oversized attachments metadata-only and update Skill Builder docs.

## Tests
- SECRET_KEY=${SECRET_KEY:-test-secret-key-for-tests-only-32-bytes} ./check.sh