### PR TITLE
Fix mobile kanban dialog back and card dragging

### DIFF
--- a/frontend/e2e/tab-board.spec.ts
+++ b/frontend/e2e/tab-board.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 import {
   createWorkflow,
@@ -25,6 +25,15 @@ const DEFAULT_COLUMNS = ["Backlog", "Planning", "Development", "Done"];
 type ApiColumn = { id: string; name: string };
 type ApiCard = { id: string; column_id: string; run_status: string };
 
+interface BoardSetupOptions {
+  mapperCredentialId?: string;
+}
+
+interface TouchPoint {
+  x: number;
+  y: number;
+}
+
 /** The board dialogs require an Agentic Kanban Model, so the account needs a credential the
  *  API accepts as its own (the models come from the provider catalog, no provider call). */
 async function setUpMapperCredential(page: Page): Promise<string> {
@@ -48,8 +57,17 @@ async function pickMapperModel(page: Page): Promise<void> {
 async function createBoardWithCard(
   page: Page,
   title: string,
+  options?: BoardSetupOptions,
 ): Promise<{ boardId: string; cardId: string; columns: ApiColumn[] }> {
-  const board = await (await page.request.post("/api/boards", { data: { name: "Test" } })).json();
+  const board = await (
+    await page.request.post("/api/boards", {
+      data: {
+        name: "Test",
+        mapper_model: options?.mapperCredentialId ? "gpt-4o" : undefined,
+        mapper_credential_id: options?.mapperCredentialId,
+      },
+    })
+  ).json();
   const state = await (await page.request.get(`/api/boards/${board.id}`)).json();
   const columns: ApiColumn[] = state.columns;
   const backlog = columns.find((c) => c.name === "Backlog")!;
@@ -59,6 +77,36 @@ async function createBoardWithCard(
     })
   ).json();
   return { boardId: board.id, cardId: card.id, columns };
+}
+
+async function dispatchSingleTouch(
+  target: Locator,
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  point: TouchPoint,
+): Promise<void> {
+  await target.evaluate(
+    (element, eventInit) => {
+      const touch = new Touch({
+        identifier: 1,
+        target: element,
+        clientX: eventInit.x,
+        clientY: eventInit.y,
+        screenX: eventInit.x,
+        screenY: eventInit.y,
+      });
+      const ended = eventInit.type === "touchend" || eventInit.type === "touchcancel";
+      element.dispatchEvent(
+        new TouchEvent(eventInit.type, {
+          bubbles: true,
+          cancelable: true,
+          touches: ended ? [] : [touch],
+          targetTouches: ended ? [] : [touch],
+          changedTouches: [touch],
+        }),
+      );
+    },
+    { type, ...point },
+  );
 }
 
 /** Poll the board until the card settles, returning its final column and status. */
@@ -311,6 +359,116 @@ test("fits board controls and lanes within a mobile viewport", async ({ page }) 
     return element.scrollLeft;
   });
   expect(scrollLeft).toBeGreaterThan(0);
