### PR TITLE
Add searchable AI canvas model dropdowns

### DIFF
--- a/frontend/e2e/tab-workflows.spec.ts
+++ b/frontend/e2e/tab-workflows.spec.ts
@@ -141,6 +141,98 @@ test("renders long model options outside the properties panel without clipping",
   }
 });
 
+test("filters AI Assistant and Analyzer credentials and models", async ({ page }) => {
+  const openAiCredentialId = "22222222-2222-4222-8222-222222222227";
+  const cerebrasCredentialId = "22222222-2222-4222-8222-222222222228";
+  const workflow = await createWorkflow(page, `Canvas AI selectors ${Date.now()}`);
+  const now = new Date().toISOString();
+
+  await page.route("**/api/credentials/llm", async (route) => {
+    await route.fulfill({
+      json: [
+        {
+          id: openAiCredentialId,
+          name: "OpenAI Canvas",
+          type: "openai",
+          masked_value: "sk-...",
+          header_key: null,
+          created_at: now,
+        },
+        {
+          id: cerebrasCredentialId,
+          name: "Cerebras Canvas",
+          type: "openai",
+          masked_value: "csk-...",
+          header_key: null,
+          created_at: now,
+        },
+      ],
+    });
+  });
+  await page.route(`**/api/credentials/${openAiCredentialId}/models`, async (route) => {
+    await route.fulfill({
+      json: [
+        {
+          id: "gpt-4o-canvas",
+          name: "GPT-4o Canvas",
+          is_reasoning: false,
+          supports_batch: false,
+          batch_support_reason: null,
+          context_window: 128000,
+        },
+      ],
+    });
+  });
+  await page.route(`**/api/credentials/${cerebrasCredentialId}/models`, async (route) => {
+    await route.fulfill({
+      json: [
+        {
+          id: "llama-canvas",
+          name: "Llama Canvas",
+          is_reasoning: false,
+          supports_batch: false,
+          batch_support_reason: null,
+          context_window: 32768,
+        },
+        {
+          id: "zai-glm-canvas",
+          name: "ZAI GLM Canvas",
+          is_reasoning: false,
+          supports_batch: false,
+          batch_support_reason: null,
+          context_window: 65536,
+        },
+      ],
+    });
+  });
+
+  try {
+    await page.goto(`/workflows/${workflow.id}`);
+    await page.getByTitle("AI Assistant").click();
+
+    const assistantCredential = page.getByTestId("ai-assistant-credential-selector");
+    const assistantModel = page.getByTestId("ai-assistant-model-selector");
+    await expect(assistantCredential.getByRole("combobox")).toHaveValue("OpenAI Canvas");
+    await expect(assistantModel.getByRole("combobox")).toHaveValue("GPT-4o Canvas");
+    await selectSearchableOption(page, assistantCredential, "Cerebras Canvas");
+    await expect(assistantModel.getByRole("combobox")).toHaveValue("ZAI GLM Canvas");
+    await selectSearchableOption(page, assistantModel, "Llama Canvas");
+    await expect(assistantModel.getByRole("combobox")).toHaveValue("Llama Canvas");
+
+    await page.getByRole("button", { name: "Analyze", exact: true }).click();
+    const analyzerCredential = page.getByTestId("ai-analyzer-credential-selector");
+    const analyzerModel = page.getByTestId("ai-analyzer-model-selector");
+    await expect(analyzerCredential.getByRole("combobox")).toHaveValue("OpenAI Canvas");
+    await expect(analyzerModel.getByRole("combobox")).toHaveValue("GPT-4o Canvas");
+    await selectSearchableOption(page, analyzerCredential, "Cerebras Canvas");
+    await expect(analyzerModel.getByRole("combobox")).toHaveValue("ZAI GLM Canvas");
+    await selectSearchableOption(page, analyzerModel, "Llama Canvas");
+    await expect(analyzerModel.getByRole("combobox")).toHaveValue("Llama Canvas");
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});
+
 test("creates a folder and filters workflows with search", async ({ page }) => {
   const workflowName = `Searchable Workflow ${Date.now()}`;
   const folderName = `E2E Folder ${Date.now()}`;

--- a/frontend/src/components/Panels/AnalysisPanel.vue
+++ b/frontend/src/components/Panels/AnalysisPanel.vue
@@ -3,7 +3,6 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import DOMPurify from "dompurify";
 import {
   AlertTriangle,
-  ChevronDown,
   Eye,
   Loader2,
   Pencil,
@@ -14,17 +13,19 @@ import {
 import { marked } from "marked";
 import { isAxiosError } from "axios";
 
+import type { CredentialListItem, LLMModel } from "@/types/credential";
+import type { AnalysisNoteEditor, AnalysisNoteResponse } from "@/services/api";
+
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import { preserveExplicitOrderedListNumbers } from "@/lib/markdown";
 import { cn } from "@/lib/utils";
-import {
-  aiApi,
-  credentialsApi,
-  workflowApi,
-  type AnalysisNoteEditor,
-  type AnalysisNoteResponse,
-} from "@/services/api";
-import type { CredentialListItem, LLMModel } from "@/types/credential";
+import { aiApi, credentialsApi, workflowApi } from "@/services/api";
 import { useWorkflowStore } from "@/stores/workflow";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
 
 interface AnalysisWorkflowPayload {
   id?: string;
@@ -57,6 +58,18 @@ const credentials = ref<CredentialListItem[]>([]);
 const credentialId = ref("");
 const models = ref<LLMModel[]>([]);
 const model = ref("");
+const credentialOptions = computed<SelectOption[]>(() =>
+  credentials.value.map((credential) => ({
+    value: credential.id,
+    label: credential.is_shared ? `${credential.name} - shared` : credential.name,
+  })),
+);
+const modelOptions = computed<SelectOption[]>(() =>
+  models.value.map((availableModel) => ({
+    value: availableModel.id,
+    label: availableModel.name,
+  })),
+);
 
 const analyzing = ref(false);
 const running = ref(false);
@@ -142,6 +155,11 @@ async function loadModels(): Promise<void> {
   if (models.value.length > 0) {
     model.value = models.value[models.value.length - 1].id;
   }
+}
+
+function handleCredentialSelect(value: string | undefined): void {
+  credentialId.value = value ?? "";
+  void loadModels();
 }
 
 const EXECUTION_CANCELLED = "Execution cancelled";
@@ -324,47 +342,38 @@ onBeforeUnmount(() => {
     <template v-else>
       <div class="px-4 py-2 border-b border-border/40 space-y-2 shrink-0">
         <div class="flex items-center gap-2">
-          <div class="relative flex-1 min-w-0">
-            <select
-              v-model="credentialId"
-              class="h-9 w-full min-w-0 truncate rounded-md border border-border bg-background pl-2.5 pr-9 text-sm appearance-none cursor-pointer"
+          <div
+            class="flex-1 min-w-0"
+            data-testid="ai-analyzer-credential-selector"
+          >
+            <SearchableSelect
+              id="ai-analyzer-credential-select"
+              :model-value="credentialId"
+              :options="credentialOptions"
+              :placeholder="credentials.length === 0 ? 'No LLM credential' : 'Select credential...'"
+              search-placeholder="Search credentials..."
+              empty-text="No credentials found."
               :disabled="analyzing"
-              @change="loadModels"
-            >
-              <option
-                v-if="credentials.length === 0"
-                value=""
-              >
-                No LLM credential
-              </option>
-              <option
-                v-for="c in credentials"
-                :key="c.id"
-                :value="c.id"
-              >
-                {{ c.name }}
-              </option>
-            </select>
-            <ChevronDown
-              class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 shrink-0 text-muted-foreground"
+              select-class="h-9 min-h-0 rounded-md border-border bg-background shadow-none"
+              content-class="z-[70]"
+              @update:model-value="handleCredentialSelect"
             />
           </div>
-          <div class="relative flex-1 min-w-0">
-            <select
-              v-model="model"
-              class="h-9 w-full min-w-0 truncate rounded-md border border-border bg-background pl-2.5 pr-9 text-sm appearance-none cursor-pointer disabled:opacity-50"
+          <div
+            class="flex-1 min-w-0"
+            data-testid="ai-analyzer-model-selector"
+          >
+            <SearchableSelect
+              id="ai-analyzer-model-select"
+              :model-value="model"
+              :options="modelOptions"
+              placeholder="Select model..."
+              search-placeholder="Search models..."
+              empty-text="No models found."
               :disabled="analyzing || models.length === 0"
-            >
-              <option
-                v-for="m in models"
-                :key="m.id"
-                :value="m.id"
-              >
-                {{ m.name }}
-              </option>
-            </select>
-            <ChevronDown
-              class="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 shrink-0 text-muted-foreground"
+              select-class="h-9 min-h-0 rounded-md border-border bg-background shadow-none"
+              content-class="z-[70]"
+              @update:model-value="model = $event ?? ''"
             />
           </div>
         </div>

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -22,6 +22,7 @@ import Button from "@/components/ui/Button.vue";
 import ClarifyCard from "@/components/ui/ClarifyCard.vue";
 import Dialog from "@/components/ui/Dialog.vue";
 import JsonTree from "@/components/ui/JsonTree.vue";
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Textarea from "@/components/ui/Textarea.vue";
 import type { ClarifyAnswer, ClarifyQuestion } from "@/types/clarify";
 import {
@@ -1259,6 +1260,11 @@ interface ChatMessage {
   clarifyAnswered?: boolean;
 }
 
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
 interface SpeechRecognitionResultAlternative {
   transcript: string;
 }
@@ -1306,6 +1312,18 @@ const aiModels = ref<LLMModel[]>([]);
 const selectedCredentialId = ref("");
 const selectedModel = ref("");
 const loadingModels = ref(false);
+const aiCredentialOptions = computed<SelectOption[]>(() =>
+  aiCredentials.value.map((credential) => ({
+    value: credential.id,
+    label: credential.is_shared ? `${credential.name} - shared` : credential.name,
+  })),
+);
+const aiModelOptions = computed<SelectOption[]>(() =>
+  aiModels.value.map((model) => ({
+    value: model.id,
+    label: model.name,
+  })),
+);
 
 const aiMessages = ref<ChatMessage[]>([]);
 const aiInputMessage = ref("");
@@ -3419,51 +3437,43 @@ function renderContent(content: string): string {
         <div class="ai-panel-config">
           <div class="config-row">
             <label class="config-label">Credential</label>
-            <select
-              v-model="selectedCredentialId"
-              class="config-select"
-              :title="aiCredentials.find(c => c.id === selectedCredentialId)?.name || ''"
+            <div
+              class="flex-1 min-w-0"
+              data-testid="ai-assistant-credential-selector"
             >
-              <option
-                value=""
-                disabled
-              >
-                Select...
-              </option>
-              <option
-                v-for="cred in aiCredentials"
-                :key="cred.id"
-                :value="cred.id"
-                :title="cred.is_shared ? `${cred.name} - shared` : cred.name"
-              >
-                {{ cred.is_shared ? `${cred.name} - shared` : cred.name }}
-              </option>
-            </select>
+              <SearchableSelect
+                id="ai-assistant-credential-select"
+                :model-value="selectedCredentialId"
+                :options="aiCredentialOptions"
+                placeholder="Select..."
+                search-placeholder="Search credentials..."
+                empty-text="No credentials found."
+                select-class="h-8 min-h-0 rounded-md border-border bg-background shadow-none"
+                content-class="z-[110]"
+                @update:model-value="selectedCredentialId = $event ?? ''"
+              />
+            </div>
           </div>
 
           <div class="config-row">
             <label class="config-label">Model</label>
-            <select
-              v-model="selectedModel"
-              :disabled="!selectedCredentialId || loadingModels"
-              class="config-select"
-              :title="aiModels.find(m => m.id === selectedModel)?.name || ''"
+            <div
+              class="flex-1 min-w-0"
+              data-testid="ai-assistant-model-selector"
             >
-              <option
-                value=""
-                disabled
-              >
-                {{ loadingModels ? "Loading..." : "Select..." }}
-              </option>
-              <option
-                v-for="model in aiModels"
-                :key="model.id"
-                :value="model.id"
-                :title="model.name"
-              >
-                {{ model.name }}
-              </option>
-            </select>
+              <SearchableSelect
+                id="ai-assistant-model-select"
+                :model-value="selectedModel"
+                :options="aiModelOptions"
+                :placeholder="loadingModels ? 'Loading...' : 'Select...'"
+                search-placeholder="Search models..."
+                empty-text="No models found."
+                :disabled="!selectedCredentialId || loadingModels"
+                select-class="h-8 min-h-0 rounded-md border-border bg-background shadow-none"
+                content-class="z-[110]"
+                @update:model-value="selectedModel = $event ?? ''"
+              />
+            </div>
           </div>
         </div>
 
@@ -3803,46 +3813,10 @@ function renderContent(content: string): string {
   flex-shrink: 0;
 }
 
-.config-row .config-select {
-  flex: 1;
-  min-width: 0;
-}
-
 .config-label {
   font-size: 12px;
   color: hsl(var(--muted-foreground));
   white-space: nowrap;
-}
-
-.config-select {
-  height: 32px;
-  padding: 0 10px;
-  border: 1px solid hsl(var(--border));
-  border-radius: 6px;
-  background: hsl(var(--background));
-  color: hsl(var(--foreground));
-  font-size: 13px;
-  cursor: pointer;
-  appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 8px center;
-  padding-right: 28px;
-  min-width: 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-
-.config-select:focus {
-  outline: none;
-  border-color: hsl(var(--primary));
-  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.15);
-}
-
-.config-select:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .ai-messages {


### PR DESCRIPTION
## Summary
- use searchable credential and model dropdowns in AI Assistant
- use searchable credential and model dropdowns in Workflow Analyzer
- add Playwright coverage for filtering and selection
- ensure Assistant menus render above its fixed panel

## Validation
- `npm run lint:check`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run typecheck`
- mocked Chromium visual and interaction check
- Playwright test discovery

## Screenshots

![pr-351-ai-analyzer-searchable-dropdown.png](https://github.com/heymrun/heym/releases/download/codex-pr-assets/pr-351-ai-analyzer-searchable-dropdown.png)

![pr-351-ai-assistant-searchable-dropdown-1.png](https://github.com/heymrun/heym/releases/download/codex-pr-assets/pr-351-ai-assistant-searchable-dropdown-1.png)
