### PR TITLE
Fix vector store showing Qdrant label for new pgvector stores

### DIFF
--- a/frontend/src/components/VectorStores/VectorStoresPanel.vue
+++ b/frontend/src/components/VectorStores/VectorStoresPanel.vue
@@ -168,6 +168,7 @@ async function createVectorStore(): Promise<void> {
       is_shared: false,
       shared_by: null,
       stats: store.stats,
+      backend: store.backend,
     });
     showCreateDialog.value = false;
   } catch (e: unknown) {
@@ -212,6 +213,7 @@ async function cloneVectorStore(store: VectorStoreListItem, event: Event): Promi
       is_shared: false,
       shared_by: null,
       stats: cloned.stats,
+      backend: cloned.backend,
     });
   } catch {
     alert("Failed to clone vector store");


### PR DESCRIPTION
## Problem

When a new RAG vector store is created (or cloned) with a Postgres/pgvector credential, the badge in the bottom-right of the card showed **"Qdrant"** by default. Refreshing the page fixed it.

## Cause

The create/clone handlers in `VectorStoresPanel.vue` build an optimistic list item but omitted the `backend` field. With `store.backend` undefined, the template's `store.backend === "pgvector" ? "Postgres" : "Qdrant"` fell through to the `"Qdrant"` default. A refresh reloaded the list from the API (which returns the correct `backend`), which is why it self-corrected.

## Fix

Carry `backend` through in both optimistic list updates (`createVectorStore` and `cloneVectorStore`). The backend already returns the correct `backend` on both endpoints.

## Testing

- `bun run typecheck` passes.
- Change is a single Vue file; no backend/logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)