+});
+
+test("mobile Back closes card detail without leaving the board", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const { boardId, cardId } = await createBoardWithCard(page, "Mobile detail");
+  await page.goto(`/?tab=board&board=${boardId}`);
+  const boardUrl = page.url();
+
+  await page.getByTestId(`board-card-${cardId}`).click();
+  await expect(page.getByPlaceholder("Describe the job for this card")).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => window.history.state?.heymDialog ?? null))
+    .not.toBeNull();
+
+  await page.evaluate(() => window.history.back());
+  await expect(page.getByPlaceholder("Describe the job for this card")).not.toBeVisible();
+  expect(page.url()).toBe(boardUrl);
+
+  // A normal close consumes the synthetic entry too, so the next Back is never wasted.
+  await page.getByTestId(`board-card-${cardId}`).click();
+  await expect(page.getByPlaceholder("Describe the job for this card")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByPlaceholder("Describe the job for this card")).not.toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => window.history.state?.heymDialog ?? null))
+    .toBeNull();
+  expect(page.url()).toBe(boardUrl);
+});
+
+test("drags a card between columns with touch and shows drop feedback", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mapperCredentialId = await setUpMapperCredential(page);
+  const { boardId, cardId, columns } = await createBoardWithCard(page, "Touch move", {
+    mapperCredentialId,
+  });
+  const planning = columns.find((column) => column.name === "Planning")!;
+  await page.goto(`/?tab=board&board=${boardId}`);
+
+  const card = page.getByTestId(`board-card-${cardId}`);
+  const cardBox = await card.boundingBox();
+  expect(cardBox).not.toBeNull();
+  const start = {
+    x: cardBox!.x + cardBox!.width / 2,
+    y: cardBox!.y + cardBox!.height / 2,
+  };
+  await dispatchSingleTouch(card, "touchstart", start);
+  await page.waitForTimeout(350);
+  await expect(card).toHaveAttribute("aria-grabbed", "true");
+
+  await dispatchSingleTouch(card, "touchcancel", start);
+  await expect(card).toHaveAttribute("aria-grabbed", "false");
+  await expect(page.getByTestId("board-column-Backlog")).not.toHaveAttribute(
+    "data-touch-drag-over",
+    "true",
+  );
+  await dispatchSingleTouch(card, "touchstart", start);
+  await page.waitForTimeout(350);
+  await expect(card).toHaveAttribute("aria-grabbed", "true");
+
+  // Holding near the edge scrolls the horizontal board until the next lane is reachable.
+  for (let index = 0; index < 20; index += 1) {
+    await dispatchSingleTouch(card, "touchmove", { x: 385, y: start.y });
+  }
+  const canvasScroll = await page.getByTestId("board-canvas").evaluate((element) =>
+    element.scrollLeft
+  );
+  expect(canvasScroll).toBeGreaterThan(0);
+
+  const planningLane = page.getByTestId("board-column-Planning");
+  const planningBox = await planningLane.boundingBox();
+  expect(planningBox).not.toBeNull();
+  const destination = {
+    x: Math.max(20, Math.min(370, planningBox!.x + planningBox!.width / 2)),
+    y: planningBox!.y + Math.min(140, planningBox!.height / 2),
+  };
+  await dispatchSingleTouch(card, "touchmove", destination);
+  await expect(planningLane).toHaveAttribute("data-touch-drag-over", "true");
+  await page.screenshot({ path: ".e2e-artifacts/mobile-kanban-touch-drag.png" });
+
+  await dispatchSingleTouch(card, "touchend", destination);
+  await expect(planningLane.getByTestId(`board-card-${cardId}`)).toBeVisible();
+  await expect(page.getByPlaceholder("Describe the job for this card")).toHaveCount(0);
+  await expect
+    .poll(async () => {
+      const state = await (await page.request.get(`/api/boards/${boardId}`)).json();
+      return (state.cards as ApiCard[]).find((entry) => entry.id === cardId)?.column_id;
+    })
+    .toBe(planning.id);
+});
+
+test("keeps desktop card drag and drop working", async ({ page }) => {
+  const mapperCredentialId = await setUpMapperCredential(page);
+  const { boardId, cardId, columns } = await createBoardWithCard(page, "Desktop move", {
+    mapperCredentialId,
+  });
+  const planning = columns.find((column) => column.name === "Planning")!;
+  await page.goto(`/?tab=board&board=${boardId}`);
+
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+  await page.getByTestId(`board-card-${cardId}`).dispatchEvent("dragstart", { dataTransfer });
+  await page.getByTestId("board-column-Planning").dispatchEvent("drop", { dataTransfer });
+
+  await expect(page.getByTestId("board-column-Planning").getByTestId(`board-card-${cardId}`))
+    .toBeVisible();
+  await expect
+    .poll(async () => {
+      const state = await (await page.request.get(`/api/boards/${boardId}`)).json();
+      return (state.cards as ApiCard[]).find((entry) => entry.id === cardId)?.column_id;
+    })
+    .toBe(planning.id);
 });
 
 test("moves a card to the top whenever it is updated", async ({ page }) => {

--- a/frontend/e2e/tab-board.spec.ts
+++ b/frontend/e2e/tab-board.spec.ts
@@ -35,12 +35,20 @@ interface TouchPoint {
 }
 
 /** The board dialogs require an Agentic Kanban Model, so the account needs a credential the
- *  API accepts as its own (the models come from the provider catalog, no provider call). */
+ *  API accepts as its own (the models come from the provider catalog, no provider call).
+ *  Credential names are unique per user, so reuse an existing Board model across serial tests. */
 async function setUpMapperCredential(page: Page): Promise<string> {
+  const listResponse = await page.request.get("/api/credentials");
+  expect(listResponse.ok()).toBeTruthy();
+  const existing = (await listResponse.json()) as Array<{ id: string; name: string; type: string }>;
+  const found = existing.find((credential) => credential.name === "Board model");
+  if (found) return found.id;
+
   const response = await page.request.post("/api/credentials", {
     data: { name: "Board model", type: "openai", config: { api_key: "sk-board-e2e" } },
   });
-  const credential = await response.json();
+  expect(response.ok()).toBeTruthy();
+  const credential = (await response.json()) as { id: string };
   return credential.id;
 }
 
@@ -59,23 +67,33 @@ async function createBoardWithCard(
   title: string,
   options?: BoardSetupOptions,
 ): Promise<{ boardId: string; cardId: string; columns: ApiColumn[] }> {
-  const board = await (
-    await page.request.post("/api/boards", {
-      data: {
-        name: "Test",
-        mapper_model: options?.mapperCredentialId ? "gpt-4o" : undefined,
-        mapper_credential_id: options?.mapperCredentialId,
-      },
-    })
-  ).json();
-  const state = await (await page.request.get(`/api/boards/${board.id}`)).json();
+  const createResponse = await page.request.post("/api/boards", {
+    data: {
+      name: "Test",
+      mapper_model: options?.mapperCredentialId ? "gpt-4o" : undefined,
+      mapper_credential_id: options?.mapperCredentialId,
+    },
+  });
+  expect(createResponse.ok()).toBeTruthy();
+  const board = (await createResponse.json()) as { id: string };
+  const stateResponse = await page.request.get(`/api/boards/${board.id}`);
+  expect(stateResponse.ok()).toBeTruthy();
+  const state = (await stateResponse.json()) as {
+    columns: ApiColumn[];
+    mapper_model: string | null;
+    mapper_credential_id: string | null;
+  };
+  if (options?.mapperCredentialId) {
+    expect(state.mapper_credential_id).toBe(options.mapperCredentialId);
+    expect(state.mapper_model).toBe("gpt-4o");
+  }
   const columns: ApiColumn[] = state.columns;
   const backlog = columns.find((c) => c.name === "Backlog")!;
-  const card = await (
-    await page.request.post(`/api/boards/${board.id}/cards`, {
-      data: { title, column_id: backlog.id },
-    })
-  ).json();
+  const cardResponse = await page.request.post(`/api/boards/${board.id}/cards`, {
+    data: { title, column_id: backlog.id },
+  });
+  expect(cardResponse.ok()).toBeTruthy();
+  const card = (await cardResponse.json()) as { id: string };
   return { boardId: board.id, cardId: card.id, columns };
 }
 
@@ -398,6 +416,8 @@ test("drags a card between columns with touch and shows drop feedback", async ({
   await page.goto(`/?tab=board&board=${boardId}`);
 
   const card = page.getByTestId(`board-card-${cardId}`);
+  // Touch drag is gated on the Agentic Kanban Model; wait until the card is actionable.
+  await expect(card).toHaveAttribute("draggable", "true");
   const cardBox = await card.boundingBox();
   expect(cardBox).not.toBeNull();
   const start = {

--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -268,9 +268,11 @@ async function copyRun(run: CardRun): Promise<void> {
   }
 }
 
-function openLiveRun(run: CardRun): void {
+async function openLiveRun(run: CardRun): Promise<void> {
   if (!run.workflow_id || !run.active_execution_id) return;
-  void router.push({
+  // Replace the dialog's same-URL history entry with the editor route. This leaves the
+  // board directly behind the editor and avoids racing the dialog's close cleanup.
+  await router.replace({
     name: "editor",
     params: {
       id: run.workflow_id,
@@ -285,6 +287,7 @@ function openLiveRun(run: CardRun): void {
   <Dialog
     :open="open"
     :title="detail?.card.title ?? 'Card'"
+    close-on-back
     @close="emit('close')"
   >
     <template

--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -270,8 +270,9 @@ async function copyRun(run: CardRun): Promise<void> {
 
 async function openLiveRun(run: CardRun): Promise<void> {
   if (!run.workflow_id || !run.active_execution_id) return;
-  // Replace the dialog's same-URL history entry with the editor route. This leaves the
-  // board directly behind the editor and avoids racing the dialog's close cleanup.
+  // Replace the dialog history entry with the editor route so Back returns to the board.
+  // Dialog unmount must not history.back() after this — useDialogBackHistory skips rewind
+  // when the URL has already left the dialog entry.
   await router.replace({
     name: "editor",
     params: {

--- a/frontend/src/components/Board/BoardCardItem.vue
+++ b/frontend/src/components/Board/BoardCardItem.vue
@@ -12,6 +12,7 @@ import {
 } from "lucide-vue-next";
 
 import type { BoardCard } from "@/types/board";
+import { useBoardCardTouchDrag } from "@/composables/useBoardCardTouchDrag";
 import { useToast } from "@/composables/useToast";
 import { useBoardStore } from "@/stores/board";
 
@@ -30,8 +31,19 @@ const emit = defineEmits<{
 const editingTitle = ref(false);
 const editedTitle = ref(props.card.title);
 const titleInput = ref<HTMLTextAreaElement | null>(null);
+const cardElement = ref<HTMLElement | null>(null);
 const savingTitle = ref(false);
 let titleClickTimer: ReturnType<typeof setTimeout> | null = null;
+
+const {
+  handlers: touchDragHandlers,
+  isTouchDragging,
+  consumeTouchDragClick,
+} = useBoardCardTouchDrag({
+  cardId: () => props.card.id,
+  enabled: () => canAct.value && !editingTitle.value,
+  sourceElement: cardElement,
+});
 
 watch(
   () => props.card.title,
@@ -52,6 +64,7 @@ async function startTitleEdit(): Promise<void> {
 }
 
 function onTitleClick(): void {
+  if (consumeTouchDragClick()) return;
   if (titleClickTimer) clearTimeout(titleClickTimer);
   titleClickTimer = setTimeout(() => {
     titleClickTimer = null;
@@ -121,19 +134,37 @@ const attachmentCount = computed<number>(() => {
 });
 
 function onDragStart(event: DragEvent): void {
+  if (isTouchDragging.value) {
+    event.preventDefault();
+    return;
+  }
   event.dataTransfer?.setData("text/board-card", props.card.id);
   if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+}
+
+function onCardClick(): void {
+  if (consumeTouchDragClick()) return;
+  emit("open", props.card.id);
 }
 </script>
 
 <template>
   <div
+    ref="cardElement"
     class="group min-w-0 cursor-pointer rounded-lg border p-2.5 text-sm shadow-sm transition-colors hover:border-primary/60 sm:p-3"
-    :class="statusClasses"
+    :class="[
+      statusClasses,
+      isTouchDragging ? 'select-none scale-[0.98] opacity-60 ring-2 ring-primary/70' : '',
+    ]"
     :draggable="canAct && !editingTitle"
+    :aria-grabbed="isTouchDragging"
     :data-testid="`board-card-${card.id}`"
     @dragstart="onDragStart"
-    @click="emit('open', card.id)"
+    @touchstart="touchDragHandlers.onTouchStart"
+    @touchmove="touchDragHandlers.onTouchMove"
+    @touchend="touchDragHandlers.onTouchEnd"
+    @touchcancel="touchDragHandlers.onTouchCancel"
+    @click="onCardClick"
   >
     <div class="flex items-start justify-between gap-2">
       <div class="min-w-0 flex-1">

--- a/frontend/src/components/Board/BoardColumnLane.vue
+++ b/frontend/src/components/Board/BoardColumnLane.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { GripVertical, Plus, Settings2, Trash2, Workflow } from "lucide-vue-next";
 
 import type { BoardCard, BoardColumn } from "@/types/board";
+import {
+  BOARD_CARD_TOUCH_DRAG_EVENT,
+  type BoardCardTouchDragDetail,
+} from "@/composables/useBoardCardTouchDrag";
 import { useBoardStore } from "@/stores/board";
 import BoardCardItem from "./BoardCardItem.vue";
 
@@ -17,8 +21,10 @@ const emit = defineEmits<{
 
 const boardStore = useBoardStore();
 const dragOver = ref(false);
+const touchDragOver = ref(false);
 const columnDragOver = ref(false);
 const newCardTitle = ref("");
+const lane = ref<HTMLElement | null>(null);
 const laneBody = ref<HTMLElement | null>(null);
 
 const cards = computed<BoardCard[]>(() => boardStore.cardsByColumn[props.column.id] ?? []);
@@ -27,16 +33,53 @@ const canAct = computed<boolean>(() => boardStore.mapperConfigured && boardStore
 // Reordering columns runs nothing, so it only needs write access to the board.
 const canReorder = computed<boolean>(() => boardStore.canWrite);
 
-function dropIndexFromPointer(event: DragEvent): number {
+function dropIndexFromClientY(clientY: number): number {
   const container = laneBody.value;
   if (!container) return cards.value.length;
   const cardEls = Array.from(container.querySelectorAll<HTMLElement>("[data-board-card]"));
   for (let i = 0; i < cardEls.length; i += 1) {
     const rect = cardEls[i].getBoundingClientRect();
-    if (event.clientY < rect.top + rect.height / 2) return i;
+    if (clientY < rect.top + rect.height / 2) return i;
   }
   return cardEls.length;
 }
+
+function containsPoint(clientX: number, clientY: number): boolean {
+  const rect = lane.value?.getBoundingClientRect();
+  if (!rect) return false;
+  return (
+    clientX >= rect.left &&
+    clientX <= rect.right &&
+    clientY >= rect.top &&
+    clientY <= rect.bottom
+  );
+}
+
+function onCardTouchDrag(event: Event): void {
+  const detail = (event as CustomEvent<BoardCardTouchDragDetail>).detail;
+  if (detail.phase === "cancel") {
+    touchDragOver.value = false;
+    return;
+  }
+
+  const isOverLane = canAct.value && containsPoint(detail.clientX, detail.clientY);
+  touchDragOver.value = detail.phase !== "end" && isOverLane;
+  if (detail.phase === "end" && isOverLane) {
+    void boardStore.moveCard(
+      detail.cardId,
+      props.column.id,
+      dropIndexFromClientY(detail.clientY),
+    );
+  }
+}
+
+onMounted(() => {
+  window.addEventListener(BOARD_CARD_TOUCH_DRAG_EVENT, onCardTouchDrag);
+});
+
+onUnmounted(() => {
+  window.removeEventListener(BOARD_CARD_TOUCH_DRAG_EVENT, onCardTouchDrag);
+});
 
 // A lane accepts two kinds of drag: a card (dropped into this column) and another column
 // (dropped at this column's place). Only the data *type* is readable during dragover.
@@ -81,7 +124,7 @@ function onDrop(event: DragEvent): void {
   if (!canAct.value) return;
   const cardId = event.dataTransfer?.getData("text/board-card");
   if (!cardId) return;
-  void boardStore.moveCard(cardId, props.column.id, dropIndexFromPointer(event));
+  void boardStore.moveCard(cardId, props.column.id, dropIndexFromClientY(event.clientY));
 }
 
 async function addCard(): Promise<void> {
@@ -106,11 +149,14 @@ async function emptyColumn(): Promise<void> {
 
 <template>
   <div
+    ref="lane"
     class="flex h-full min-h-0 w-[calc(100vw-2.5rem)] max-w-[18rem] shrink-0 flex-col overflow-hidden rounded-xl border border-border/60 bg-muted/30 md:w-72"
     :class="[
       dragOver ? 'ring-2 ring-primary/50' : '',
+      touchDragOver ? 'bg-primary/5 ring-2 ring-primary/80' : '',
       columnDragOver ? 'ring-2 ring-primary' : '',
     ]"
+    :data-touch-drag-over="touchDragOver ? 'true' : undefined"
     :data-testid="`board-column-${column.name}`"
     @dragover="onDragOver"
     @dragleave="onDragLeave"

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -2,6 +2,8 @@
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 import { Maximize2, Minimize2, X } from "lucide-vue-next";
 
+import { useDialogBackHistory } from "@/composables/useDialogBackHistory";
+
 interface Props {
   open: boolean;
   title?: string;
@@ -9,6 +11,7 @@ interface Props {
   allowFullscreen?: boolean;
   defaultFullscreen?: boolean;
   closeOnEscape?: boolean;
+  closeOnBack?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -17,6 +20,7 @@ const props = withDefaults(defineProps<Props>(), {
   allowFullscreen: false,
   defaultFullscreen: false,
   closeOnEscape: true,
+  closeOnBack: false,
 });
 
 const isFullscreen = ref(props.defaultFullscreen);
@@ -44,6 +48,11 @@ const emit = defineEmits<{
 }>();
 
 const containerRef = ref<HTMLDivElement | null>(null);
+const { pushDialogHistoryEntry, removeDialogHistoryEntry } = useDialogBackHistory({
+  enabled: () => props.closeOnBack,
+  isOpen: () => props.open,
+  onBack: () => emit("close"),
+});
 
 function handleEscape(event: KeyboardEvent): void {
   if (event.key === "Escape") {
@@ -73,6 +82,7 @@ watch(
       document.body.style.overflow = "hidden";
       isFullscreen.value = props.defaultFullscreen;
       window.addEventListener("keydown", handleEscape, captureOptions);
+      pushDialogHistoryEntry();
       nextTick(() => {
         containerRef.value?.focus();
       });
@@ -80,6 +90,7 @@ watch(
       document.body.style.overflow = "";
       isFullscreen.value = props.defaultFullscreen;
       window.removeEventListener("keydown", handleEscape, captureOptions);
+      removeDialogHistoryEntry();
     }
   },
   { immediate: true },
@@ -87,6 +98,7 @@ watch(
 
 onUnmounted(() => {
   window.removeEventListener("keydown", handleEscape, captureOptions);
+  removeDialogHistoryEntry();
 });
 
 function toggleFullscreen(): void {

--- a/frontend/src/composables/useBoardCardTouchDrag.ts
+++ b/frontend/src/composables/useBoardCardTouchDrag.ts
@@ -1,0 +1,212 @@
+import { onUnmounted, ref } from "vue";
+import type { Ref } from "vue";
+
+export const BOARD_CARD_TOUCH_DRAG_EVENT = "heym:board-card-touch-drag";
+
+export type BoardCardTouchDragPhase = "start" | "move" | "end" | "cancel";
+
+export interface BoardCardTouchDragDetail {
+  phase: BoardCardTouchDragPhase;
+  cardId: string;
+  clientX: number;
+  clientY: number;
+}
+
+interface UseBoardCardTouchDragOptions {
+  cardId: () => string;
+  enabled: () => boolean;
+  sourceElement: Ref<HTMLElement | null>;
+}
+
+interface TouchPoint {
+  clientX: number;
+  clientY: number;
+}
+
+interface BoardCardTouchDragHandlers {
+  onTouchStart: (event: TouchEvent) => void;
+  onTouchMove: (event: TouchEvent) => void;
+  onTouchEnd: (event: TouchEvent) => void;
+  onTouchCancel: (event: TouchEvent) => void;
+}
+
+interface UseBoardCardTouchDragResult {
+  handlers: BoardCardTouchDragHandlers;
+  isTouchDragging: Ref<boolean>;
+  consumeTouchDragClick: () => boolean;
+}
+
+const LONG_PRESS_MS = 300;
+const MOVE_TOLERANCE_PX = 10;
+const EDGE_SCROLL_ZONE_PX = 48;
+const EDGE_SCROLL_STEP_PX = 18;
+const CLICK_SUPPRESSION_MS = 700;
+const captureOptions = { capture: true };
+
+function findTouch(touches: TouchList, identifier: number): Touch | null {
+  for (let index = 0; index < touches.length; index += 1) {
+    const touch = touches.item(index);
+    if (touch?.identifier === identifier) return touch;
+  }
+  return null;
+}
+
+export function useBoardCardTouchDrag(
+  options: UseBoardCardTouchDragOptions,
+): UseBoardCardTouchDragResult {
+  const isTouchDragging = ref(false);
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+  let touchIdentifier: number | null = null;
+  let startPoint: TouchPoint | null = null;
+  let latestPoint: TouchPoint | null = null;
+  let suppressClickUntil = 0;
+
+  function clearLongPressTimer(): void {
+    if (longPressTimer === null) return;
+    clearTimeout(longPressTimer);
+    longPressTimer = null;
+  }
+
+  function dispatchTouchDrag(phase: BoardCardTouchDragPhase, point: TouchPoint): void {
+    window.dispatchEvent(
+      new CustomEvent<BoardCardTouchDragDetail>(BOARD_CARD_TOUCH_DRAG_EVENT, {
+        detail: {
+          phase,
+          cardId: options.cardId(),
+          clientX: point.clientX,
+          clientY: point.clientY,
+        },
+      }),
+    );
+  }
+
+  function resetGesture(): void {
+    clearLongPressTimer();
+    window.removeEventListener("touchstart", onAdditionalTouchStart, captureOptions);
+    isTouchDragging.value = false;
+    touchIdentifier = null;
+    startPoint = null;
+    latestPoint = null;
+  }
+
+  function cancelGesture(): void {
+    if (isTouchDragging.value && latestPoint) {
+      dispatchTouchDrag("cancel", latestPoint);
+      suppressClickUntil = Date.now() + CLICK_SUPPRESSION_MS;
+    }
+    resetGesture();
+  }
+
+  function scrollBoardAtEdge(point: TouchPoint): void {
+    const canvas = options.sourceElement.value?.closest<HTMLElement>("[data-testid='board-canvas']");
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    if (point.clientX < rect.left + EDGE_SCROLL_ZONE_PX) {
+      canvas.scrollLeft -= EDGE_SCROLL_STEP_PX;
+    } else if (point.clientX > rect.right - EDGE_SCROLL_ZONE_PX) {
+      canvas.scrollLeft += EDGE_SCROLL_STEP_PX;
+    }
+  }
+
+  function onAdditionalTouchStart(event: TouchEvent): void {
+    if (touchIdentifier !== null && event.touches.length !== 1) cancelGesture();
+  }
+
+  function onTouchStart(event: TouchEvent): void {
+    if (!options.enabled() || event.touches.length !== 1) {
+      cancelGesture();
+      return;
+    }
+    const target = event.target;
+    if (
+      target instanceof Element &&
+      target.closest("button, input, textarea, a, select, [contenteditable='true']")
+    ) {
+      return;
+    }
+    const touch = event.touches.item(0);
+    if (!touch) return;
+
+    cancelGesture();
+    touchIdentifier = touch.identifier;
+    startPoint = { clientX: touch.clientX, clientY: touch.clientY };
+    latestPoint = startPoint;
+    window.addEventListener("touchstart", onAdditionalTouchStart, captureOptions);
+    longPressTimer = setTimeout(() => {
+      longPressTimer = null;
+      if (!options.enabled() || touchIdentifier === null || !latestPoint) {
+        resetGesture();
+        return;
+      }
+      isTouchDragging.value = true;
+      suppressClickUntil = Number.POSITIVE_INFINITY;
+      dispatchTouchDrag("start", latestPoint);
+    }, LONG_PRESS_MS);
+  }
+
+  function onTouchMove(event: TouchEvent): void {
+    if (touchIdentifier === null || !startPoint) return;
+    if (event.touches.length !== 1) {
+      cancelGesture();
+      return;
+    }
+    const touch = findTouch(event.touches, touchIdentifier);
+    if (!touch) {
+      cancelGesture();
+      return;
+    }
+
+    const point = { clientX: touch.clientX, clientY: touch.clientY };
+    latestPoint = point;
+    if (!isTouchDragging.value) {
+      const distance = Math.hypot(
+        point.clientX - startPoint.clientX,
+        point.clientY - startPoint.clientY,
+      );
+      if (distance > MOVE_TOLERANCE_PX) resetGesture();
+      return;
+    }
+
+    if (event.cancelable) event.preventDefault();
+    scrollBoardAtEdge(point);
+    dispatchTouchDrag("move", point);
+  }
+
+  function onTouchEnd(event: TouchEvent): void {
+    if (touchIdentifier === null) return;
+    const touch = findTouch(event.changedTouches, touchIdentifier);
+    if (!isTouchDragging.value) {
+      resetGesture();
+      return;
+    }
+    if (!touch) {
+      cancelGesture();
+      return;
+    }
+
+    if (event.cancelable) event.preventDefault();
+    event.stopPropagation();
+    const point = { clientX: touch.clientX, clientY: touch.clientY };
+    dispatchTouchDrag("end", point);
+    suppressClickUntil = Date.now() + CLICK_SUPPRESSION_MS;
+    resetGesture();
+  }
+
+  function onTouchCancel(_event: TouchEvent): void {
+    cancelGesture();
+  }
+
+  function consumeTouchDragClick(): boolean {
+    if (Date.now() > suppressClickUntil) return false;
+    suppressClickUntil = 0;
+    return true;
+  }
+
+  onUnmounted(cancelGesture);
+
+  return {
+    handlers: { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel },
+    isTouchDragging,
+    consumeTouchDragClick,
+  };
+}

--- a/frontend/src/composables/useDialogBackHistory.ts
+++ b/frontend/src/composables/useDialogBackHistory.ts
@@ -18,6 +18,7 @@ export function useDialogBackHistory(
 ): UseDialogBackHistoryResult {
   const dialogHistoryId = `dialog-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   let ownsHistoryEntry = false;
+  let dialogHistoryHref: string | null = null;
 
   function currentHistoryBelongsToDialog(): boolean {
     const state = window.history.state as Record<string, unknown> | null;
@@ -27,6 +28,7 @@ export function useDialogBackHistory(
   function handlePopState(event: PopStateEvent): void {
     if (!ownsHistoryEntry || !options.isOpen()) return;
     ownsHistoryEntry = false;
+    dialogHistoryHref = null;
     window.removeEventListener("popstate", handlePopState, captureOptions);
     event.stopImmediatePropagation();
     options.onBack();
@@ -39,10 +41,11 @@ export function useDialogBackHistory(
       currentState !== null && typeof currentState === "object"
         ? (currentState as Record<string, unknown>)
         : {};
+    dialogHistoryHref = window.location.href;
     window.history.pushState(
       { ...state, [DIALOG_HISTORY_STATE_KEY]: dialogHistoryId },
       "",
-      window.location.href,
+      dialogHistoryHref,
     );
     ownsHistoryEntry = true;
     // Capture runs before Vue Router and the app-wide overlay handler. The pushed URL is
@@ -54,7 +57,12 @@ export function useDialogBackHistory(
     window.removeEventListener("popstate", handlePopState, captureOptions);
     if (!ownsHistoryEntry) return;
     ownsHistoryEntry = false;
+    const pushedHref = dialogHistoryHref;
+    dialogHistoryHref = null;
     if (!currentHistoryBelongsToDialog()) return;
+    // Navigating away (e.g. Open live → editor) already replaced/left this entry. Calling
+    // history.back() here would undo that route and land back on the board (`/` pathname).
+    if (pushedHref !== null && window.location.href !== pushedHref) return;
 
     // The global overlay handler must ignore the pop used only to remove this dialog's
     // same-URL history entry after a close button, backdrop click, or Escape press.

--- a/frontend/src/composables/useDialogBackHistory.ts
+++ b/frontend/src/composables/useDialogBackHistory.ts
@@ -1,0 +1,66 @@
+interface UseDialogBackHistoryOptions {
+  enabled: () => boolean;
+  isOpen: () => boolean;
+  onBack: () => void;
+}
+
+interface UseDialogBackHistoryResult {
+  pushDialogHistoryEntry: () => void;
+  removeDialogHistoryEntry: () => void;
+}
+
+const DIALOG_HISTORY_STATE_KEY = "heymDialog";
+const captureOptions = { capture: true };
+
+/** Manages a same-URL history entry that lets browser Back dismiss one dialog. */
+export function useDialogBackHistory(
+  options: UseDialogBackHistoryOptions,
+): UseDialogBackHistoryResult {
+  const dialogHistoryId = `dialog-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  let ownsHistoryEntry = false;
+
+  function currentHistoryBelongsToDialog(): boolean {
+    const state = window.history.state as Record<string, unknown> | null;
+    return state?.[DIALOG_HISTORY_STATE_KEY] === dialogHistoryId;
+  }
+
+  function handlePopState(event: PopStateEvent): void {
+    if (!ownsHistoryEntry || !options.isOpen()) return;
+    ownsHistoryEntry = false;
+    window.removeEventListener("popstate", handlePopState, captureOptions);
+    event.stopImmediatePropagation();
+    options.onBack();
+  }
+
+  function pushDialogHistoryEntry(): void {
+    if (!options.enabled() || ownsHistoryEntry) return;
+    const currentState = window.history.state;
+    const state =
+      currentState !== null && typeof currentState === "object"
+        ? (currentState as Record<string, unknown>)
+        : {};
+    window.history.pushState(
+      { ...state, [DIALOG_HISTORY_STATE_KEY]: dialogHistoryId },
+      "",
+      window.location.href,
+    );
+    ownsHistoryEntry = true;
+    // Capture runs before Vue Router and the app-wide overlay handler. The pushed URL is
+    // identical, so consuming it closes this dialog without changing the active route.
+    window.addEventListener("popstate", handlePopState, captureOptions);
+  }
+
+  function removeDialogHistoryEntry(): void {
+    window.removeEventListener("popstate", handlePopState, captureOptions);
+    if (!ownsHistoryEntry) return;
+    ownsHistoryEntry = false;
+    if (!currentHistoryBelongsToDialog()) return;
+
+    // The global overlay handler must ignore the pop used only to remove this dialog's
+    // same-URL history entry after a close button, backdrop click, or Escape press.
+    document.body.dataset.heymIgnoreNextOverlayDismiss = "true";
+    window.history.back();
+  }
+
+  return { pushDialogHistoryEntry, removeDialogHistoryEntry };
+}


### PR DESCRIPTION
## Summary
- Close card details on browser Back using an opt-in same-URL dialog history entry
- Add long-press mobile card dragging with edge scrolling and cancellation handling
- Highlight touch drop targets while preserving permissions and desktop drag behavior
- Add Playwright coverage for mobile Back, touch drag/drop, cancellation, and desktop drag/drop

## Validation
- Frontend lint and strict typecheck passed
- Production build passed
- Touch-enabled Chromium smoke validation passed
- Screenshot captured under `frontend/.e2e-artifacts/`
- Full E2E runner was unavailable because Docker is not running

## Screenshots

![pr-359-mobile-kanban-touch-drag.png](https://github.com/heymrun/heym/releases/download/codex-pr-assets/pr-359-mobile-kanban-touch-drag.png)
