### PR TITLE
Sort named MCP servers by selection and workflow recency

### DIFF
--- a/backend/app/api/mcp_servers.py
+++ b/backend/app/api/mcp_servers.py
@@ -45,6 +45,7 @@ from app.models.schemas import (
     MCPServerCreate,
     MCPServerListResponse,
     MCPServerResponse,
+    MCPServerWorkflowItem,
     MCPServerWorkflowToggleRequest,
     MCPToolsListResponse,
 )
@@ -75,13 +76,6 @@ async def _fetch_server_for_user(
     return server
 
 
-async def _get_server_workflow_ids(db: AsyncSession, server_id: uuid.UUID) -> list[uuid.UUID]:
-    result = await db.execute(
-        select(MCPServerWorkflow.workflow_id).where(MCPServerWorkflow.mcp_server_id == server_id)
-    )
-    return [row[0] for row in result.all()]
-
-
 async def _get_server_workflows(db: AsyncSession, server_id: uuid.UUID) -> list[Workflow]:
     result = await db.execute(
         select(Workflow)
@@ -89,6 +83,24 @@ async def _get_server_workflows(db: AsyncSession, server_id: uuid.UUID) -> list[
         .where(MCPServerWorkflow.mcp_server_id == server_id)
     )
     return list(result.scalars().all())
+
+
+def _mcp_server_response(server: MCPServer, workflows: list[Workflow]) -> MCPServerResponse:
+    return MCPServerResponse(
+        id=server.id,
+        name=server.name,
+        api_key=server.api_key,
+        created_at=server.created_at,
+        workflow_ids=[workflow.id for workflow in workflows],
+        workflows=[
+            MCPServerWorkflowItem(
+                id=workflow.id,
+                mcp_enabled=workflow.mcp_enabled,
+                updated_at=workflow.updated_at,
+            )
+            for workflow in workflows
+        ],
+    )
 
 
 def _sanitize_tool_name(name: str) -> str:
@@ -224,17 +236,9 @@ async def list_mcp_servers(
     )
     servers = list(result.scalars().all())
     items = []
-    for s in servers:
-        workflow_ids = await _get_server_workflow_ids(db, s.id)
-        items.append(
-            MCPServerResponse(
-                id=s.id,
-                name=s.name,
-                api_key=s.api_key,
-                created_at=s.created_at,
-                workflow_ids=workflow_ids,
-            )
-        )
+    for server in servers:
+        workflows = await _get_server_workflows(db, server.id)
+        items.append(_mcp_server_response(server, workflows))
     return MCPServerListResponse(servers=items)
 
 
@@ -252,13 +256,7 @@ async def create_mcp_server(
     db.add(server)
     await db.commit()
     await db.refresh(server)
-    return MCPServerResponse(
-        id=server.id,
-        name=server.name,
-        api_key=server.api_key,
-        created_at=server.created_at,
-        workflow_ids=[],
-    )
+    return _mcp_server_response(server, [])
 
 
 @router.delete("/{server_id}", status_code=204)
@@ -282,14 +280,8 @@ async def regenerate_server_key(
     server.api_key = secrets.token_urlsafe(48)
     await db.commit()
     await db.refresh(server)
-    workflow_ids = await _get_server_workflow_ids(db, server.id)
-    return MCPServerResponse(
-        id=server.id,
-        name=server.name,
-        api_key=server.api_key,
-        created_at=server.created_at,
-        workflow_ids=workflow_ids,
-    )
+    workflows = await _get_server_workflows(db, server.id)
+    return _mcp_server_response(server, workflows)
 
 
 @router.patch("/{server_id}/workflows/{workflow_id}")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1081,12 +1081,19 @@ class MCPServerWorkflowToggleRequest(BaseModel):
     enabled: bool
 
 
+class MCPServerWorkflowItem(BaseModel):
+    id: uuid.UUID
+    mcp_enabled: bool
+    updated_at: datetime
+
+
 class MCPServerResponse(BaseModel):
     id: uuid.UUID
     name: str
     api_key: str
     created_at: datetime
     workflow_ids: list[uuid.UUID] = Field(default_factory=list)
+    workflows: list[MCPServerWorkflowItem] = Field(default_factory=list)
 
 
 class MCPServerListResponse(BaseModel):

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -31,6 +31,8 @@ def _make_workflow(owner_id: uuid.UUID) -> SimpleNamespace:
         id=uuid.uuid4(),
         owner_id=owner_id,
         name="My Workflow",
+        mcp_enabled=True,
+        updated_at=datetime.now(timezone.utc),
     )
 
 
@@ -62,6 +64,7 @@ class MCPServerCreateTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.api_key)
         self.assertEqual(result.id, server_id)
         self.assertEqual(len(result.workflow_ids), 0)
+        self.assertEqual(len(result.workflows), 0)
         db.commit.assert_called_once()
 
 
@@ -69,21 +72,31 @@ class MCPServerListTests(unittest.IsolatedAsyncioTestCase):
     async def test_list_returns_only_user_servers(self) -> None:
         user = SimpleNamespace(id=uuid.uuid4())
         server = _make_server(user.id)
+        workflow = _make_workflow(user.id)
 
         db = AsyncMock()
-        # First execute: list servers; second execute: workflow_ids per server
+        # First execute: list servers; second execute: assigned workflows per server
         db.execute = AsyncMock(
             side_effect=[
                 MagicMock(
                     scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[server])))
                 ),
-                MagicMock(all=MagicMock(return_value=[])),
+                MagicMock(
+                    scalars=MagicMock(
+                        return_value=MagicMock(all=MagicMock(return_value=[workflow]))
+                    )
+                ),
             ]
         )
 
         result = await list_mcp_servers(current_user=user, db=db)
         self.assertEqual(len(result.servers), 1)
         self.assertEqual(result.servers[0].name, "Test Server")
