### PR TITLE
Fix check.sh ruff import and flaky execution deep-link E2E

### DIFF
--- a/backend/alembic/versions/098_add_board_mapper.py
+++ b/backend/alembic/versions/098_add_board_mapper.py
@@ -8,8 +8,9 @@ Create Date: 2026-07-12
 from typing import Union
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
 
 revision: str = "098_add_board_mapper"
 down_revision: Union[str, None] = "097_add_boards"

--- a/frontend/e2e/execution-deep-link.spec.ts
+++ b/frontend/e2e/execution-deep-link.spec.ts
@@ -110,11 +110,31 @@ test("brings a past execution onto the canvas via /workflows/:id/:executionId", 
     await page.getByRole("button", { name: "History", exact: true }).click();
     await expect(page.getByRole("heading", { name: "All Execution History" })).toBeVisible();
     await page.keyboard.press("s");
-    await page
-      .getByPlaceholder("Search by workflow name, trigger, status...")
-      .fill(workflow.name);
-    await expect(page.locator("button").filter({ hasText: workflow.name }).first()).toBeVisible();
-    await page.getByRole("button", { name: "Bring to Canvas" }).click();
+    const allHistorySearch = page.getByPlaceholder(
+      "Search by workflow name, trigger, status...",
+    );
+    const filteredHistoryResponse = page.waitForResponse(
+      (candidate) => {
+        const url = new URL(candidate.url());
+        return (
+          candidate.request().method() === "GET" &&
+          url.pathname === "/api/workflows/history/all" &&
+          url.searchParams.get("search") === workflow.name
+        );
+      },
+      { timeout: 10_000 },
+    );
+    await allHistorySearch.fill(workflow.name);
+    await filteredHistoryResponse;
+    const matchingHistoryEntry = page.locator("button").filter({ hasText: workflow.name }).first();
+    await expect(matchingHistoryEntry).toBeVisible();
+    await matchingHistoryEntry.click();
+    const bringToCanvasFromAllHistory = page
+      .locator("div.space-y-3")
+      .filter({ hasText: workflow.name })
+      .getByRole("button", { name: "Bring to Canvas" });
+    await expect(bringToCanvasFromAllHistory).toBeVisible();
+    await bringToCanvasFromAllHistory.click();
     await expectExecutionPath(page, workflow.id, entryId);
     await expect(page.getByPlaceholder("Enter text...")).toHaveValue("deeplink payload");
 


### PR DESCRIPTION
## Summary
- Fix Ruff I001 import ordering in `098_add_board_mapper.py` so `./check.sh` passes.
- Stabilize `execution-deep-link.spec.ts` when other workflows leave entries in All Execution History: wait for the debounced search API response, select the matching history row, then click Bring to Canvas scoped to that detail panel.

## Test plan
- [x] `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh`
- [x] `SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./run_e2e.sh e2e/file-upload-trigger.spec.ts e2e/execution-deep-link.spec.ts`


Made with [Cursor](https://cursor.com)