### PR TITLE
Fix named MCP server sorting

### DIFF
--- a/frontend/src/components/MCP/MCPPanel.vue
+++ b/frontend/src/components/MCP/MCPPanel.vue
@@ -57,44 +57,20 @@ const enabledCount = computed(() => {
   return config.value?.workflows.filter((w) => w.mcp_enabled).length ?? 0;
 });
 
-const serverWorkflowsSorted = computed(() => {
+function getServerWorkflowsSorted(server: MCPServerItem): MCPWorkflowItem[] {
+  const selectedIds = new Set(server.workflow_ids);
+
   return [...allWorkflows.value].sort((a, b) => {
+    const aSelected = selectedIds.has(a.id);
+    const bSelected = selectedIds.has(b.id);
+    if (aSelected !== bSelected) return aSelected ? -1 : 1;
+
     const aTime = a.updated_at ?? "";
     const bTime = b.updated_at ?? "";
     if (aTime !== bTime) return bTime.localeCompare(aTime);
     return a.name.localeCompare(b.name);
   });
-});
-
-const namedServersSorted = computed(() => {
-  const workflowsById = new Map(allWorkflows.value.map((workflow) => [workflow.id, workflow]));
-
-  return namedServers.value
-    .map((server, originalIndex) => {
-      let isSelected = false;
-      let latestUpdatedAt = Number.NEGATIVE_INFINITY;
-
-      for (const workflowId of server.workflow_ids) {
-        const workflow = workflowsById.get(workflowId);
-        if (!workflow) continue;
-
-        if (workflow.mcp_enabled) isSelected = true;
-
-        if (workflow.updated_at) {
-          const updatedAt = Date.parse(workflow.updated_at);
-          if (!Number.isNaN(updatedAt)) latestUpdatedAt = Math.max(latestUpdatedAt, updatedAt);
-        }
-      }
-
-      return { server, originalIndex, isSelected, latestUpdatedAt };
-    })
-    .sort((a, b) => {
-      if (a.isSelected !== b.isSelected) return a.isSelected ? -1 : 1;
-      if (a.latestUpdatedAt !== b.latestUpdatedAt) return b.latestUpdatedAt - a.latestUpdatedAt;
-      return a.originalIndex - b.originalIndex;
-    })
-    .map(({ server }) => server);
-});
+}
 
 // Use browser's URL for SSE endpoint instead of backend-provided URL
 const sseEndpointUrl = computed(() => {
@@ -775,7 +751,7 @@ function addToCursor(): void {
           class="space-y-3"
         >
           <Card
-            v-for="server in namedServersSorted"
+            v-for="server in namedServers"
             :key="server.id"
             class="overflow-hidden"
           >
@@ -914,7 +890,7 @@ function addToCursor(): void {
               <div>
                 <label class="text-xs font-medium text-muted-foreground block mb-2">Assigned Workflows</label>
                 <div
-                  v-if="serverWorkflowsSorted.length === 0"
+                  v-if="allWorkflows.length === 0"
                   class="text-xs text-muted-foreground italic"
                 >
                   No workflows available. Create workflows to assign them here.
@@ -924,7 +900,7 @@ function addToCursor(): void {
                   class="space-y-1 max-h-48 overflow-y-auto pr-1"
                 >
                   <div
-                    v-for="workflow in serverWorkflowsSorted"
+                    v-for="workflow in getServerWorkflowsSorted(server)"
                     :key="workflow.id"
                     class="flex items-center justify-between gap-2 p-2 rounded-md hover:bg-muted/50 transition-colors cursor-pointer"
                     @click="toggleServerWorkflow(server, workflow.id)"

--- a/frontend/src/components/MCP/MCPPanel.vue
+++ b/frontend/src/components/MCP/MCPPanel.vue
@@ -66,6 +66,36 @@ const serverWorkflowsSorted = computed(() => {
   });
 });
 
+const namedServersSorted = computed(() => {
+  const workflowsById = new Map(allWorkflows.value.map((workflow) => [workflow.id, workflow]));
+
+  return namedServers.value
+    .map((server, originalIndex) => {
+      let isSelected = false;
+      let latestUpdatedAt = Number.NEGATIVE_INFINITY;
+
+      for (const workflowId of server.workflow_ids) {
+        const workflow = workflowsById.get(workflowId);
+        if (!workflow) continue;
+
+        if (workflow.mcp_enabled) isSelected = true;
+
+        if (workflow.updated_at) {
+          const updatedAt = Date.parse(workflow.updated_at);
+          if (!Number.isNaN(updatedAt)) latestUpdatedAt = Math.max(latestUpdatedAt, updatedAt);
+        }
+      }
+
+      return { server, originalIndex, isSelected, latestUpdatedAt };
+    })
+    .sort((a, b) => {
+      if (a.isSelected !== b.isSelected) return a.isSelected ? -1 : 1;
+      if (a.latestUpdatedAt !== b.latestUpdatedAt) return b.latestUpdatedAt - a.latestUpdatedAt;
+      return a.originalIndex - b.originalIndex;
+    })
+    .map(({ server }) => server);
+});
+
 // Use browser's URL for SSE endpoint instead of backend-provided URL
 const sseEndpointUrl = computed(() => {
   return joinOriginAndPath(window.location.origin, "/api/mcp/sse");
@@ -745,7 +775,7 @@ function addToCursor(): void {
           class="space-y-3"
         >
           <Card
-            v-for="server in namedServers"
+            v-for="server in namedServersSorted"
             :key="server.id"
             class="overflow-hidden"
           >


### PR DESCRIPTION
## Summary
- prioritize named servers with enabled assigned workflows
- sort next by the latest assigned workflow update
- preserve original order for ties

## Validation
- ordering assertions passed
- lint/typecheck unavailable because Bun is not installed