### PR TITLE
Add Teams tab to Ctrl+K command palette

### DIFF
--- a/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
+++ b/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
@@ -20,6 +20,7 @@ import {
   Table2,
   Terminal,
   Trash2,
+  Users,
   Variable,
   Workflow,
 } from "lucide-vue-next";
@@ -49,6 +50,7 @@ const TABS = [
   { id: "datatable", label: "DataTable", icon: Table2 },
   { id: "evals", label: "Evals", icon: FlaskConical },
   { id: "schedules", label: "Scheduled", icon: CalendarDays },
+  { id: "teams", label: "Teams", icon: Users },
   { id: "logs", label: "Logs", icon: Terminal },
 ] as const;
 


### PR DESCRIPTION
## Summary
- Adds the missing **Teams** entry to the Ctrl+K (`WorkflowCommandPalette`) "Go to tab" list
- Uses the same `teams` tab id and `Users` icon as the dashboard nav, so existing tab navigation handlers work unchanged

## Test plan
- [ ] Open dashboard and press `Ctrl+K` / `Cmd+K`
- [ ] Confirm **Teams** appears under "Go to tab"
- [ ] Search for "teams" and verify the tab result is shown
- [ ] Select Teams and confirm navigation to `/?tab=teams`
- [ ] Repeat from editor, docs, evals, and chats views


Made with [Cursor](https://cursor.com)