### PR TITLE
Drive bulk delete, reliable skill file button, selectable highlights, tab path routing

### DIFF
--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -15,6 +15,7 @@ from app.db.models import FileAccessToken, FileTeamShare, GeneratedFile, Team, T
 from app.db.session import get_db
 from app.models.schemas import (
     BulkCreateFileShareRequest,
+    BulkFileDeleteRequest,
     BulkFileDownloadRequest,
     BulkFileOperationResponse,
     BulkFileTeamSharingRequest,
@@ -297,6 +298,26 @@ async def delete_all_files_endpoint(
     for row in rows:
         await delete_file(db, row)
     await db.commit()
+
+
+@router.post("/delete/bulk", response_model=BulkFileOperationResponse)
+async def bulk_delete_files(
+    payload: BulkFileDeleteRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BulkFileOperationResponse:
+    """Delete multiple owned files (and their share tokens) in one request."""
+    succeeded: list[uuid.UUID] = []
+    failed: list[uuid.UUID] = []
+    for file_id in payload.file_ids:
+        row = await _get_owned_file(db, file_id, user.id)
+        if not row:
+            failed.append(file_id)
+            continue
+        await delete_file(db, row)
+        succeeded.append(file_id)
+    await db.commit()
+    return BulkFileOperationResponse(succeeded=succeeded, failed=failed)
 
 
 @router.post("/upload", response_model=GeneratedFileResponse)

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1431,6 +1431,10 @@ class BulkFileDownloadRequest(BaseModel):
     file_ids: list[uuid.UUID] = Field(min_length=1)
 
 
+class BulkFileDeleteRequest(BaseModel):
+    file_ids: list[uuid.UUID] = Field(min_length=1)
+
+
 class FileListResponse(BaseModel):
     files: list[GeneratedFileResponse] = Field(default_factory=list)
     total: int = 0

--- a/backend/app/services/node_execution/nodes/agent_node.py
+++ b/backend/app/services/node_execution/nodes/agent_node.py
@@ -7,6 +7,44 @@ from importlib import import_module
 from app.services.node_execution.base import NodeExecutionContext
 
 
+def _collect_generated_files_from_output(output: object) -> list[dict]:
+    """Aggregate skill-generated file links found anywhere in an agent result.
+
+    Skill tool results embed a ``_generated_files`` array under their tool call.
+    Surfacing the union at the top level lets the execution log render a download
+    button and lets expressions reference ``$agentLabel._generated_files`` even
+    when JSON output mode replaces the raw agent result.
+    """
+    collected: list[dict] = []
+    seen: set[str] = set()
+
+    def _walk(value: object, depth: int) -> None:
+        if depth > 6:
+            return
+        if isinstance(value, list):
+            for item in value:
+                _walk(item, depth + 1)
+            return
+        if not isinstance(value, dict):
+            return
+        files = value.get("_generated_files")
+        if isinstance(files, list):
+            for entry in files:
+                if not isinstance(entry, dict):
+                    continue
+                key = str(entry.get("download_url") or entry.get("id") or "")
+                if key and key in seen:
+                    continue
+                if key:
+                    seen.add(key)
+                collected.append(copy.deepcopy(entry))
+        for nested in value.values():
+            _walk(nested, depth + 1)
+
+    _walk(output, 0)
+    return collected
+
+
 def execute(ctx: NodeExecutionContext) -> object:
     """Execute the agent node."""
     _workflow_executor = import_module("app.services.workflow_executor")
@@ -39,6 +77,9 @@ def execute(ctx: NodeExecutionContext) -> object:
     output = self._execute_agent_node(
         node_id, inputs, node_data, guardrails_config=agent_guardrails_config
     )
+    generated_files = _collect_generated_files_from_output(output)
+    if generated_files:
+        output["_generated_files"] = generated_files
     trace_id = self._pop_internal_trace_id(output)
     pending_meta = output.pop("_hitl_pending", None)
     if agent_json_output_enabled and not output.get("error"):
@@ -59,6 +100,8 @@ def execute(ctx: NodeExecutionContext) -> object:
             output["fallbackUsed"] = agent_output["fallbackUsed"]
         if agent_output.get("model"):
             output["model"] = agent_output["model"]
+        if generated_files:
+            output["_generated_files"] = generated_files
         self._restore_internal_trace_id(output, trace_id)
     if output.get("error"):
         if trace_id:

--- a/backend/tests/test_agent_node_generated_files.py
+++ b/backend/tests/test_agent_node_generated_files.py
@@ -1,0 +1,71 @@
+"""Tests for surfacing skill-generated files on the agent node output.
+
+The execution-log download button and `$agentLabel._generated_files` expressions
+both rely on a top-level `_generated_files` array on the agent result, aggregated
+from skill tool calls (including nested sub-agent calls and JSON output mode).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from app.services.node_execution.nodes.agent_node import (
+    _collect_generated_files_from_output,
+)
+
+
+def _file(name: str, url: str) -> dict:
+    return {
+        "id": url.rsplit("/", 1)[-1],
+        "filename": name,
+        "mime_type": "text/plain",
+        "size_bytes": 3,
+        "download_url": url,
+    }
+
+
+class CollectGeneratedFilesTests(unittest.TestCase):
+    def test_collects_from_tool_call_result(self) -> None:
+        f = _file("report.txt", "https://x/api/files/dl/aaa")
+        output = {
+            "text": "done",
+            "tool_calls": [{"name": "skill_x", "result": {"_generated_files": [f]}}],
+        }
+        self.assertEqual(_collect_generated_files_from_output(output), [f])
+
+    def test_collects_from_nested_sub_agent_result(self) -> None:
+        f = _file("nested.txt", "https://x/api/files/dl/bbb")
+        output = {
+            "text": "done",
+            "tool_calls": [
+                {
+                    "name": "call_sub_agent",
+                    "result": {
+                        "text": "sub",
+                        "tool_calls": [{"name": "skill_y", "result": {"_generated_files": [f]}}],
+                    },
+                }
+            ],
+        }
+        self.assertEqual(_collect_generated_files_from_output(output), [f])
+
+    def test_dedupes_by_download_url(self) -> None:
+        f = _file("dup.txt", "https://x/api/files/dl/ccc")
+        output = {
+            "tool_calls": [
+                {"name": "skill_a", "result": {"_generated_files": [f]}},
+                {"name": "skill_b", "result": {"_generated_files": [dict(f)]}},
+            ],
+        }
+        collected = _collect_generated_files_from_output(output)
+        self.assertEqual(len(collected), 1)
+        self.assertEqual(collected[0]["download_url"], f["download_url"])
+
+    def test_returns_empty_when_no_files(self) -> None:
+        self.assertEqual(_collect_generated_files_from_output({"text": "hi"}), [])
+        self.assertEqual(_collect_generated_files_from_output(None), [])
+        self.assertEqual(_collect_generated_files_from_output("nope"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_files_bulk.py
+++ b/backend/tests/test_files_bulk.py
@@ -15,11 +15,13 @@ from fastapi import HTTPException
 
 from app.api.files import (
     bulk_create_share,
+    bulk_delete_files,
     bulk_download_files,
     bulk_update_file_team_sharing,
 )
 from app.models.schemas import (
     BulkCreateFileShareRequest,
+    BulkFileDeleteRequest,
     BulkFileDownloadRequest,
     BulkFileTeamSharingRequest,
 )
@@ -164,6 +166,50 @@ class BulkCreateShareApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.failed, [not_owned])
         create_token.assert_awaited_once()
         self.assertEqual(create_token.await_args.kwargs["file_id"], owned)
+        db.commit.assert_awaited_once()
+
+
+class BulkDeleteApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deletes_all_owned_files(self) -> None:
+        owner = _user()
+        ids = [uuid.uuid4() for _ in range(3)]
+        db = _db()
+
+        with (
+            patch("app.api.files._get_owned_file", new=_owned_lookup(owner, set(ids))),
+            patch("app.api.files.delete_file", new=AsyncMock()) as delete,
+        ):
+            response = await bulk_delete_files(
+                BulkFileDeleteRequest(file_ids=ids),
+                user=owner,
+                db=db,
+            )
+
+        self.assertEqual(set(response.succeeded), set(ids))
+        self.assertEqual(response.failed, [])
+        self.assertEqual(delete.await_count, 3)
+        db.commit.assert_awaited_once()
+
+    async def test_non_owned_ids_land_in_failed_and_are_not_deleted(self) -> None:
+        owner = _user()
+        owned = uuid.uuid4()
+        not_owned = uuid.uuid4()
+        db = _db()
+
+        with (
+            patch("app.api.files._get_owned_file", new=_owned_lookup(owner, {owned})),
+            patch("app.api.files.delete_file", new=AsyncMock()) as delete,
+        ):
+            response = await bulk_delete_files(
+                BulkFileDeleteRequest(file_ids=[owned, not_owned]),
+                user=owner,
+                db=db,
+            )
+
+        self.assertEqual(response.succeeded, [owned])
+        self.assertEqual(response.failed, [not_owned])
+        delete.assert_awaited_once()
+        self.assertEqual(delete.await_args.args[1].id, owned)
         db.commit.assert_awaited_once()
 
 

--- a/frontend/src/components/Canvas/HighlightPopup.vue
+++ b/frontend/src/components/Canvas/HighlightPopup.vue
@@ -189,7 +189,7 @@ function previewHtml(record: HighlightRecord): string {
   <div
     v-if="visible"
     data-testid="execution-highlights-panel"
-    class="absolute right-4 top-4 z-20 flex max-h-[calc(100%-2rem)] w-80 flex-col rounded-lg border border-border bg-background shadow-lg"
+    class="nopan absolute right-4 top-4 z-20 flex max-h-[calc(100%-2rem)] w-80 select-text flex-col rounded-lg border border-border bg-background shadow-lg"
   >
     <div class="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
       <span class="shrink-0 text-sm font-medium">Execution Highlights</span>

--- a/frontend/src/components/Drive/DrivePanel.vue
+++ b/frontend/src/components/Drive/DrivePanel.vue
@@ -47,6 +47,7 @@ const shareFilename = ref("");
 
 const showBulk = ref(false);
 const downloadingBulk = ref(false);
+const deletingBulk = ref(false);
 const selectedIds = ref<Set<string>>(new Set());
 const lastSelectedIndex = ref<number | null>(null);
 
@@ -240,6 +241,28 @@ async function downloadSelected(): Promise<void> {
   }
 }
 
+async function deleteSelected(): Promise<void> {
+  const ids = selectedFileIds.value;
+  if (ids.length === 0 || deletingBulk.value) return;
+  if (
+    !window.confirm(
+      `Delete ${ids.length} selected file${ids.length === 1 ? "" : "s"}? This cannot be undone.`,
+    )
+  ) {
+    return;
+  }
+  deletingBulk.value = true;
+  error.value = "";
+  try {
+    await filesApi.bulkDelete(ids);
+    await loadFiles();
+  } catch {
+    error.value = "Failed to delete selected files";
+  } finally {
+    deletingBulk.value = false;
+  }
+}
+
 function mimeIcon(mime: string) {
   if (mime.startsWith("image/")) return Image;
   if (mime === "application/pdf") return FileText;
@@ -425,6 +448,16 @@ onBeforeUnmount(() => {
       >
         <Settings class="w-3.5 h-3.5 mr-1" />
         Actions
+      </Button>
+      <Button
+        size="sm"
+        variant="destructive"
+        :loading="deletingBulk"
+        :disabled="deletingBulk"
+        @click="deleteSelected"
+      >
+        <Trash2 class="w-3.5 h-3.5 mr-1" />
+        Delete
       </Button>
       <Button
         size="sm"

--- a/frontend/src/docs/content/tabs/drive-tab.md
+++ b/frontend/src/docs/content/tabs/drive-tab.md
@@ -27,6 +27,7 @@ Files you own show a checkbox at the start of their row (files shared with you t
 - **Bulk actions** opens a single dialog to apply one setting to every selected file:
   - **Share all with my teams** / **Remove team sharing** in one click
   - **Create share link for each file** using the same password, expiry, and max-downloads settings
+- **Delete** removes every selected file and its share links after a confirmation
 - **Clear selection** deselects everything
 
 The dialog reports how many files it applied to (files you don't own are skipped). Use the rows-per-page selector's **All** option to load every file on one page and select across your whole Drive. Typing in the search box automatically switches the rows-per-page selector to **All** so the search covers every file, not just the current page; clearing the search restores your previous selection.

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -13,9 +13,42 @@ function sanitizeRouterBase(raw: unknown): string {
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
 }
 
+// Dashboard tabs are query-driven (`/?tab=<name>`). Expose friendly path aliases
+// (e.g. `/mcp`, `/drive`) that redirect to the matching dashboard tab so links and
+// manual URLs land on the right place.
+const DASHBOARD_TAB_PATHS = [
+  "schedules",
+  "credentials",
+  "globalvariables",
+  "vectorstores",
+  "mcp",
+  "traces",
+  "analytics",
+  "dashboard",
+  "templates",
+  "teams",
+  "logs",
+  "drive",
+  "datatable",
+] as const;
+
+const dashboardTabRoutes = DASHBOARD_TAB_PATHS.map((tab) => ({
+  path: `/${tab}`,
+  redirect: { path: "/", query: { tab } },
+}));
+
 const router = createRouter({
   history: createWebHistory(sanitizeRouterBase(import.meta.env.BASE_URL)),
   routes: [
+    {
+      path: "/workflows",
+      redirect: { path: "/" },
+    },
+    {
+      path: "/chat",
+      redirect: { name: "chats" },
+    },
+    ...dashboardTabRoutes,
     {
       path: "/login",
       name: "login",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2849,6 +2849,13 @@ export const filesApi = {
     });
     return response.data as Blob;
   },
+
+  bulkDelete: async (fileIds: string[]): Promise<BulkFileOperationResult> => {
+    const response = await api.post<BulkFileOperationResult>("/files/delete/bulk", {
+      file_ids: fileIds,
+    });
+    return response.data;
+  },
 };
 
 // ---------- Data Tables ----------


### PR DESCRIPTION
## Summary

Four independent UX improvements:

1. **Drive tab — bulk delete.** The multi-select action bar now has a **Delete** button that removes every selected file (and its share links) after a confirmation. Backed by a new `POST /files/delete/bulk` endpoint returning the standard `{ succeeded, failed }` result; files the user does not own are reported as failed and left untouched.

2. **Execution log — skill file button reliability.** Skill-generated files were embedded only inside nested agent `tool_calls[].result._generated_files`, and JSON output mode dropped them entirely, so the download button could go missing. The agent node now aggregates all generated files into a top-level `_generated_files` array on its output (recursing sub-agent tool calls, deduped by download URL, preserved through JSON output mode). This makes the execution-log download button appear consistently and keeps `$agentLabel._generated_files` expressions resolvable.

3. **Canvas Execution Highlights — selectable text.** The highlights panel inherited `select-none` from the canvas root, so its content could not be selected or copied. Added `select-text` (plus `nopan`) to the panel so text is selectable.

4. **Tab path routing.** Added friendly path aliases that redirect to the matching dashboard tab: `/mcp`, `/drive`, `/traces`, `/templates`, `/teams`, `/logs`, `/schedules`, `/credentials`, `/globalvariables`, `/vectorstores`, `/analytics`, `/dashboard`, `/datatable`, plus `/workflows` -> `/` and `/chat` -> `/chats`.

## Tests

- New `backend/tests/test_agent_node_generated_files.py` covers the aggregation helper (tool call, nested sub-agent, dedupe, empty).
- Extended `backend/tests/test_files_bulk.py` with bulk-delete cases (all owned deleted; non-owned reported failed and not deleted).
- Backend: targeted suite `235 passed`; new files `13 passed`. Ruff format + check clean.
- Frontend: `bun run typecheck` and `bun run lint` clean (pre-existing unrelated warnings only).
- Docs: updated `drive-tab.md` bulk actions list.