### PR TITLE
Fix UI layout issue in Activity section - prevent text overflow for long content

### DIFF
--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -567,9 +567,19 @@ async function copyRun(run: CardRun): Promise<void> {
 </template>
 
 <style scoped>
+.board-activity-md {
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+}
+
 .board-activity-md :deep(p) {
   margin: 0 0 0.4rem;
   white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .board-activity-md :deep(p:last-child) {
@@ -582,6 +592,9 @@ async function copyRun(run: CardRun): Promise<void> {
   margin: 0.4rem 0 0.25rem;
   font-size: 0.875rem;
   font-weight: 600;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .board-activity-md :deep(ul),
@@ -600,6 +613,9 @@ async function copyRun(run: CardRun): Promise<void> {
 
 .board-activity-md :deep(li) {
   margin: 0.1rem 0;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .board-activity-md :deep(li::marker) {
@@ -614,6 +630,10 @@ async function copyRun(run: CardRun): Promise<void> {
 .board-activity-md :deep(a) {
   color: hsl(var(--primary));
   text-decoration: underline;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
 }
 
 .board-activity-md :deep(code) {
@@ -621,6 +641,9 @@ async function copyRun(run: CardRun): Promise<void> {
   background: hsl(var(--muted));
   padding: 0.05rem 0.25rem;
   font-size: 0.78rem;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .board-activity-md :deep(pre) {
@@ -628,10 +651,15 @@ async function copyRun(run: CardRun): Promise<void> {
   border-radius: 0.375rem;
   background: hsl(var(--muted));
   padding: 0.5rem;
+  max-width: 100%;
 }
 
 .board-activity-md :deep(pre code) {
   background: transparent;
   padding: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 </style>


### PR DESCRIPTION
## Problem
The Activity section in board cards had a UI layout issue where long content (like links) caused horizontal overflow, breaking the card layout and making content difficult to read.

## Solution
Added comprehensive CSS word-wrapping properties to the `.board-activity-md` class and all its nested elements to ensure proper text wrapping:

### Changes Made:
- Added `max-width: 100%` to the main `.board-activity-md` container
- Applied `overflow-wrap: break-word`, `word-wrap: break-word`, and `word-break: break-word` to:
  - All paragraph elements (`p`)
  - All heading elements (`h1`, `h2`, `h3`)
  - All list items (`li`)
  - All anchor/link elements (`a`)
  - All code elements (`code`)
  - All preformatted text blocks (`pre` and `pre code`)

### Benefits:
✅ **Card height remains unchanged** - No impact on the fixed height layout
✅ **Markdown rendering preserved** - All markdown formatting continues to work correctly
✅ **Content wraps vertically** - Long text and links now wrap to the next line instead of overflowing horizontally
✅ **Width overflow prevented** - Content stays within the container bounds
✅ **Improved readability** - Users can now read long URLs and content without horizontal scrolling

### Testing:
The fix handles various content types:
- Long URLs/links
- Code blocks
- Lists with long items
- Headings with long text
- Regular paragraph text

All content now properly wraps within the fixed-height Activity section while maintaining the existing scroll functionality.