### PR TITLE
Allow shared AI credentials in board configuration

### DIFF
--- a/backend/app/api/boards.py
+++ b/backend/app/api/boards.py
@@ -56,6 +56,7 @@ from app.models.board_schemas import (
     CommentCreateRequest,
 )
 from app.services import board_run_service
+from app.services.credential_access import get_accessible_credential
 from app.services.file_storage import (
     build_download_url,
     create_access_token,
@@ -225,10 +226,8 @@ def _card_response(card: BoardCard) -> BoardCardResponse:
 async def _validate_owned_credential(
     db: AsyncSession, credential_id: uuid.UUID, user: User
 ) -> None:
-    result = await db.execute(
-        select(Credential.id).where(Credential.id == credential_id, Credential.owner_id == user.id)
-    )
-    if result.scalar_one_or_none() is None:
+    credential = await get_accessible_credential(db, credential_id, user.id)
+    if credential is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Credential not found")
 
 

--- a/backend/tests/test_boards_api.py
+++ b/backend/tests/test_boards_api.py
@@ -89,6 +89,36 @@ class TestCreateBoard(unittest.IsolatedAsyncioTestCase):
         db.commit.assert_awaited()
 
 
+class TestBoardCredentialValidation(unittest.IsolatedAsyncioTestCase):
+    async def test_accepts_accessible_shared_credential(self):
+        db = AsyncMock()
+        user = _User()
+        credential_id = uuid.uuid4()
+
+        with patch(
+            "app.api.boards.get_accessible_credential",
+            AsyncMock(return_value=MagicMock()),
+        ) as get_credential:
+            await boards_api._validate_owned_credential(db, credential_id, user)
+
+        get_credential.assert_awaited_once_with(db, credential_id, user.id)
+
+    async def test_rejects_inaccessible_credential(self):
+        db = AsyncMock()
+        user = _User()
+        credential_id = uuid.uuid4()
+
+        with patch(
+            "app.api.boards.get_accessible_credential",
+            AsyncMock(return_value=None),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await boards_api._validate_owned_credential(db, credential_id, user)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Credential not found")
+
+
 class TestBoardOwnership(unittest.IsolatedAsyncioTestCase):
     async def test_get_board_404_for_missing_or_foreign_board(self):
         db = AsyncMock()


### PR DESCRIPTION
Use the shared credential access service when validating board mapper credentials so directly shared and team-shared credentials work during board creation and updates. Preserve the existing 400 response for inaccessible credentials and add regression coverage.