### PR TITLE
Add Base64 expression encode and decode functions

### DIFF
--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -122,7 +122,7 @@ A workflow consists of nodes (operations) and edges (connections between nodes).
 - **⛔ ABSOLUTE BAN:** The following names (and all their case variations, including uppercase/lowercase/mixed-case) are STRICTLY FORBIDDEN as either node names or parameter names:
   - **"result" and "results"** (e.g., `result`, `results`, `Result`, `Results`, `RESULT`, `RESULTS`). These cause critical system conflicts and must never be used anywhere.
   - System fields: `headers`, `query`, `value`, `list`, `array`, `vars`, `items`, `name`, `type`, `input`, `now`, `date`, `workflowName`, `workflowDescription`, `workflowUrl`, `workflowPath`, `executionId`
-  - String methods: `length`, `orEmpty`, `toString`, `toUpperCase`, `toLowerCase`, `substring`, `indexOf`, `contains`, `startsWith`, `endsWith`, `replace`, `replaceAll`, `regexReplace`, `hash`
+  - String methods: `length`, `orEmpty`, `toString`, `toUpperCase`, `toLowerCase`, `substring`, `indexOf`, `contains`, `startsWith`, `endsWith`, `replace`, `replaceAll`, `regexReplace`, `hash`, `base64Encode`, `base64Decode`
   - Array methods: `first`, `last`, `random`, `reverse`, `distinct`, `notNull`, `filter`, `map`, `sort`, `join`
   - HTTP fields: `status`, `body`
   - Execution/Workflow fields: `outputs`, `result`, `status`, `workflow_id` (and when `executeDoNotWait: true`, specifically `status`, `workflow_id`)
@@ -1532,7 +1532,7 @@ Notes:
 **⚠️ RESERVED VARIABLE NAMES**: The following names are RESERVED and CANNOT be used as `variableName`:
 - **⛔ ABSOLUTE BAN**: `result` and `results` are reserved and CANNOT be used as variable names!
 - System fields: `headers`, `query`, `value`, `list`, `array`, `vars`, `items`, `name`, `type`, `length`, `input`, `now`, `date`, `workflowName`, `workflowDescription`, `workflowUrl`, `workflowPath`, `executionId`
-- String methods: `orEmpty`, `toString`, `toUpperCase`, `toLowerCase`, `substring`, `indexOf`, `contains`, `startswith`, `endswith`, `replace`, `replaceAll`, `regexReplace`, `hash`
+- String methods: `orEmpty`, `toString`, `toUpperCase`, `toLowerCase`, `substring`, `indexOf`, `contains`, `startswith`, `endswith`, `replace`, `replaceAll`, `regexReplace`, `hash`, `base64Encode`, `base64Decode`
 - Array methods: `first`, `last`, `random`, `reverse`, `distinct`, `notNull`, `join`
 - HTTP response fields: `status`, `body`
 - Execute node fields: `outputs`, `result`, `status`, `workflow_id`
@@ -3697,6 +3697,8 @@ Create objects/dictionaries directly using curly brace syntax with any string ke
 - `join(separator, list)` - Join list
 - `replace(text, old, new)` - Replace text
 - `regexReplace(text, pattern, replacement)` - Replace with regex pattern
+- `base64Encode(text)` - Encode UTF-8 text as standard Base64
+- `base64Decode(text)` - Decode standard Base64 as UTF-8 text
 
 ### String Methods (on string values)
 - `.orEmpty()` - Return the string value, or `""` when the value is null/missing
@@ -3713,6 +3715,8 @@ Create objects/dictionaries directly using curly brace syntax with any string ke
 - `.replaceAll(old, new)` - Replace all occurrences
 - `.regexReplace(pattern, replacement)` - Replace with regex pattern
 - `.hash()` - MD5 hash of the string
+- `.base64Encode()` - Encode UTF-8 text as standard Base64
+- `.base64Decode()` - Decode standard Base64 as UTF-8 text
 - `.urlEncode()` - URL encode the string
 - `.urlDecode()` - URL decode the string
 
