### PR TITLE
Make board selector width fit board names

### DIFF
--- a/frontend/src/components/Board/BoardPanel.vue
+++ b/frontend/src/components/Board/BoardPanel.vue
@@ -144,7 +144,7 @@ function closeErrorHistory(): void {
       <!-- SearchableSelect's root is w-full, so its wrapper controls the responsive width. -->
       <div
         v-if="boardStore.boards.length"
-        class="order-last w-full shrink-0 sm:order-none sm:ml-auto sm:w-56"
+        class="order-last w-full shrink-0 sm:order-none sm:ml-auto sm:w-auto sm:min-w-[200px]"
       >
         <!-- Keyed on the name: the combobox caches its display value, so a rename only
              shows up if the select is rebuilt. -->

--- a/frontend/src/components/ui/SearchableSelect.vue
+++ b/frontend/src/components/ui/SearchableSelect.vue
@@ -107,6 +107,10 @@ const hasValue = computed<boolean>(() => {
   return typeof props.modelValue === "string" && props.modelValue.length > 0;
 });
 
+const triggerSizingText = computed<string>(() => {
+  return selectedOption.value?.label ?? props.placeholder;
+});
+
 const wrapperClass = computed(() =>
   cn("relative group min-w-0 w-full", props.class)
 );
@@ -218,6 +222,13 @@ function clearValue(): void {
     @update:model-value="handleUpdateSelectedKey"
   >
     <ComboboxAnchor :class="wrapperClass">
+      <span
+        aria-hidden="true"
+        class="invisible block h-0 overflow-hidden whitespace-nowrap pl-12 text-sm"
+        :class="clearable && hasValue ? 'pr-16' : 'pr-9'"
+      >
+        {{ triggerSizingText }}
+      </span>
       <div
         :class="anchorClass"
         @click="openOptions"
@@ -225,7 +236,7 @@ function clearValue(): void {
         <Search class="ml-3.5 h-4 w-4 shrink-0 text-muted-foreground" />
         <ComboboxInput
           :id="id"
-          class="h-full min-w-0 flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground/60 disabled:cursor-not-allowed"
+          class="h-full w-0 min-w-0 flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground/60 disabled:cursor-not-allowed"
           :placeholder="open ? searchPlaceholder : placeholder"
           :disabled="disabled"
         />


### PR DESCRIPTION
## Summary

- Make the board selector auto-size above the mobile breakpoint with a 200px minimum.
- Size the shared select trigger from its selected label.
- Preserve full-width mobile behavior and max-content dropdown expansion.

## Validation

- Frontend lint passed with four unrelated existing warnings.
- Frontend typecheck passed.
- Frontend production build passed.
- Chromium verified 200px for `Ops`, 370.44px for the long name, dropdown expansion beyond the trigger, and no board-panel overflow at desktop or 320px mobile widths.

## Screenshot

Attach the generated screenshot from `frontend/.e2e-artifacts/board-select-auto-width.png` when creating the merge request.