### PR TITLE
Fix mobile board layout overflow

### DIFF
--- a/frontend/e2e/tab-board.spec.ts
+++ b/frontend/e2e/tab-board.spec.ts
@@ -230,6 +230,7 @@ test("keeps columns within the viewport and scrolls only the card area", async (
   expect(layout[0]).not.toBeNull();
   expect(layout[1]).not.toBeNull();
   expect(layout[2]).not.toBeNull();
+  expect(layout[0]!.width).toBe(288);
   expect(layout[0]!.y + layout[0]!.height).toBeLessThanOrEqual(720);
   expect(layout[0]!.x + layout[0]!.width - (layout[2]!.x + layout[2]!.width)).toBeLessThan(16);
   const pageScroll = await page.evaluate(() => ({
@@ -250,6 +251,66 @@ test("keeps columns within the viewport and scrolls only the card area", async (
   });
   await expect(header).toBeVisible();
   expect((await header.boundingBox())!.y).toBe(headerY);
+});
+
+test("fits board controls and lanes within a mobile viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 });
+  const { boardId } = await createBoardWithCard(
+    page,
+    "Mobile card with a long uninterruptedwordthatmustwrapwithoutoverflowing",
+  );
+
+  await page.goto(`/?tab=board&board=${boardId}`);
+
+  const panel = page.getByTestId("board-panel");
+  const header = page.getByTestId("board-header");
+  const canvas = page.getByTestId("board-canvas");
+  const lane = page.getByTestId("board-column-Backlog");
+  await expect(lane).toBeVisible();
+
+  const headerBox = await header.boundingBox();
+  expect(headerBox).not.toBeNull();
+  for (const control of [
+    header.getByRole("heading", { name: "Board" }),
+    header.getByPlaceholder("Select board"),
+    header.getByRole("button", { name: "New board" }),
+    header.getByRole("button", { name: "Board settings" }),
+    header.getByRole("button", { name: "Delete board" }),
+  ]) {
+    const controlBox = await control.boundingBox();
+    expect(controlBox).not.toBeNull();
+    expect(controlBox!.x).toBeGreaterThanOrEqual(headerBox!.x);
+    expect(controlBox!.x + controlBox!.width).toBeLessThanOrEqual(
+      headerBox!.x + headerBox!.width,
+    );
+  }
+
+  const layout = await Promise.all([
+    panel.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    })),
+    canvas.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    })),
+    lane.boundingBox(),
+    lane.evaluate((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+    })),
+  ]);
+  expect(layout[0].scrollWidth).toBeLessThanOrEqual(layout[0].clientWidth);
+  expect(layout[1].scrollWidth).toBeGreaterThan(layout[1].clientWidth);
+  expect(layout[2]).not.toBeNull();
+  expect(layout[2]!.width).toBeLessThanOrEqual(layout[1].clientWidth);
+  expect(layout[3].scrollWidth).toBeLessThanOrEqual(layout[3].clientWidth);
+
+  const scrollLeft = await canvas.evaluate((element) => {
+    element.scrollLeft = element.scrollWidth;
+    return element.scrollLeft;
+  });
+  expect(scrollLeft).toBeGreaterThan(0);
 });
 
 test("moves a card to the top whenever it is updated", async ({ page }) => {

--- a/frontend/src/components/Board/BoardCanvas.vue
+++ b/frontend/src/components/Board/BoardCanvas.vue
@@ -62,7 +62,7 @@ async function addColumn(): Promise<void> {
 <template>
   <div
     ref="canvas"
-    class="flex min-h-0 gap-3 overflow-x-auto p-4"
+    class="flex min-h-0 w-full min-w-0 gap-3 overflow-x-auto overscroll-x-contain p-2 sm:p-4"
     :style="availableHeight === null ? undefined : { height: `${availableHeight}px` }"
     data-testid="board-canvas"
   >
@@ -77,7 +77,7 @@ async function addColumn(): Promise<void> {
       @open-settings="emit('openSettings', $event)"
       @open-error-history="emit('openErrorHistory', $event)"
     />
-    <div class="flex w-64 shrink-0 flex-col">
+    <div class="flex w-[calc(100vw-2.5rem)] max-w-[16rem] shrink-0 flex-col sm:w-64">
       <button
         v-if="!addingColumn"
         class="flex h-full w-full flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border/60 p-4 text-sm text-muted-foreground hover:border-primary/50 hover:text-foreground"

--- a/frontend/src/components/Board/BoardCardItem.vue
+++ b/frontend/src/components/Board/BoardCardItem.vue
@@ -128,7 +128,7 @@ function onDragStart(event: DragEvent): void {
 
 <template>
   <div
-    class="group cursor-pointer rounded-lg border p-3 text-sm shadow-sm transition-colors hover:border-primary/60"
+    class="group min-w-0 cursor-pointer rounded-lg border p-2.5 text-sm shadow-sm transition-colors hover:border-primary/60 sm:p-3"
     :class="statusClasses"
     :draggable="canAct && !editingTitle"
     :data-testid="`board-card-${card.id}`"
@@ -162,7 +162,7 @@ function onDragStart(event: DragEvent): void {
         </div>
         <span
           v-else
-          class="line-clamp-3 whitespace-pre-line font-medium"
+          class="line-clamp-3 whitespace-pre-line break-words font-medium sm:break-normal"
           :data-testid="`board-card-title-${card.id}`"
           @click.stop="onTitleClick"
           @dblclick.stop="onTitleDblClick"
@@ -233,7 +233,7 @@ function onDragStart(event: DragEvent): void {
     </div>
     <p
       v-if="card.content"
-      class="mt-1 line-clamp-2 text-xs text-muted-foreground"
+      class="mt-1 line-clamp-2 break-words text-xs text-muted-foreground sm:break-normal"
     >
       {{ card.content }}
     </p>

--- a/frontend/src/components/Board/BoardColumnLane.vue
+++ b/frontend/src/components/Board/BoardColumnLane.vue
@@ -106,7 +106,7 @@ async function emptyColumn(): Promise<void> {
 
 <template>
   <div
-    class="flex h-full min-h-0 w-72 shrink-0 flex-col overflow-hidden rounded-xl border border-border/60 bg-muted/30"
+    class="flex h-full min-h-0 w-[calc(100vw-2.5rem)] max-w-[18rem] shrink-0 flex-col overflow-hidden rounded-xl border border-border/60 bg-muted/30 md:w-72"
     :class="[
       dragOver ? 'ring-2 ring-primary/50' : '',
       columnDragOver ? 'ring-2 ring-primary' : '',
@@ -125,7 +125,7 @@ async function emptyColumn(): Promise<void> {
       @dragstart="onColumnDragStart"
     >
       <GripVertical
-        class="-ml-1.5 h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/header:opacity-100"
+        class="-ml-1.5 hidden h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/header:opacity-100 md:block"
       />
       <span
         class="h-2.5 w-2.5 rounded-full"
@@ -192,7 +192,7 @@ async function emptyColumn(): Promise<void> {
         :disabled="!canAct"
         :placeholder="canAct ? 'Add a card' : 'Set the Agentic Kanban Model in board settings first'"
         :title="canAct ? '' : 'Pick a credential and model above to use the board'"
-        class="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
+        class="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
         @keydown.enter="addCard"
       >
     </div>

--- a/frontend/src/components/Board/BoardPanel.vue
+++ b/frontend/src/components/Board/BoardPanel.vue
@@ -119,13 +119,16 @@ function closeErrorHistory(): void {
 
 <template>
   <div
-    class="flex h-full flex-col"
+    class="flex h-full w-full min-w-0 flex-col"
     data-testid="board-panel"
   >
     <!-- pt-0 so the title sits at the same height as the Workflows tab heading. -->
-    <div class="flex items-center gap-3 border-b border-border/60 pb-2.5 pt-0">
-      <div class="flex min-w-0 shrink flex-col">
-        <h2 class="text-xl md:text-2xl font-bold tracking-tight">
+    <div
+      class="flex flex-wrap items-center gap-x-2 gap-y-2 border-b border-border/60 pb-2.5 pt-0 sm:flex-nowrap sm:gap-3"
+      data-testid="board-header"
+    >
+      <div class="mr-auto flex min-w-0 flex-1 flex-col sm:mr-0 sm:flex-initial sm:shrink">
+        <h2 class="text-xl font-bold tracking-tight md:text-2xl">
           Board
         </h2>
         <p
@@ -138,10 +141,10 @@ function closeErrorHistory(): void {
         </p>
       </div>
 
-      <!-- SearchableSelect's root is w-full, so it needs a fixed-width wrapper. -->
+      <!-- SearchableSelect's root is w-full, so its wrapper controls the responsive width. -->
       <div
         v-if="boardStore.boards.length"
-        class="ml-auto w-56 shrink-0"
+        class="order-last w-full shrink-0 sm:order-none sm:ml-auto sm:w-56"
       >
         <!-- Keyed on the name: the combobox caches its display value, so a rename only
              shows up if the select is rebuilt. -->
@@ -158,17 +161,19 @@ function closeErrorHistory(): void {
       <Button
         size="sm"
         variant="outline"
-        class="shrink-0"
+        class="shrink-0 px-3 sm:px-4"
+        aria-label="New board"
         data-testid="board-new"
         @click="createOpen = true"
       >
-        <Plus class="mr-1 h-4 w-4" /> New board
+        <Plus class="h-4 w-4 sm:mr-1" />
+        <span>New<span class="hidden sm:inline"> board</span></span>
       </Button>
       <Button
         v-if="boardStore.isOwner"
         size="sm"
         variant="ghost"
-        class="shrink-0"
+        class="w-11 shrink-0 px-0 sm:w-auto sm:px-4"
         aria-label="Board settings"
         title="Board settings"
         data-testid="board-edit"
@@ -180,7 +185,7 @@ function closeErrorHistory(): void {
         v-if="boardStore.isOwner"
         size="sm"
         variant="ghost"
-        class="shrink-0"
+        class="w-11 shrink-0 px-0 sm:w-auto sm:px-4"
         aria-label="Delete board"
         @click="removeActiveBoard"
       >


### PR DESCRIPTION
- Wrap and resize board header controls on mobile
- Fit lanes within narrow viewports while preserving desktop widths
- Prevent card content from causing horizontal overflow
- Add mobile and desktop board layout regression coverage