### PR TITLE
Prevent loop self-edges from racing body execution

### DIFF
--- a/backend/app/services/node_execution/nodes/loop_node.py
+++ b/backend/app/services/node_execution/nodes/loop_node.py
@@ -13,7 +13,11 @@ def execute(ctx: NodeExecutionContext) -> object:
 
     is_loop_back = False
     for edge in self.edges:
-        if edge.get("target") == node_id and edge.get("targetHandle") == "loop":
+        if (
+            edge.get("source") != node_id
+            and edge.get("target") == node_id
+            and edge.get("targetHandle") == "loop"
+        ):
             source_id = edge.get("source", "")
             source_label = self.get_node_label(source_id)
             if source_label in inputs and source_id in self.node_outputs:
@@ -46,7 +50,11 @@ def execute(ctx: NodeExecutionContext) -> object:
         self.loop_states[node_id]["current_index"] += 1
         loop_back_input = None
         for edge in self.edges:
-            if edge.get("target") == node_id and edge.get("targetHandle") == "loop":
+            if (
+                edge.get("source") != node_id
+                and edge.get("target") == node_id
+                and edge.get("targetHandle") == "loop"
+            ):
                 source_label = self.get_node_label(edge.get("source", ""))
                 if source_label in inputs:
                     loop_back_input = inputs[source_label]

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -2465,6 +2465,16 @@ class WorkflowExecutor:
                 or edge["target"] in self.error_handler_nodes
             ):
                 continue
+            if (
+                edge["source"] == edge["target"]
+                and target_node.get("type") == "loop"
+                and edge.get("targetHandle") == "loop"
+            ):
+                # Some canvas workflows contain a visual loop-handle self-edge in
+                # addition to the body node's real back-connection. The self-edge is
+                # not an execution dependency: scheduling it advances the loop while
+                # the body is still running.
+                continue
             if source_node.get("type") == "jsonOutputMapper":
                 continue
             if source_node.get("type") == "output":

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -2520,6 +2520,22 @@ class WorkflowExecutor:
             inputs[_EXECUTION_CONTEXT_INPUT_KEY] = execution_context
         return inputs
 
+    def get_loop_reexecution_inputs(
+        self,
+        loop_node_id: str,
+        feedback_source_node_id: str,
+        edges: list[dict],
+    ) -> dict:
+        """Return loop inputs with feedback only from the branch that just completed."""
+        relevant_edges = [
+            edge
+            for edge in edges
+            if edge.get("target") != loop_node_id
+            or edge.get("targetHandle") != "loop"
+            or edge.get("source") == feedback_source_node_id
+        ]
+        return self.get_node_inputs_for_edges(loop_node_id, relevant_edges)
+
     def get_node_inputs(self, node_id: str) -> dict:
         inputs = {}
         execution_context: dict[str, object] = {}
@@ -2678,6 +2694,11 @@ class WorkflowExecutor:
                 if edge["source"] != current:
                     continue
                 target = edge["target"]
+                if (
+                    edge.get("targetHandle") == "loop"
+                    and self.nodes.get(target, {}).get("type") == "loop"
+                ):
+                    continue
                 if target not in reachable and target not in excluded:
                     queue.append(target)
 
@@ -2698,6 +2719,11 @@ class WorkflowExecutor:
         for edge in self.edges:
             if edge["source"] == node_id:
                 target = edge["target"]
+                if (
+                    edge.get("targetHandle") == "loop"
+                    and self.nodes.get(target, {}).get("type") == "loop"
+                ):
+                    continue
                 if target in preserved or target in stopped:
                     continue
                 self.mark_branch_as_skipped(
@@ -7509,7 +7535,9 @@ class WorkflowExecutor:
                         ):
                             already_running = any(nid == target for nid in running_futures.values())
                             if not already_running:
-                                inputs = self.get_node_inputs_for_edges(target, active_edges)
+                                inputs = self.get_loop_reexecution_inputs(
+                                    target, source_node_id, active_edges
+                                )
                                 new_future = _SHARED_EXECUTOR.submit(
                                     self.execute_node_parallel, target, inputs
                                 )
