### PR TITLE
Restrict column settings to users with write access

### DIFF
--- a/frontend/src/components/Board/BoardColumnLane.vue
+++ b/frontend/src/components/Board/BoardColumnLane.vue
@@ -136,6 +136,7 @@ async function deleteCard(cardId: string): Promise<void> {
         {{ column.workflows.length }}
       </span>
       <button
+        v-if="boardStore.canWrite"
         class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
         :class="column.workflows.length ? '' : 'ml-auto'"
         :aria-label="`Configure ${column.name}`"


### PR DESCRIPTION
Hide the column settings button unless the current user has write access to the board. This prevents read-only users from attempting unauthorized column updates while preserving settings access for users with write permission.