### PR TITLE
Add empty-column action to kanban boards

### DIFF
--- a/backend/app/api/boards.py
+++ b/backend/app/api/boards.py
@@ -11,7 +11,7 @@ from fastapi import (
     UploadFile,
     status,
 )
-from sqlalchemy import func, or_, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user
@@ -541,6 +541,20 @@ async def delete_column(
             detail="Move or delete the cards in this column first",
         )
     await db.delete(column)
+    await db.commit()
+
+
+@router.delete("/{board_id}/columns/{column_id}/cards", status_code=status.HTTP_204_NO_CONTENT)
+async def empty_column(
+    board_id: uuid.UUID,
+    column_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """Delete every card in a board column."""
+    board, _ = await _get_board_for_user(db, board_id, current_user, write=True)
+    column = await _get_board_column(db, board, column_id)
+    await db.execute(delete(BoardCard).where(BoardCard.column_id == column.id))
     await db.commit()
 
 

--- a/backend/tests/test_boards_api.py
+++ b/backend/tests/test_boards_api.py
@@ -189,6 +189,31 @@ class TestColumnEndpoints(unittest.IsolatedAsyncioTestCase):
             )
         self.assertEqual(ctx.exception.status_code, 409)
 
+    async def test_empty_column_deletes_all_cards_and_commits(self):
+        user = _User()
+        board = self._board(user)
+        column = MagicMock()
+        column.id = uuid.uuid4()
+        column.board_id = board.id
+
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with(scalar=board),
+                _result_with(scalar=column),
+                _result_with(),
+            ]
+        )
+
+        await boards_api.empty_column(
+            board_id=board.id, column_id=column.id, db=db, current_user=user
+        )
+
+        delete_statement = db.execute.await_args_list[2].args[0]
+        self.assertEqual(delete_statement.table.name, "board_cards")
+        self.assertIn("board_cards.column_id", str(delete_statement.whereclause))
+        db.commit.assert_awaited_once()
+
 
 class TestCardEndpoints(unittest.IsolatedAsyncioTestCase):
     async def test_create_card_defaults_to_first_column_bottom(self):

--- a/frontend/src/components/Board/BoardColumnLane.vue
+++ b/frontend/src/components/Board/BoardColumnLane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { GripVertical, Plus, Settings2, Workflow } from "lucide-vue-next";
+import { GripVertical, Plus, Settings2, Trash2, Workflow } from "lucide-vue-next";
 
 import type { BoardCard, BoardColumn } from "@/types/board";
 import { useBoardStore } from "@/stores/board";
@@ -97,6 +97,11 @@ async function deleteCard(cardId: string): Promise<void> {
   if (!window.confirm(`Delete card "${card?.title ?? ""}"?`)) return;
   await boardStore.deleteCard(cardId);
 }
+
+async function emptyColumn(): Promise<void> {
+  if (!window.confirm(`Delete all cards in "${props.column.name}" column?`)) return;
+  await boardStore.emptyColumn(props.column.id);
+}
 </script>
 
 <template>
@@ -140,6 +145,14 @@ async function deleteCard(cardId: string): Promise<void> {
         v-if="boardStore.canWrite"
         class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
         :class="column.workflows.length ? '' : 'ml-auto'"
+        :aria-label="`Empty ${column.name}`"
+        @click="emptyColumn"
+      >
+        <Trash2 class="h-4 w-4" />
+      </button>
+      <button
+        v-if="boardStore.canWrite"
+        class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
         :aria-label="`Configure ${column.name}`"
         @click="emit('openSettings', column.id)"
       >

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1513,6 +1513,9 @@ export const boardApi = {
   deleteColumn: async (boardId: string, columnId: string): Promise<void> => {
     await api.delete(`/boards/${boardId}/columns/${columnId}`);
   },
+  emptyColumn: async (boardId: string, columnId: string): Promise<void> => {
+    await api.delete(`/boards/${boardId}/columns/${columnId}/cards`);
+  },
   createCard: async (boardId: string, payload: CardCreatePayload): Promise<BoardCard> => {
     const response = await api.post<BoardCard>(`/boards/${boardId}/cards`, payload);
     return response.data;

--- a/frontend/src/stores/board.ts
+++ b/frontend/src/stores/board.ts
@@ -173,6 +173,12 @@ export const useBoardStore = defineStore("board", () => {
     await refreshActiveBoard();
   }
 
+  async function emptyColumn(columnId: string): Promise<void> {
+    if (!activeBoard.value) return;
+    await boardApi.emptyColumn(activeBoard.value.id, columnId);
+    await refreshActiveBoard();
+  }
+
   async function cloneCard(cardId: string): Promise<void> {
     const board = activeBoard.value;
     if (!board) return;
@@ -207,6 +213,7 @@ export const useBoardStore = defineStore("board", () => {
     moveCard,
     runFollowUp,
     deleteCard,
+    emptyColumn,
     cloneCard,
     stopPolling,
   };


### PR DESCRIPTION
Add a write-protected endpoint for deleting every card in a board column. Expose the action through the frontend API and board store, then add a confirmed Trash2 action to writable column headers. Refresh the active board after successful deletion and cover the backend operation with a focused test.