@@ -7672,8 +7700,8 @@ class WorkflowExecutor:
                                                             for n in remaining_futures.values()
                                                         )
                                                         if not already:
-                                                            inp = self.get_node_inputs_for_edges(
-                                                                tgt, active_edges
+                                                            inp = self.get_loop_reexecution_inputs(
+                                                                tgt, nid, active_edges
                                                             )
                                                             new_f = _SHARED_EXECUTOR.submit(
                                                                 self.execute_node_parallel,
@@ -8077,7 +8105,9 @@ def resume_workflow_execution(
                             new_future = _SHARED_EXECUTOR.submit(
                                 wf_executor.execute_node_parallel,
                                 target,
-                                wf_executor.get_node_inputs_for_edges(target, active_edges),
+                                wf_executor.get_loop_reexecution_inputs(
+                                    target, source_node_id, active_edges
+                                ),
                             )
                             running_futures[new_future] = target
                     continue
@@ -8216,8 +8246,8 @@ def resume_workflow_execution(
                                                         new_future = _SHARED_EXECUTOR.submit(
                                                             wf_executor.execute_node_parallel,
                                                             tgt,
-                                                            wf_executor.get_node_inputs_for_edges(
-                                                                tgt, active_edges
+                                                            wf_executor.get_loop_reexecution_inputs(
+                                                                tgt, nid, active_edges
                                                             ),
                                                         )
                                                         remaining_futures[new_future] = tgt
@@ -8440,7 +8470,7 @@ def execute_llm_batch_notification_branch(
             }
         )
 
-    def _submit_node(node_id: str) -> None:
+    def _submit_node(node_id: str, node_inputs: dict | None = None) -> None:
         already_running = any(
             pending_node_id == node_id for pending_node_id in running_futures.values()
         )
@@ -8450,7 +8480,11 @@ def execute_llm_batch_notification_branch(
         new_future = _SHARED_EXECUTOR.submit(
             wf_executor.execute_node_parallel,
             node_id,
-            wf_executor.get_node_inputs_for_edges(node_id, branch_edges),
+            (
+                node_inputs
+                if node_inputs is not None
+                else wf_executor.get_node_inputs_for_edges(node_id, branch_edges)
+            ),
         )
         running_futures[new_future] = node_id
 
@@ -8504,7 +8538,10 @@ def execute_llm_batch_notification_branch(
                     completed_nodes=completed_nodes,
                     pending_count=pending_count,
                 ):
-                    _submit_node(target)
+                    _submit_node(
+                        target,
+                        wf_executor.get_loop_reexecution_inputs(target, source_id, branch_edges),
+                    )
                 continue
 
             if target not in pending_count or target in completed_nodes:
@@ -8710,7 +8747,9 @@ def execute_hitl_notification_branch(
                         new_future = _SHARED_EXECUTOR.submit(
                             wf_executor.execute_node_parallel,
                             target,
-                            wf_executor.get_node_inputs_for_edges(target, active_edges),
+                            wf_executor.get_loop_reexecution_inputs(
+                                target, source_node_id, active_edges
+                            ),
                         )
                         running_futures[new_future] = target
                 continue
@@ -9094,7 +9133,7 @@ def _execute_workflow_streaming_impl(
             }
         )
 
-    def execute_and_report(node_id: str) -> NodeResult:
+    def execute_and_report(node_id: str, node_inputs: dict | None = None) -> NodeResult:
         wf_executor.check_cancelled()
         node = wf_executor.nodes[node_id]
         node_label = node.get("data", {}).get("label", node_id)
@@ -9109,7 +9148,8 @@ def _execute_workflow_streaming_impl(
             node_start_event["message"] = start_message
         event_queue.put(node_start_event)
 
-        node_inputs = wf_executor.get_node_inputs_for_edges(node_id, active_edges)
+        if node_inputs is None:
+            node_inputs = wf_executor.get_node_inputs_for_edges(node_id, active_edges)
         result = wf_executor.execute_node_parallel(node_id, node_inputs, on_retry=on_retry_callback)
 
         output = result.output
@@ -9164,7 +9204,13 @@ def _execute_workflow_streaming_impl(
                     ):
                         already_running = any(nid == target for nid in running_futures.values())
                         if not already_running:
-                            new_future = _SHARED_EXECUTOR.submit(execute_and_report, target)
+                            new_future = _SHARED_EXECUTOR.submit(
+                                execute_and_report,
+                                target,
+                                wf_executor.get_loop_reexecution_inputs(
+                                    target, source_node_id, active_edges
+                                ),
+                            )
                             running_futures[new_future] = target
                     continue
 

--- a/backend/tests/test_workflow_executor_thread_safety.py
+++ b/backend/tests/test_workflow_executor_thread_safety.py
@@ -8,6 +8,8 @@ import uuid
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 from app.services.node_execution.base import NodeExecutionContext
 from app.services.node_execution.nodes import agent_node, llm_node
 from app.services.workflow_executor import (
@@ -90,6 +92,96 @@ def _make_self_referential_loop_workflow() -> tuple[list[dict], list[dict]]:
             "target": "loop_1",
             "sourceHandle": "output",
             "targetHandle": "loop",
+        },
+    ]
+    return nodes, edges
+
+
+def _make_branched_loop_workflow() -> tuple[list[dict], list[dict]]:
+    nodes = [
+        {
+            "id": "var_numbers",
+            "type": "variable",
+            "data": {
+                "label": "createNumbers",
+                "variableName": "numbers",
+                "variableValue": "$array(1, 2, 3, 4, 5)",
+                "variableType": "array",
+            },
+        },
+        {
+            "id": "loop_1",
+            "type": "loop",
+            "data": {"label": "processNumbers", "arrayExpression": "$vars.numbers"},
+        },
+        {
+            "id": "condition_1",
+            "type": "condition",
+            "data": {"label": "checkIsThree", "condition": "$processNumbers.item == 3"},
+        },
+        {
+            "id": "console_log",
+            "type": "consoleLog",
+            "data": {"label": "printNumber", "logMessage": "$processNumbers.item"},
+        },
+        {
+            "id": "wait_1",
+            "type": "wait",
+            "data": {"label": "wait", "duration": 20},
+        },
+        {
+            "id": "http_1",
+            "type": "http",
+            "data": {
+                "label": "httpRequest",
+                "curl": "curl -X GET https://example.test/$processNumbers.item",
+                "onErrorEnabled": True,
+            },
+        },
+        {
+            "id": "output_done",
+            "type": "output",
+            "data": {"label": "finalOutput", "message": "Loop completed"},
+        },
+    ]
+    edges = [
+        {"id": "e1", "source": "var_numbers", "target": "loop_1"},
+        {
+            "id": "e2",
+            "source": "loop_1",
+            "target": "condition_1",
+            "sourceHandle": "loop",
+        },
+        {
+            "id": "e3",
+            "source": "condition_1",
+            "target": "console_log",
+            "sourceHandle": "false",
+        },
+        {"id": "e4", "source": "console_log", "target": "wait_1"},
+        {
+            "id": "e5",
+            "source": "wait_1",
+            "target": "loop_1",
+            "targetHandle": "loop",
+        },
+        {
+            "id": "e6",
+            "source": "condition_1",
+            "target": "http_1",
+            "sourceHandle": "true",
+        },
+        {
+            "id": "e7",
+            "source": "http_1",
+            "target": "loop_1",
+            "targetHandle": "loop",
+        },
+        {
+            "id": "e8",
+            "source": "loop_1",
+            "target": "output_done",
+            "sourceHandle": "done",
         },
     ]
     return nodes, edges
@@ -456,6 +548,157 @@ class LoopSelfEdgeExecutionTests(unittest.TestCase):
             {"finalOutput": {"result": "Loop completed"}},
         )
         self.assert_sequential_loop_results(node_results)
+
+
+class LoopBranchExecutionTests(unittest.TestCase):
+    """Verify each loop iteration waits for only its selected condition branch."""
+
+    def _assert_branched_loop_results(self, node_results: list[dict]) -> None:
+        loop_results = [
+            row
+            for row in node_results
+            if row["node_label"] == "processNumbers" and row["status"] == "success"
+        ]
+        condition_results = [
+            row
+            for row in node_results
+            if row["node_label"] == "checkIsThree" and row["status"] == "success"
+        ]
+        console_results = [
+            row
+            for row in node_results
+            if row["node_label"] == "printNumber" and row["status"] == "success"
+        ]
+        wait_results = [
+            row
+            for row in node_results
+            if row["node_label"] == "wait" and row["status"] == "success"
+        ]
+        http_results = [
+            row
+            for row in node_results
+            if row["node_label"] == "httpRequest" and row["status"] == "success"
+        ]
+
+        self.assertEqual(
+            [row["output"].get("item") for row in loop_results[:-1]],
+            [1, 2, 3, 4, 5],
+        )
+        self.assertEqual(
+            [row["output"]["branch"] for row in condition_results],
+            ["false", "false", "true", "false", "false"],
+        )
+        self.assertEqual(
+            [row["output"]["logMessage"] for row in console_results],
+            [1, 2, 4, 5],
+        )
+        self.assertEqual(
+            [row["output"]["logMessage"] for row in wait_results],
+            [1, 2, 4, 5],
+        )
+        self.assertEqual(len(http_results), 1)
+        if "request" in http_results[0]["output"]:
+            self.assertEqual(http_results[0]["output"]["request"]["url"], "https://example.test/3")
+        self.assertEqual(
+            loop_results[-1]["output"]["results"],
+            [
+                {"branch": "false", "logMessage": 1},
+                {"branch": "false", "logMessage": 2},
+                http_results[0]["output"],
+                {"branch": "false", "logMessage": 4},
+                {"branch": "false", "logMessage": 5},
+            ],
+        )
+
+        selected_branch_results = [
+            wait_results[0],
+            wait_results[1],
+            http_results[0],
+            wait_results[2],
+            wait_results[3],
+        ]
+        for index, branch_result in enumerate(selected_branch_results):
+            self.assertLess(
+                loop_results[index]["metadata"]["sequence"],
+                branch_result["metadata"]["sequence"],
+            )
+            self.assertLess(
+                branch_result["metadata"]["sequence"],
+                loop_results[index + 1]["metadata"]["sequence"],
+            )
+
+    @staticmethod
+    def _mock_http_response(method: str, url: str, **_kwargs: object) -> httpx.Response:
+        request = httpx.Request(method, url)
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+    def test_loop_waits_for_selected_condition_branch(self) -> None:
+        nodes, edges = _make_branched_loop_workflow()
+        executor = WorkflowExecutor(nodes=nodes, edges=edges)
+
+        with patch("app.services.workflow_executor.get_http_client") as mock_get_client:
+            mock_get_client.return_value.request.side_effect = self._mock_http_response
+            result = executor.execute(workflow_id=uuid.uuid4(), initial_inputs={})
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.outputs, {"finalOutput": {"result": "Loop completed"}})
+        self._assert_branched_loop_results(result.node_results)
+
+    def test_loop_waits_for_selected_branch_when_http_returns_error_output(self) -> None:
+        nodes, edges = _make_branched_loop_workflow()
+        executor = WorkflowExecutor(nodes=nodes, edges=edges)
+
+        with patch("app.services.workflow_executor.get_http_client") as mock_get_client:
+            mock_get_client.return_value.request.side_effect = httpx.ConnectError(
+                "Name or service not known"
+            )
+            result = executor.execute(workflow_id=uuid.uuid4(), initial_inputs={})
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.outputs, {"finalOutput": {"result": "Loop completed"}})
+        self._assert_branched_loop_results(result.node_results)
+
+        http_result = next(
+            row
+            for row in result.node_results
+            if row["node_label"] == "httpRequest" and row["status"] == "success"
+        )
+        self.assertTrue(http_result["output"]["_errorBranch"])
+
+    def test_streaming_loop_waits_for_selected_condition_branch(self) -> None:
+        nodes, edges = _make_branched_loop_workflow()
+
+        with patch("app.services.workflow_executor.get_http_client") as mock_get_client:
+            mock_get_client.return_value.request.side_effect = self._mock_http_response
+            events = list(
+                execute_workflow_streaming(
+                    workflow_id=uuid.uuid4(),
+                    nodes=nodes,
+                    edges=edges,
+                    inputs={},
+                )
+            )
+
+        node_results = [
+            {
+                "node_label": event["node_label"],
+                "status": event["status"],
+                "output": event["output"],
+                "metadata": event["metadata"],
+            }
+            for event in events
+            if event.get("type") == "node_complete"
+        ]
+        execution_complete = next(
+            event for event in events if event.get("type") == "execution_complete"
+        )
+
+        self.assertEqual(execution_complete["status"], "success")
+        self.assertEqual(
+            execution_complete["outputs"],
+            {"finalOutput": {"result": "Loop completed"}},
+        )
+        self._assert_branched_loop_results(node_results)
 
 
 class OutputAllowDownstreamTests(unittest.TestCase):

--- a/backend/tests/test_workflow_executor_thread_safety.py
+++ b/backend/tests/test_workflow_executor_thread_safety.py
@@ -2,13 +2,97 @@
 
 from __future__ import annotations
 
+import time
 import unittest
 import uuid
-from unittest.mock import MagicMock
+from collections.abc import Callable
+from unittest.mock import MagicMock, patch
 
 from app.services.node_execution.base import NodeExecutionContext
 from app.services.node_execution.nodes import agent_node, llm_node
-from app.services.workflow_executor import NodeTraceableExecutionError, WorkflowExecutor
+from app.services.workflow_executor import (
+    NodeResult,
+    NodeTraceableExecutionError,
+    WorkflowExecutor,
+    execute_workflow_streaming,
+)
+
+_ORIGINAL_EXECUTE_NODE_PARALLEL = WorkflowExecutor.execute_node_parallel
+
+
+def _execute_node_parallel_with_slow_set(
+    executor: WorkflowExecutor,
+    node_id: str,
+    inputs: dict,
+    on_retry: Callable[[NodeResult, int, int], None] | None = None,
+) -> NodeResult:
+    if node_id == "node_1784204114120_is6kul2q1":
+        time.sleep(0.02)
+    return _ORIGINAL_EXECUTE_NODE_PARALLEL(executor, node_id, inputs, on_retry)
+
+
+def _make_self_referential_loop_workflow() -> tuple[list[dict], list[dict]]:
+    nodes = [
+        {
+            "id": "var_numbers",
+            "type": "variable",
+            "data": {
+                "label": "createNumbers",
+                "variableName": "numbers",
+                "variableValue": "$array(1, 2, 3, 4, 5)",
+                "variableType": "array",
+            },
+        },
+        {
+            "id": "loop_1",
+            "type": "loop",
+            "data": {"label": "processNumbers", "arrayExpression": "$vars.numbers"},
+        },
+        {
+            "id": "output_done",
+            "type": "output",
+            "data": {"label": "finalOutput", "message": "Loop completed"},
+        },
+        {
+            "id": "node_1784204114120_is6kul2q1",
+            "type": "set",
+            "data": {
+                "label": "set",
+                "mappings": [{"key": "num", "value": "$processNumbers.item"}],
+            },
+        },
+    ]
+    edges = [
+        {"id": "edge_1", "source": "var_numbers", "target": "loop_1"},
+        {
+            "id": "edge_7",
+            "source": "loop_1",
+            "target": "output_done",
+            "sourceHandle": "done",
+        },
+        {
+            "id": "edge_loop_1_loop_1_1784204041004_1yec6",
+            "source": "loop_1",
+            "target": "loop_1",
+            "sourceHandle": "loop",
+            "targetHandle": "loop",
+        },
+        {
+            "id": "edge_loop_1_node_1784204114120_is6kul2q1_1784204114120",
+            "source": "loop_1",
+            "target": "node_1784204114120_is6kul2q1",
+            "sourceHandle": "loop",
+            "targetHandle": "input",
+        },
+        {
+            "id": "edge_node_1784204114120_is6kul2q1_loop_1_1784204141287",
+            "source": "node_1784204114120_is6kul2q1",
+            "target": "loop_1",
+            "sourceHandle": "output",
+            "targetHandle": "loop",
+        },
+    ]
+    return nodes, edges
 
 
 def _make_llm_ctx(
@@ -283,6 +367,95 @@ class LoopWithInputSnapshotTests(unittest.TestCase):
             if row["node_label"] == "itemLoop" and row["status"] == "success"
         ]
         self.assertEqual(len(loop_results), 4)  # 3 loop iterations + 1 done
+
+
+class LoopSelfEdgeExecutionTests(unittest.TestCase):
+    """Verify visual self-edges cannot advance a loop ahead of its body."""
+
+    def assert_sequential_loop_results(self, node_results: list[dict]) -> None:
+        """Assert every body result completes before the following loop iteration."""
+        loop_results = [
+            row
+            for row in node_results
+            if row["node_label"] == "processNumbers" and row["status"] == "success"
+        ]
+        set_results = [
+            row for row in node_results if row["node_label"] == "set" and row["status"] == "success"
+        ]
+
+        self.assertEqual(
+            [row["output"].get("item") for row in loop_results[:-1]],
+            [1, 2, 3, 4, 5],
+        )
+        self.assertEqual([row["output"] for row in set_results], [{"num": i} for i in range(1, 6)])
+        self.assertEqual(loop_results[-1]["output"]["branch"], "done")
+        self.assertEqual(
+            loop_results[-1]["output"]["results"],
+            [{"num": i} for i in range(1, 6)],
+        )
+
+        for index, set_result in enumerate(set_results):
+            self.assertLess(
+                loop_results[index]["metadata"]["sequence"],
+                set_result["metadata"]["sequence"],
+            )
+            self.assertLess(
+                set_result["metadata"]["sequence"],
+                loop_results[index + 1]["metadata"]["sequence"],
+            )
+
+    def test_loop_self_edge_does_not_skip_body_iterations(self) -> None:
+        nodes, edges = _make_self_referential_loop_workflow()
+        executor = WorkflowExecutor(nodes=nodes, edges=edges)
+
+        with patch.object(
+            WorkflowExecutor,
+            "execute_node_parallel",
+            _execute_node_parallel_with_slow_set,
+        ):
+            result = executor.execute(workflow_id=uuid.uuid4(), initial_inputs={})
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.outputs, {"finalOutput": {"result": "Loop completed"}})
+        self.assert_sequential_loop_results(result.node_results)
+
+    def test_streaming_loop_self_edge_does_not_skip_body_iterations(self) -> None:
+        nodes, edges = _make_self_referential_loop_workflow()
+
+        with patch.object(
+            WorkflowExecutor,
+            "execute_node_parallel",
+            _execute_node_parallel_with_slow_set,
+        ):
+            events = list(
+                execute_workflow_streaming(
+                    workflow_id=uuid.uuid4(),
+                    nodes=nodes,
+                    edges=edges,
+                    inputs={},
+                )
+            )
+
+        node_results = [
+            {
+                "node_label": event["node_label"],
+                "status": event["status"],
+                "output": event["output"],
+                "metadata": event["metadata"],
+            }
+            for event in events
+            if event.get("type") == "node_complete"
+        ]
+        execution_complete = next(
+            event for event in events if event.get("type") == "execution_complete"
+        )
+
+        self.assertEqual(execution_complete["status"], "success")
+        self.assertEqual(
+            execution_complete["outputs"],
+            {"finalOutput": {"result": "Loop completed"}},
+        )
+        self.assert_sequential_loop_results(node_results)
 
 
 class OutputAllowDownstreamTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- ignore canvas loop self-edges when building the executable graph
- advance loop state only from distinct body-node back-connections
- add normal and streaming regressions for the supplied five-item workflow
- verify every set execution completes before the next iteration

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- full backend suite: 2,140 tests and 170 subtests passed
- `./check.sh` frontend stage unavailable because Bun is not installed