### PR TITLE
Add failed-card error history indicator

### DIFF
--- a/frontend/src/components/Board/BoardCanvas.vue
+++ b/frontend/src/components/Board/BoardCanvas.vue
@@ -9,6 +9,7 @@ import BoardColumnLane from "./BoardColumnLane.vue";
 const emit = defineEmits<{
   (e: "openCard", cardId: string): void;
   (e: "openSettings", columnId: string): void;
+  (e: "openErrorHistory", cardId: string): void;
 }>();
 
 const boardStore = useBoardStore();
@@ -37,6 +38,7 @@ async function addColumn(): Promise<void> {
       :index="index"
       @open-card="emit('openCard', $event)"
       @open-settings="emit('openSettings', $event)"
+      @open-error-history="emit('openErrorHistory', $event)"
     />
     <div class="flex w-64 shrink-0 flex-col">
       <button

--- a/frontend/src/components/Board/BoardCardItem.vue
+++ b/frontend/src/components/Board/BoardCardItem.vue
@@ -6,6 +6,7 @@ import {
   Copy,
   Paperclip,
   XCircle,
+  ExternalLink,
   PauseCircle,
   Trash2,
 } from "lucide-vue-next";
@@ -24,6 +25,7 @@ const emit = defineEmits<{
   (e: "open", cardId: string): void;
   (e: "clone", cardId: string): void;
   (e: "delete", cardId: string): void;
+  (e: "openErrorHistory", cardId: string): void;
 }>();
 const editingTitle = ref(false);
 const editedTitle = ref(props.card.title);
@@ -199,6 +201,17 @@ function onDragStart(event: DragEvent): void {
           />
         </div>
         <div class="hidden items-center gap-0.5 group-hover:flex">
+          <button
+            v-if="card.run_status === 'failed'"
+            class="flex items-center justify-center gap-0.5 rounded p-0.5 text-red-500 underline decoration-dotted transition-colors hover:bg-red-500/10 hover:text-red-400"
+            aria-label="View error history"
+            title="View error history"
+            :data-testid="`board-card-error-history-${card.id}`"
+            @click.stop="emit('openErrorHistory', card.id)"
+          >
+            <XCircle class="h-3.5 w-3.5" />
+            <ExternalLink class="h-3 w-3" />
+          </button>
           <button
             class="flex items-center justify-center rounded p-0.5 text-muted-foreground hover:text-primary"
             aria-label="Clone card"

--- a/frontend/src/components/Board/BoardColumnLane.vue
+++ b/frontend/src/components/Board/BoardColumnLane.vue
@@ -12,6 +12,7 @@ const props = defineProps<{ column: BoardColumn; index: number }>();
 const emit = defineEmits<{
   (e: "openCard", cardId: string): void;
   (e: "openSettings", columnId: string): void;
+  (e: "openErrorHistory", cardId: string): void;
 }>();
 
 const boardStore = useBoardStore();
@@ -161,6 +162,7 @@ async function deleteCard(cardId: string): Promise<void> {
           @open="emit('openCard', $event)"
           @clone="boardStore.cloneCard"
           @delete="deleteCard"
+          @open-error-history="emit('openErrorHistory', $event)"
         />
       </div>
     </div>

--- a/frontend/src/components/Board/BoardPanel.vue
+++ b/frontend/src/components/Board/BoardPanel.vue
@@ -3,10 +3,13 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { Plus, Settings, SquareKanban, Trash2 } from "lucide-vue-next";
 
+import ExecutionHistoryAllDialog from "@/components/Panels/ExecutionHistoryAllDialog.vue";
 import Button from "@/components/ui/Button.vue";
 import SearchableSelect from "@/components/ui/SearchableSelect.vue";
-import { useBoardStore } from "@/stores/board";
 import { onDismissOverlays } from "@/composables/useOverlayBackHandler";
+import { useToast } from "@/composables/useToast";
+import { boardApi } from "@/services/api";
+import { useBoardStore } from "@/stores/board";
 import BoardCanvas from "./BoardCanvas.vue";
 import BoardCardDetailDialog from "./BoardCardDetailDialog.vue";
 import BoardColumnSettingsDialog from "./BoardColumnSettingsDialog.vue";
@@ -16,10 +19,13 @@ import BoardEditDialog from "./BoardEditDialog.vue";
 const boardStore = useBoardStore();
 const route = useRoute();
 const router = useRouter();
+const { showToast } = useToast();
 const createOpen = ref(false);
 const editOpen = ref(false);
 const openCardId = ref<string | null>(null);
 const settingsColumnId = ref<string | null>(null);
+const historyOpen = ref(false);
+const historyWorkflowId = ref<string | undefined>(undefined);
 
 async function openBoardWithUrl(boardId: string): Promise<void> {
   await boardStore.openBoard(boardId);
@@ -39,6 +45,8 @@ onMounted(async () => {
     editOpen.value = false;
     openCardId.value = null;
     settingsColumnId.value = null;
+    historyOpen.value = false;
+    historyWorkflowId.value = undefined;
   });
   await boardStore.fetchBoards();
   const urlBoardId = typeof route.query.board === "string" ? route.query.board : null;
@@ -78,6 +86,34 @@ async function removeActiveBoard(): Promise<void> {
 
 async function onBoardCreated(boardId: string): Promise<void> {
   await openBoardWithUrl(boardId);
+}
+
+async function openErrorHistory(cardId: string): Promise<void> {
+  const boardId = boardStore.activeBoard?.id;
+  if (!boardId) return;
+
+  try {
+    const detail = await boardApi.getCard(boardId, cardId);
+    const failedRun = [...detail.runs].reverse().find(
+      (run) => run.status === "failed" && run.workflow_id !== null,
+    );
+    if (!failedRun?.workflow_id) {
+      showToast("No workflow error history is available for this card", "error");
+      return;
+    }
+
+    openCardId.value = null;
+    historyOpen.value = false;
+    historyWorkflowId.value = failedRun.workflow_id;
+    historyOpen.value = true;
+  } catch {
+    showToast("Failed to load card error history", "error");
+  }
+}
+
+function closeErrorHistory(): void {
+  historyOpen.value = false;
+  historyWorkflowId.value = undefined;
 }
 </script>
 
@@ -173,6 +209,7 @@ async function onBoardCreated(boardId: string): Promise<void> {
       v-else-if="boardStore.activeBoard"
       @open-card="openCardId = $event"
       @open-settings="settingsColumnId = $event"
+      @open-error-history="openErrorHistory"
     />
 
     <BoardCreateDialog
@@ -193,6 +230,12 @@ async function onBoardCreated(boardId: string): Promise<void> {
       :open="settingsColumnId !== null"
       :column-id="settingsColumnId"
       @close="settingsColumnId = null"
+    />
+    <ExecutionHistoryAllDialog
+      :open="historyOpen"
+      :workflow-id="historyWorkflowId"
+      initial-status="error"
+      @close="closeErrorHistory"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- show a red error-history action when hovering failed board cards
- propagate the action through the board lane and canvas
- resolve the latest failed workflow run and open its filtered execution history
- close existing card details and report unavailable history with a toast

## Validation
- Not run: Bun is unavailable in the environment (`bun: command not found`).