### PR TITLE
Show editable skill files first in properties panel

### DIFF
--- a/frontend/src/components/Panels/AgentSkillCard.vue
+++ b/frontend/src/components/Panels/AgentSkillCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import {
   ChevronDown,
   ChevronRight,
@@ -15,7 +15,13 @@ import Button from "@/components/ui/Button.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
 import Textarea from "@/components/ui/Textarea.vue";
-import type { AgentSkill, AgentSkillFile } from "@/types/workflow";
+import {
+  getSkillFileImageSrc,
+  getSkillFilesSortedForDisplay,
+  isImageSkillFile,
+  isTextSkillFile,
+} from "@/lib/skillFilePreview";
+import type { AgentSkill } from "@/types/workflow";
 
 interface Props {
   skill: AgentSkill;
@@ -25,7 +31,11 @@ interface Props {
   downloadLoading?: boolean;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const sortedSkillFiles = computed(() =>
+  getSkillFilesSortedForDisplay(props.skill.files ?? []),
+);
 
 const emit = defineEmits<{
   (e: "toggle-expand"): void;
@@ -43,22 +53,6 @@ const emit = defineEmits<{
 
 const fileInputRef = ref<HTMLInputElement | null>(null);
 const isFileDragActive = ref(false);
-
-function isTextSkillFile(file: AgentSkillFile): boolean {
-  return !file.encoding || file.encoding === "text";
-}
-
-function isImageSkillFile(file: AgentSkillFile): boolean {
-  return file.encoding === "base64" && (file.mimeType?.startsWith("image/") ?? false);
-}
-
-function getSkillFilePreviewSrc(file: AgentSkillFile): string {
-  if (!isImageSkillFile(file) || !file.content) {
-    return "";
-  }
-  const mimeType = file.mimeType || "image/png";
-  return `data:${mimeType};base64,${file.content}`;
-}
 
 function openFilePicker(): void {
   fileInputRef.value?.click();
@@ -250,8 +244,8 @@ function handleFileDrop(event: DragEvent): void {
       >
         <Label class="text-xs">Files ({{ skill.files.length }})</Label>
         <div
-          v-for="(file, fileIndex) in skill.files"
-          :key="fileIndex"
+          v-for="{ file, originalIndex } in sortedSkillFiles"
+          :key="file.path"
           class="rounded border bg-muted/20 p-2 min-w-0"
         >
           <div class="flex justify-between items-center gap-2 mb-1 min-w-0">
@@ -263,7 +257,7 @@ function handleFileDrop(event: DragEvent): void {
               variant="ghost"
               size="sm"
               class="gap-1 shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10"
-              @click="emit('remove-file', fileIndex)"
+              @click="emit('remove-file', originalIndex)"
             >
               <Trash2 class="w-3.5 h-3.5" />
               Remove
@@ -274,8 +268,8 @@ function handleFileDrop(event: DragEvent): void {
             class="space-y-2"
           >
             <img
-              v-if="getSkillFilePreviewSrc(file)"
-              :src="getSkillFilePreviewSrc(file)"
+              v-if="getSkillFileImageSrc(file)"
+              :src="getSkillFileImageSrc(file)"
               :alt="file.path"
               class="max-h-56 w-auto max-w-full rounded border bg-background object-contain"
             >
@@ -288,7 +282,7 @@ function handleFileDrop(event: DragEvent): void {
             :model-value="file.content"
             :rows="4"
             class="font-mono text-xs"
-            @update:model-value="emit('update:file-content', fileIndex, $event)"
+            @update:model-value="emit('update:file-content', originalIndex, $event)"
           />
           <p
             v-else

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -20,6 +20,7 @@ import {
   parseSkillAssetFile,
   parseSkillZip,
 } from "@/lib/skillZipParser";
+import { sortSkillFiles } from "@/lib/skillFilePreview";
 import { isRetryAttemptNodeResult } from "@/lib/executionLog";
 import { findEnclosingLoopIdForListSize, findNodeResultIndexForLoopIteration, mapNodeResultsToEnclosingLoopIterations, selectedLoopIterationIndexForNode } from "@/lib/loopNodeDisplay";
 import { getGitHubExpressionFields, type GitHubExpressionFieldKey } from "@/lib/githubExpressionFields";
@@ -7083,7 +7084,7 @@ export function usePropertiesPanelController() {
       filesByPath.set(file.path, file);
     });
 
-    const nextFiles = Array.from(filesByPath.values());
+    const nextFiles = sortSkillFiles(Array.from(filesByPath.values()));
     skills[skillIndex] = {
       ...skill,
       content: nextContent,

--- a/frontend/src/lib/skillFilePreview.test.ts
+++ b/frontend/src/lib/skillFilePreview.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentSkillFile } from "@/types/workflow";
+import {
+  getSkillFilesSortedForDisplay,
+  isEditableSkillFile,
+  sortSkillFiles,
+} from "@/lib/skillFilePreview";
+
+function makeFile(
+  path: string,
+  encoding: AgentSkillFile["encoding"] = "text",
+): AgentSkillFile {
+  return {
+    path,
+    content: encoding === "base64" ? "YWJj" : `# ${path}`,
+    encoding,
+    mimeType: encoding === "base64" ? "application/pdf" : "text/plain",
+  };
+}
+
+describe("skillFilePreview", () => {
+  it("treats text and svg files as editable", () => {
+    expect(isEditableSkillFile(makeFile("main.py"))).toBe(true);
+    expect(isEditableSkillFile(makeFile("icon.svg"))).toBe(true);
+    expect(isEditableSkillFile(makeFile("doc.pdf", "base64"))).toBe(false);
+  });
+
+  it("sorts editable files before binary attachments", () => {
+    const files = [
+      makeFile("assets/report.pdf", "base64"),
+      makeFile("tools/run.py"),
+      makeFile("README.md"),
+    ];
+
+    expect(sortSkillFiles(files).map((file) => file.path)).toEqual([
+      "README.md",
+      "tools/run.py",
+      "assets/report.pdf",
+    ]);
+  });
+
+  it("preserves original indices for sorted display entries", () => {
+    const files = [
+      makeFile("assets/report.pdf", "base64"),
+      makeFile("tools/run.py"),
+      makeFile("README.md"),
+    ];
+
+    expect(getSkillFilesSortedForDisplay(files)).toEqual([
+      { file: files[2], originalIndex: 2 },
+      { file: files[1], originalIndex: 1 },
+      { file: files[0], originalIndex: 0 },
+    ]);
+  });
+});

--- a/frontend/src/lib/skillFilePreview.ts
+++ b/frontend/src/lib/skillFilePreview.ts
@@ -58,3 +58,43 @@ export function getSkillFileImageSrc(file: AgentSkillFile): string {
 export function canPreviewSkillFile(file: AgentSkillFile): boolean {
   return isTextSkillFile(file) || isImageSkillFile(file) || isSvgSkillFile(file);
 }
+
+export function isEditableSkillFile(file: AgentSkillFile): boolean {
+  return isTextSkillFile(file);
+}
+
+export interface SkillFileWithIndex {
+  file: AgentSkillFile;
+  originalIndex: number;
+}
+
+export function compareSkillFilesForDisplay(
+  left: AgentSkillFile,
+  right: AgentSkillFile,
+): number {
+  const leftEditable = isEditableSkillFile(left);
+  const rightEditable = isEditableSkillFile(right);
+  if (leftEditable !== rightEditable) {
+    return leftEditable ? -1 : 1;
+  }
+
+  return left.path.localeCompare(right.path);
+}
+
+export function sortSkillFiles(files: AgentSkillFile[]): AgentSkillFile[] {
+  return [...files].sort(compareSkillFilesForDisplay);
+}
+
+export function getSkillFilesSortedForDisplay(
+  files: AgentSkillFile[],
+): SkillFileWithIndex[] {
+  return files
+    .map((file, originalIndex) => ({ file, originalIndex }))
+    .sort((left, right) => {
+      const order = compareSkillFilesForDisplay(left.file, right.file);
+      if (order !== 0) {
+        return order;
+      }
+      return left.originalIndex - right.originalIndex;
+    });
+}


### PR DESCRIPTION
## Summary
- Sort skill attachment files in the Agent properties panel so text-editable files (`.md`, `.py`, `.svg`, etc.) always appear above binary attachments.
- Reuse shared helpers from `skillFilePreview.ts` in `AgentSkillCard` and preserve original file indices for edit/remove actions.
- Apply the same ordering when new files are attached to a skill.

## Test plan
- [x] `bunx vitest run src/lib/skillFilePreview.test.ts`
- [x] `bun run typecheck`
- [ ] Open an Agent node with a skill that mixes `.py`/`.md` and binary attachments; confirm editable files render at the top
- [ ] Edit and remove a file after sorting; confirm the correct file is updated/removed
- [ ] Attach a new binary file; confirm editable files stay above it


Made with [Cursor](https://cursor.com)