### PR TITLE
Redirect /board to the dashboard board tab

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -29,6 +29,7 @@ const DASHBOARD_TAB_PATHS = [
   "teams",
   "logs",
   "drive",
+  "board",
   "datatable",
 ] as const;
 


### PR DESCRIPTION
Add `board` to the dashboard tab route aliases so `/board` redirects to `/?tab=board`, consistent with `/drive` and `/mcp`.