### PR TITLE
Fix shared board credential validation

### DIFF
--- a/backend/app/api/boards.py
+++ b/backend/app/api/boards.py
@@ -223,7 +223,7 @@ def _card_response(card: BoardCard) -> BoardCardResponse:
     )
 
 
-async def _validate_owned_credential(
+async def _validate_accessible_credential(
     db: AsyncSession, credential_id: uuid.UUID, user: User
 ) -> None:
     credential = await get_accessible_credential(db, credential_id, user.id)
@@ -323,7 +323,7 @@ async def create_board(
     current_user: User = Depends(get_current_user),
 ) -> BoardSummaryResponse:
     if request.mapper_credential_id is not None:
-        await _validate_owned_credential(db, request.mapper_credential_id, current_user)
+        await _validate_accessible_credential(db, request.mapper_credential_id, current_user)
     board = Board(
         owner_id=current_user.id,
         name=request.name,
@@ -405,7 +405,7 @@ async def update_board(
         board.mapper_model = request.mapper_model
     if "mapper_credential_id" in fields_set:
         if request.mapper_credential_id is not None:
-            await _validate_owned_credential(db, request.mapper_credential_id, current_user)
+            await _validate_accessible_credential(db, request.mapper_credential_id, current_user)
         board.mapper_credential_id = request.mapper_credential_id
     await db.commit()
     await db.refresh(board)

--- a/backend/tests/test_boards_api.py
+++ b/backend/tests/test_boards_api.py
@@ -90,7 +90,7 @@ class TestCreateBoard(unittest.IsolatedAsyncioTestCase):
 
 
 class TestBoardCredentialValidation(unittest.IsolatedAsyncioTestCase):
-    async def test_accepts_accessible_shared_credential(self):
+    async def test_accepts_accessible_credential(self):
         db = AsyncMock()
         user = _User()
         credential_id = uuid.uuid4()
@@ -99,7 +99,7 @@ class TestBoardCredentialValidation(unittest.IsolatedAsyncioTestCase):
             "app.api.boards.get_accessible_credential",
             AsyncMock(return_value=MagicMock()),
         ) as get_credential:
-            await boards_api._validate_owned_credential(db, credential_id, user)
+            await boards_api._validate_accessible_credential(db, credential_id, user)
 
         get_credential.assert_awaited_once_with(db, credential_id, user.id)
 
@@ -113,7 +113,7 @@ class TestBoardCredentialValidation(unittest.IsolatedAsyncioTestCase):
             AsyncMock(return_value=None),
         ):
             with self.assertRaises(HTTPException) as ctx:
-                await boards_api._validate_owned_credential(db, credential_id, user)
+                await boards_api._validate_accessible_credential(db, credential_id, user)
 
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertEqual(ctx.exception.detail, "Credential not found")

--- a/backend/tests/test_credential_access.py
+++ b/backend/tests/test_credential_access.py
@@ -13,6 +13,23 @@ def make_result(value: object) -> Mock:
 
 
 class CredentialAccessTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_owned_credential(self) -> None:
+        user_id = uuid.uuid4()
+        credential = Credential(
+            id=uuid.uuid4(),
+            owner_id=user_id,
+            name="Owned OpenAI",
+            type=CredentialType.openai,
+            encrypted_config="encrypted",
+        )
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=make_result(credential))
+
+        result = await get_accessible_credential(db, credential.id, user_id)
+
+        self.assertIs(result, credential)
+        db.execute.assert_awaited_once()
+
     async def test_returns_directly_shared_credential(self) -> None:
         user_id = uuid.uuid4()
         credential = Credential(
@@ -56,4 +73,13 @@ class CredentialAccessTests(unittest.IsolatedAsyncioTestCase):
         result = await get_accessible_credential(db, credential.id, user_id)
 
         self.assertIs(result, credential)
+        self.assertEqual(db.execute.await_count, 3)
+
+    async def test_returns_none_for_inaccessible_credential(self) -> None:
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=make_result(None))
+
+        result = await get_accessible_credential(db, uuid.uuid4(), uuid.uuid4())
+
+        self.assertIsNone(result)
         self.assertEqual(db.execute.await_count, 3)


### PR DESCRIPTION
Use get_accessible_credential when validating board mapper credentials so owned, directly shared, and team-shared credentials are accepted. Add regression tests covering every credential access pattern and inaccessible credentials.