+        self.assertEqual(result.servers[0].workflow_ids, [workflow.id])
+        self.assertEqual(len(result.servers[0].workflows), 1)
+        self.assertEqual(result.servers[0].workflows[0].id, workflow.id)
+        self.assertTrue(result.servers[0].workflows[0].mcp_enabled)
+        self.assertEqual(result.servers[0].workflows[0].updated_at, workflow.updated_at)
 
 
 class MCPServerDeleteTests(unittest.IsolatedAsyncioTestCase):

--- a/frontend/e2e/tab-mcp.spec.ts
+++ b/frontend/e2e/tab-mcp.spec.ts
@@ -17,6 +17,111 @@ test("shows the MCP connection config and named servers section", async ({ page 
   ).toBeVisible();
 });
 
+test("sorts only named servers by selected workflows and recent updates", async ({ page }) => {
+  const workflows = [
+    {
+      id: "workflow-unselected-newest",
+      name: "Unselected Newest Workflow",
+      description: null,
+      mcp_enabled: false,
+      input_fields: [],
+      updated_at: "2026-06-01T00:00:00Z",
+    },
+    {
+      id: "workflow-selected-older",
+      name: "Selected Older Workflow",
+      description: null,
+      mcp_enabled: true,
+      input_fields: [],
+      updated_at: "2026-03-01T00:00:00Z",
+    },
+    {
+      id: "workflow-selected-newer",
+      name: "Selected Newer Workflow",
+      description: null,
+      mcp_enabled: true,
+      input_fields: [],
+      updated_at: "2026-05-01T00:00:00Z",
+    },
+    {
+      id: "workflow-unselected-older",
+      name: "Unselected Older Workflow",
+      description: null,
+      mcp_enabled: false,
+      input_fields: [],
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  ];
+  const servers = [
+    {
+      id: "server-unselected-newest",
+      name: "Unselected Newest Server",
+      api_key: "unselected-newest-api-key",
+      created_at: "2026-01-01T00:00:00Z",
+      workflow_ids: ["workflow-unselected-newest"],
+      workflows: [],
+    },
+    {
+      id: "server-selected-older",
+      name: "Selected Older Server",
+      api_key: "selected-older-api-key",
+      created_at: "2026-01-02T00:00:00Z",
+      workflow_ids: ["workflow-selected-older"],
+      workflows: [],
+    },
+    {
+      id: "server-empty",
+      name: "Empty Server",
+      api_key: "empty-server-api-key",
+      created_at: "2026-01-03T00:00:00Z",
+      workflow_ids: [],
+      workflows: [],
+    },
+    {
+      id: "server-selected-newer",
+      name: "Selected Newer Server",
+      api_key: "selected-newer-api-key",
+      created_at: "2026-01-04T00:00:00Z",
+      workflow_ids: ["workflow-selected-newer"],
+      workflows: [],
+    },
+    {
+      id: "server-unselected-older",
+      name: "Unselected Older Server",
+      api_key: "unselected-older-api-key",
+      created_at: "2026-01-05T00:00:00Z",
+      workflow_ids: ["workflow-unselected-older"],
+      workflows: [],
+    },
+  ];
+
+  await page.route("**/api/mcp/config", async (route) => {
+    await route.fulfill({
+      json: {
+        mcp_api_key: "test-mcp-api-key",
+        mcp_endpoint_url: "http://localhost/api/mcp/sse",
+        workflows,
+      },
+    });
+  });
+  await page.route("**/api/mcp/servers", async (route) => {
+    await route.fulfill({ json: { servers } });
+  });
+
+  await page.goto("/?tab=mcp");
+
+  await expect(page.locator("p.font-medium.text-sm.truncate")).toHaveText([
+    "Selected Newer Server",
+    "Selected Older Server",
+    "Unselected Newest Server",
+    "Unselected Older Server",
+    "Empty Server",
+  ]);
+  await expect(page.locator("h4.font-medium.truncate")).toHaveText(
+    workflows.map((workflow) => workflow.name),
+  );
+});
+
 test("creates a named MCP server, reveals its endpoint, and deletes it", async ({ page }) => {
   const serverName = `E2E MCP ${Date.now()}`;
 

--- a/frontend/src/components/MCP/MCPPanel.vue
+++ b/frontend/src/components/MCP/MCPPanel.vue
@@ -66,6 +66,36 @@ const serverWorkflowsSorted = computed(() => {
   });
 });
 
+const namedServersSorted = computed<MCPServerItem[]>(() => {
+  const workflowsById = new Map(
+    allWorkflows.value.map((workflow) => [workflow.id, workflow]),
+  );
+
+  return namedServers.value
+    .map((server, originalIndex) => {
+      const assignedWorkflows = server.workflow_ids
+        .map((workflowId) => workflowsById.get(workflowId))
+        .filter((workflow): workflow is MCPWorkflowItem => workflow !== undefined);
+      const hasSelectedWorkflow = assignedWorkflows.some((workflow) => workflow.mcp_enabled);
+      const mostRecentWorkflowUpdate = assignedWorkflows.reduce((mostRecent, workflow) => {
+        const updatedAt = workflow.updated_at ? Date.parse(workflow.updated_at) : 0;
+        return Number.isNaN(updatedAt) ? mostRecent : Math.max(mostRecent, updatedAt);
+      }, 0);
+
+      return { server, originalIndex, hasSelectedWorkflow, mostRecentWorkflowUpdate };
+    })
+    .sort((a, b) => {
+      if (a.hasSelectedWorkflow !== b.hasSelectedWorkflow) {
+        return Number(b.hasSelectedWorkflow) - Number(a.hasSelectedWorkflow);
+      }
+      if (a.mostRecentWorkflowUpdate !== b.mostRecentWorkflowUpdate) {
+        return b.mostRecentWorkflowUpdate - a.mostRecentWorkflowUpdate;
+      }
+      return a.originalIndex - b.originalIndex;
+    })
+    .map(({ server }) => server);
+});
+
 // Use browser's URL for SSE endpoint instead of backend-provided URL
 const sseEndpointUrl = computed(() => {
   return joinOriginAndPath(window.location.origin, "/api/mcp/sse");
@@ -745,7 +775,7 @@ function addToCursor(): void {
           class="space-y-3"
         >
           <Card
-            v-for="server in namedServers"
+            v-for="server in namedServersSorted"
             :key="server.id"
             class="overflow-hidden"
           >

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2079,6 +2079,13 @@ export interface MCPServerItem {
   api_key: string;
   created_at: string;
   workflow_ids: string[];
+  workflows: MCPServerWorkflowItem[];
+}
+
+export interface MCPServerWorkflowItem {
+  id: string;
+  mcp_enabled: boolean;
+  updated_at: string;
 }
 
 export interface MCPServerListResponse {


### PR DESCRIPTION
## Summary
- sort named MCP servers by enabled workflow presence and workflow recency
- include assigned workflow metadata in MCP server API responses
- preserve unnamed workflow ordering
- add backend and Playwright coverage

## Validation
- Backend Ruff formatting/checks passed
- 11 focused backend tests passed
- Frontend ESLint and typecheck passed
- Playwright coverage added; execution unavailable because Docker was not running