### PR TITLE
Remove Star History chart from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,16 +718,6 @@ Commercial licensing, enterprise deployment help, and professional support are a
 
 [⭐ Star this repo](https://github.com/heymrun/heym/stargazers) · [🐛 Report a bug](https://github.com/heymrun/heym/issues) · [💡 Request a feature](https://github.com/heymrun/heym/discussions)
 
-## ⭐ Star History
-
-<a href="https://www.star-history.com/#heymrun/heym&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=heymrun/heym&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=heymrun/heym&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=heymrun/heym&type=Date" />
-  </picture>
-</a>
-
 ## Contributors
 
 <a href="https://github.com/heymrun/heym/graphs/contributors">


### PR DESCRIPTION
## What

Removes the `## Star History` section from the README, which embedded the star-history.com chart.

## Why

The star-history.com chart depends on GitHub's star history API, which has become unreliable (rate limiting and broken images). The chart often fails to render.

The `Star this repo` stargazers link is kept as the call to action, so there is no lost functionality and no external API dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)