@@ -3834,7 +3838,7 @@ For boolean values, use them directly without `== true`:
 **For complex iteration logic, use the `loop` node!**
 
 **If a function is NOT in the documentation above, it DOES NOT EXIST!**
-Use ONLY: `str()`, `int()`, `float()`, `bool()`, `list()`, `dict(key=value)`, `len()`, `abs()`, `min()`, `max()`, `round()`, `sum()`, `sorted()`, `randomInt()`, `range()`, `array()`, `notNull()`, `upper()`, `lower()`, `strip()`, `capitalize()`, `title()`, `split()`, `join()`, `replace()`, `regexReplace()`, `hash()`, and the documented string/array/object methods.
+Use ONLY: `str()`, `int()`, `float()`, `bool()`, `list()`, `dict(key=value)`, `len()`, `abs()`, `min()`, `max()`, `round()`, `sum()`, `sorted()`, `randomInt()`, `range()`, `array()`, `notNull()`, `upper()`, `lower()`, `strip()`, `capitalize()`, `title()`, `split()`, `join()`, `replace()`, `regexReplace()`, `hash()`, `base64Encode()`, `base64Decode()`, and the documented string/array/object methods.
 
 ### 35. s3 (Amazon S3 Operations)
 - **Type**: `s3`

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -1,5 +1,7 @@
 import ast
 import asyncio
+import base64
+import binascii
 import copy
 import gc
 import hashlib
@@ -194,6 +196,24 @@ def _build_agent_execution_log_output(agent_result: dict) -> dict:
 
 class ExpressionFunctionError(ValueError):
     """Raised by expression functions to stop workflow execution."""
+
+
+def _base64_encode_text(value: object) -> str:
+    if not isinstance(value, str):
+        raise ExpressionFunctionError("$base64Encode(text) requires a string")
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+
+def _base64_decode_text(value: object) -> str:
+    if not isinstance(value, str):
+        raise ExpressionFunctionError("$base64Decode(text) requires a string")
+    try:
+        decoded = base64.b64decode(value.encode("ascii"), validate=True)
+        return decoded.decode("utf-8")
+    except (binascii.Error, UnicodeError) as exc:
+        raise ExpressionFunctionError(
+            "$base64Decode(text) requires valid Base64-encoded UTF-8 text"
+        ) from exc
 
 
 class NodeTraceableExecutionError(ValueError):
@@ -1150,6 +1170,18 @@ class DotStr(str):
 
     def hash(self) -> "DotStr":
         return DotStr(hashlib.md5(self.encode("utf-8")).hexdigest())
+
+    def base64Encode(self) -> "DotStr":  # noqa: N802
+        return DotStr(_base64_encode_text(self))
+
+    def base64_encode(self) -> "DotStr":
+        return self.base64Encode()
+
+    def base64Decode(self) -> "DotStr":  # noqa: N802
+        return DotStr(_base64_decode_text(self))
+
+    def base64_decode(self) -> "DotStr":
+        return self.base64Decode()
 
     def urlEncode(self) -> "DotStr":  # noqa: N802
         return DotStr(quote(self, safe=""))
@@ -5766,6 +5798,8 @@ class WorkflowExecutor:
             "strip": lambda s: s.strip() if isinstance(s, str) else s,
             "capitalize": lambda s: s.capitalize() if isinstance(s, str) else s,
             "title": lambda s: s.title() if isinstance(s, str) else s,
+            "base64Encode": lambda s: DotStr(_base64_encode_text(s)),
+            "base64Decode": lambda s: DotStr(_base64_decode_text(s)),
             "split": lambda s, sep=None: (
                 DotList(list(s) if sep == "" else s.split(sep)) if isinstance(s, str) else s
             ),
@@ -6021,6 +6055,8 @@ class WorkflowExecutor:
                     "notNull": lambda lst: (
                         DotList([x for x in lst if x is not None]) if isinstance(lst, list) else lst
                     ),
+                    "base64Encode": lambda value: DotStr(_base64_encode_text(value)),
+                    "base64Decode": lambda value: DotStr(_base64_decode_text(value)),
                 }
                 if func_name in functions:
                     args = []
