### PR TITLE
Pull remote changes before pushing Codex branch

### DIFF
--- a/backend/app/services/codex_runner_service.py
+++ b/backend/app/services/codex_runner_service.py
@@ -650,11 +650,32 @@ class CodexRunnerService:
 
     def _push_branch(self, workspace: Path, request: CodexRunRequest, branch: str) -> None:
         remote_url = self._clone_url_with_token(request.repository_url, request.github_config)
+        sensitive_values = [request.github_config.get("api_key", "")]
         self._run_command(["git", "remote", "set-url", "origin", remote_url], cwd=workspace)
+        remote_branch = self._git_output(
+            ["git", "ls-remote", "--heads", "origin", f"refs/heads/{branch}"], workspace
+        )
+        if remote_branch.strip():
+            try:
+                self._run_command(
+                    ["git", "pull", "--rebase", "origin", branch],
+                    cwd=workspace,
+                    sensitive_values=sensitive_values,
+                )
+            except ValueError as exc:
+                # A failed rebase leaves the workspace in an unusable state. Restore the local
+                # commit while surfacing an actionable conflict error instead of attempting push.
+                try:
+                    self._run_command(["git", "rebase", "--abort"], cwd=workspace)
+                except ValueError:
+                    pass
+                raise ValueError(
+                    f"Could not synchronize branch '{branch}' with origin before push: {exc}"
+                ) from exc
         self._run_command(
             ["git", "push", "-u", "origin", branch],
             cwd=workspace,
-            sensitive_values=[request.github_config.get("api_key", "")],
+            sensitive_values=sensitive_values,
         )
 
     def _current_branch(self, workspace: Path) -> str:

--- a/backend/tests/test_codex_publish_modes.py
+++ b/backend/tests/test_codex_publish_modes.py
@@ -104,6 +104,58 @@ class TestCommitMessage(unittest.TestCase):
         self.assertIn("ran docker compose config", body)
 
 
+class TestPushBranch(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CodexRunnerService()
+        self.runner._run_command = MagicMock()  # type: ignore[method-assign]
+        self.workspace = Path("/tmp/ws")
+        self.request = _request("commit_push")
+
+    def test_existing_remote_branch_is_rebased_before_push(self) -> None:
+        self.runner._git_output = MagicMock(  # type: ignore[method-assign]
+            return_value="abc123\trefs/heads/codex/run\n"
+        )
+
+        self.runner._push_branch(self.workspace, self.request, "codex/run")
+
+        commands = [call.args[0] for call in self.runner._run_command.call_args_list]
+        self.assertEqual(commands[1], ["git", "pull", "--rebase", "origin", "codex/run"])
+        self.assertEqual(commands[2], ["git", "push", "-u", "origin", "codex/run"])
+
+    def test_new_remote_branch_skips_pull(self) -> None:
+        self.runner._git_output = MagicMock(return_value="")  # type: ignore[method-assign]
+
+        self.runner._push_branch(self.workspace, self.request, "codex/run")
+
+        commands = [call.args[0] for call in self.runner._run_command.call_args_list]
+        self.assertEqual(
+            commands,
+            [
+                [
+                    "git",
+                    "remote",
+                    "set-url",
+                    "origin",
+                    "https://x-access-token:ghp@github.com/acme/app",
+                ],
+                ["git", "push", "-u", "origin", "codex/run"],
+            ],
+        )
+
+    def test_pull_conflict_aborts_rebase_and_does_not_push(self) -> None:
+        self.runner._git_output = MagicMock(  # type: ignore[method-assign]
+            return_value="abc123\trefs/heads/codex/run\n"
+        )
+        self.runner._run_command.side_effect = [None, ValueError("CONFLICT in app.py"), None]
+
+        with self.assertRaisesRegex(ValueError, "Could not synchronize branch"):
+            self.runner._push_branch(self.workspace, self.request, "codex/run")
+
+        commands = [call.args[0] for call in self.runner._run_command.call_args_list]
+        self.assertEqual(commands[-1], ["git", "rebase", "--abort"])
+        self.assertNotIn(["git", "push", "-u", "origin", "codex/run"], commands)
+
+
 class TestPublishDispatch(unittest.TestCase):
     def setUp(self) -> None:
         self.runner = CodexRunnerService()


### PR DESCRIPTION
Synchronize existing remote branches with `git pull --rebase` before pushing Codex changes. Abort conflicted rebases and surface an actionable error while preserving normal behavior for new branches.