### PR TITLE
Done.

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -391,7 +391,13 @@ const isMac = computed((): boolean => {
 });
 
 const searchShortcutLabel = computed((): string => {
+  if (isMobile.value) return "";
   return isMac.value ? "⌘F" : "Ctrl+F";
+});
+
+const searchPlaceholder = computed((): string => {
+  const label = searchShortcutLabel.value;
+  return label ? `Search workflows (${label})` : "Search workflows";
 });
 
 function isFolderExpandedForDisplay(folderId: string): boolean {
@@ -1494,7 +1500,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                     type="text"
                     autocomplete="off"
                     class="h-11 min-h-[44px] md:h-9 w-full rounded-xl border border-border bg-background px-9 py-2 text-sm shadow-sm transition-all duration-200 placeholder:text-muted-foreground/60 hover:border-border/80 focus-visible:outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
-                    :placeholder="`Search workflows (${searchShortcutLabel})`"
+                    :placeholder="searchPlaceholder"
                     @keydown.esc.prevent.stop="clearWorkflowSearch"
                   >
                   <button


### PR DESCRIPTION
Done. Here's a summary of the changes made to `frontend/src/views/DashboardView.vue`:

1. **`searchShortcutLabel` computed** (line 393-396): Added `if (isMobile.value) return "";` guard so it returns an empty string on mobile viewports (max-width: 767px), preserving `"⌘F"` / `"Ctrl+F"` on desktop.

2. **`searchPlaceholder` computed** (line 398-401): New computed property that builds the full placeholder string, only including the shortcut in parentheses when a label is present — shows `"Search workflows"` on mobile and `"Search workflows (Ctrl+F)"` on desktop.

3. **Template** (line 1503): Changed `:placeholder` from the inline template literal to the new `searchPlaceholder` computed property.

Screenshot saved to `frontend/.e2e-artifacts/workflow-list-mobile-search-placeholder.png`.

## Screenshots

![pr-358-workflow-list-mobile-search-placeholder.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-358-workflow-list-mobile-search-placeholder.png)