@@ -6045,6 +6081,8 @@ class WorkflowExecutor:
                 "capitalize": lambda s: s.capitalize(),
                 "title": lambda s: s.title(),
                 "length": lambda s: len(s),
+                "base64Encode": _base64_encode_text,
+                "base64Decode": _base64_decode_text,
                 "urlEncode": lambda s: quote(s, safe=""),
                 "urlDecode": lambda s: unquote(s),
                 "escape": lambda s: json.dumps(s),

--- a/backend/tests/test_expression_evaluator_service.py
+++ b/backend/tests/test_expression_evaluator_service.py
@@ -1106,6 +1106,62 @@ class TestExpressionEvaluatorServiceEvaluate(unittest.TestCase):
         response = self._service().evaluate("$data.text.upper()", {"data": {"text": "hello"}})
         self.assertEqual(response.result, "HELLO")
 
+    def test_base64_functions_encode_and_decode_ascii(self) -> None:
+        encoded = self._service().evaluate('$base64Encode("hello")', {})
+        decoded = self._service().evaluate('$base64Decode("aGVsbG8=")', {})
+
+        self.assertEqual(encoded.result, "aGVsbG8=")
+        self.assertEqual(decoded.result, "hello")
+        self.assertIsNone(encoded.error)
+        self.assertIsNone(decoded.error)
+
+    def test_base64_functions_support_utf8(self) -> None:
+        context = {
+            "data": {
+                "text": "Héym 🌍",
+                "encoded": "SMOpeW0g8J+MjQ==",
+            }
+        }
+
+        encoded = self._service().evaluate("$base64Encode($data.text)", context)
+        decoded = self._service().evaluate("$base64Decode($data.encoded)", context)
+
+        self.assertEqual(encoded.result, "SMOpeW0g8J+MjQ==")
+        self.assertEqual(decoded.result, "Héym 🌍")
+        self.assertIsNone(encoded.error)
+        self.assertIsNone(decoded.error)
+
+    def test_base64_functions_handle_empty_strings(self) -> None:
+        encoded = self._service().evaluate('$base64Encode("")', {})
+        decoded = self._service().evaluate('$base64Decode("")', {})
+
+        self.assertEqual(encoded.result, "")
+        self.assertEqual(decoded.result, "")
+        self.assertIsNone(encoded.error)
+        self.assertIsNone(decoded.error)
+
+    def test_base64_string_methods_round_trip_embedded_null(self) -> None:
+        response = self._service().evaluate(
+            "$data.text.base64Encode().base64Decode()",
+            {"data": {"text": "\x00binaryÿ"}},
+        )
+
+        self.assertEqual(response.result, "\x00binaryÿ")
+        self.assertIsNone(response.error)
+
+    def test_base64_decode_rejects_invalid_input(self) -> None:
+        response = self._service().evaluate('$base64Decode("not-base64!")', {})
+
+        self.assertIsNone(response.result)
+        self.assertIn("valid Base64-encoded UTF-8 text", response.error or "")
+
+    def test_base64_functions_require_string_input(self) -> None:
+        encoded = self._service().evaluate("$base64Encode(123)", {})
+        decoded = self._service().evaluate("$base64Decode(123)", {})
+
+        self.assertIn("requires a string", encoded.error or "")
+        self.assertIn("requires a string", decoded.error or "")
+
     def test_string_method_or_empty_preserves_string(self) -> None:
         response = self._service().evaluate("$data.text.orEmpty()", {"data": {"text": "hello"}})
         self.assertEqual(response.result, "hello")

--- a/frontend/src/composables/useExpressionCompletion.ts
+++ b/frontend/src/composables/useExpressionCompletion.ts
@@ -110,6 +110,8 @@ const METHOD_RETURN_TYPES: Record<string, PropertyType> = {
   strip: "string",
   capitalize: "string",
   title: "string",
+  base64Encode: "string",
+  base64Decode: "string",
   charAt: "string",
   replace: "string",
   replaceAll: "string",

--- a/frontend/src/docs/content/reference/expression-dsl.md
+++ b/frontend/src/docs/content/reference/expression-dsl.md
@@ -213,6 +213,8 @@ Create objects/dictionaries using curly brace syntax with any string keys:
 - `join(separator, list)` - Join list
 - `replace(text, old, new)` - Replace text
 - `regexReplace(text, pattern, replacement)` - Replace with regex pattern
+- `base64Encode(text)` - Encode UTF-8 text as standard Base64
+- `base64Decode(text)` - Decode standard Base64 into UTF-8 text
 
 ## String Methods (on string values)
 - `.orEmpty()` - Return the string value, or `""` when the value is null/missing
@@ -229,6 +231,8 @@ Create objects/dictionaries using curly brace syntax with any string keys:
 - `.replaceAll(old, new)` - Replace all occurrences
 - `.regexReplace(pattern, replacement)` - Replace with regex pattern
 - `.hash()` - MD5 hash of the string
+- `.base64Encode()` - Encode UTF-8 text as standard Base64
+- `.base64Decode()` - Decode standard Base64 into UTF-8 text
 - `.urlEncode()` - URL encode string
 - `.urlDecode()` - URL decode string
 - `.escape()` - JSON escape string (convert special characters to JSON format)
@@ -244,6 +248,8 @@ Create objects/dictionaries using curly brace syntax with any string keys:
 - `$text.length` - Get string length
 - `$text.escape()` - Escape special JSON characters (e.g., quotes, newlines)
 - `$escapedText.unescape()` - Unescape JSON formatted string back to original
+- `$base64Encode("Héym 🌍")` - Return `SMOpeW0g8J+MjQ==`
+- `$encodedText.base64Decode()` - Decode Base64 into UTF-8 text
 - `$text.urlEncode()` - URL encode for API parameters
 - `$encodedText.urlDecode()` - Decode URL encoded text
 
@@ -338,6 +344,7 @@ Use ONLY:
 - `randomInt()`, `range()`, `array()`, `notNull()`
 - `upper()`, `lower()`, `strip()`, `capitalize()`, `title()`
 - `split()`, `join()`, `replace()`, `regexReplace()`, `hash()`
+- `base64Encode()`, `base64Decode()`
 - documented string/array/object methods
 
 If a function is not listed above, it does not exist.

--- a/frontend/src/types/expression.ts
+++ b/frontend/src/types/expression.ts
@@ -569,6 +569,20 @@ export const BUILTIN_FUNCTIONS: CompletionSuggestion[] = [
     description: "title($text)",
   },
   {
+    label: "base64Encode",
+    insertText: "base64Encode()",
+    type: "function",
+    detail: "Encode UTF-8 text as Base64",
+    description: "base64Encode($text)",
+  },
+  {
+    label: "base64Decode",
+    insertText: "base64Decode()",
+    type: "function",
+    detail: "Decode Base64 as UTF-8 text",
+    description: "base64Decode($text)",
+  },
+  {
     label: "split",
     insertText: "split()",
     type: "function",
@@ -751,6 +765,20 @@ export const STRING_METHODS: CompletionSuggestion[] = [
     insertText: "hash()",
     type: "function",
     detail: "MD5 hash",
+    propertyType: "string",
+  },
+  {
+    label: "base64Encode",
+    insertText: "base64Encode()",
+    type: "function",
+    detail: "Encode UTF-8 text as Base64",
+    propertyType: "string",
+  },
+  {
+    label: "base64Decode",
+    insertText: "base64Decode()",
+    type: "function",
+    detail: "Decode Base64 as UTF-8 text",
     propertyType: "string",
   },
   {


### PR DESCRIPTION
## Summary
- Add UTF-8 Base64 expression functions and string methods
- Expose them through DSL guidance and frontend autocomplete
- Document usage and error behavior
- Cover ASCII, Unicode, empty, invalid, and non-string inputs

## Validation
- 2,138 backend tests passed with 170 subtests
- Ruff format and lint passed
- Frontend ESLint and typecheck passed
- File-line guard passed