### PR TITLE
Polish board card detail: column badge, Open live, compact header

### DIFF
--- a/backend/app/services/board_run_service.py
+++ b/backend/app/services/board_run_service.py
@@ -562,6 +562,7 @@ async def _fail_open_runs(db, card_id: uuid.UUID, error: str) -> None:
     for run in runs:
         run.status = "failed"
         run.error = error
+        run.active_execution_id = None
         run.finished_at = datetime.now(timezone.utc)
 
 

--- a/backend/tests/test_board_run_service.py
+++ b/backend/tests/test_board_run_service.py
@@ -582,3 +582,24 @@ class TestEnqueueHoldsTaskReference(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(0)
             await asyncio.sleep(0)
         self.assertEqual(len(board_run_service._BACKGROUND_CHAIN_TASKS), 0)
+
+
+class TestFailOpenRuns(unittest.IsolatedAsyncioTestCase):
+    async def test_clears_active_execution_id(self):
+        run = SimpleNamespace(
+            status="running",
+            error=None,
+            active_execution_id=uuid.uuid4(),
+            finished_at=None,
+        )
+        runs_res = MagicMock()
+        runs_res.scalars.return_value.all.return_value = [run]
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=runs_res)
+
+        await board_run_service._fail_open_runs(db, uuid.uuid4(), "chain crashed")
+
+        self.assertEqual(run.status, "failed")
+        self.assertEqual(run.error, "chain crashed")
+        self.assertIsNone(run.active_execution_id)
+        self.assertIsNotNone(run.finished_at)

--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -248,6 +248,14 @@ async function removeActivity(activityId: string): Promise<void> {
   await reload();
 }
 
+const currentColumnName = computed<string>(() => {
+  if (!detail.value || !boardStore.activeBoard) return "";
+  const column = boardStore.activeBoard.columns.find(
+    (col) => col.id === detail.value!.card.column_id,
+  );
+  return column?.name ?? "";
+});
+
 const copiedRunId = ref<string | null>(null);
 const activeLiveRun = computed<CardRun | null>(() =>
   detail.value?.runs.find((run) => Boolean(run.active_execution_id)) ?? null,
@@ -307,6 +315,12 @@ async function openLiveRun(run: CardRun): Promise<void> {
           }"
         >
           {{ detail.card.run_status }}
+        </span>
+        <span
+          v-if="currentColumnName"
+          class="text-xs text-muted-foreground"
+        >
+          {{ currentColumnName }}
         </span>
         <button
           v-if="activeLiveRun"

--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -6,6 +6,7 @@ import { marked } from "marked";
 import {
   Bot,
   Check,
+  Columns3,
   Copy,
   Loader2,
   Paperclip,
@@ -257,8 +258,12 @@ const currentColumnName = computed<string>(() => {
 });
 
 const copiedRunId = ref<string | null>(null);
+// Only a currently running execution is live; stale active_execution_id on finished
+// runs must not keep the Open live action visible after the card settles.
 const activeLiveRun = computed<CardRun | null>(() =>
-  detail.value?.runs.find((run) => Boolean(run.active_execution_id)) ?? null,
+  detail.value?.runs.find(
+    (run) => run.status === "running" && Boolean(run.active_execution_id),
+  ) ?? null,
 );
 
 async function copyRun(run: CardRun): Promise<void> {
@@ -318,8 +323,11 @@ async function openLiveRun(run: CardRun): Promise<void> {
         </span>
         <span
           v-if="currentColumnName"
-          class="text-xs text-muted-foreground"
+          class="inline-flex items-center gap-1 rounded-full border border-border/70 bg-muted/60 px-2 py-0.5 text-xs font-medium text-foreground/85"
+          data-testid="card-active-column"
+          :title="`Active column: ${currentColumnName}`"
         >
+          <Columns3 class="h-3 w-3 text-muted-foreground" />
           {{ currentColumnName }}
         </span>
         <button
@@ -335,18 +343,18 @@ async function openLiveRun(run: CardRun): Promise<void> {
       </span>
     </template>
     <template #header-trailing>
-      <Button
+      <button
         v-if="detail"
-        size="icon"
-        variant="outline"
+        type="button"
+        class="flex h-8 w-8 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground transition-all duration-200 hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
         data-testid="card-run-followup"
         title="Run follow-up round"
         aria-label="Run follow-up round"
         :disabled="detail.card.run_status === 'running' || detail.card.run_status === 'pending'"
         @click="runFollowUp"
       >
-        <Play class="h-4 w-4" />
-      </Button>
+        <Play class="h-3.5 w-3.5" />
+      </button>
     </template>
     <div
       v-if="loading"

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -163,29 +163,29 @@ function toggleFullscreen(): void {
             <div class="flex items-center gap-1.5 flex-shrink-0">
               <button
                 v-if="allowFullscreen"
-                class="dialog-btn flex items-center justify-center w-11 h-11 min-h-[44px] min-w-[44px] md:w-8 md:h-8 rounded-xl text-muted-foreground hover:text-foreground transition-all duration-200"
+                class="dialog-btn flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground transition-all duration-200"
                 @click="toggleFullscreen"
               >
                 <Minimize2
                   v-if="isFullscreen"
-                  class="h-4 w-4"
+                  class="h-3.5 w-3.5"
                 />
                 <Maximize2
                   v-else
-                  class="h-4 w-4"
+                  class="h-3.5 w-3.5"
                 />
               </button>
               <div
                 v-if="$slots['header-trailing']"
-                class="flex items-center gap-1.5"
+                class="flex items-center gap-1"
               >
                 <slot name="header-trailing" />
               </div>
               <button
-                class="dialog-btn flex items-center justify-center w-11 h-11 min-h-[44px] min-w-[44px] md:w-8 md:h-8 rounded-xl text-muted-foreground hover:text-foreground transition-all duration-200"
+                class="dialog-btn flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground transition-all duration-200"
                 @click="emit('close')"
               >
-                <X class="h-4 w-4" />
+                <X class="h-3.5 w-3.5" />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Show the active column as a compact badge (icon + name) in the card detail subtitle.
- Hide **Open live** unless a run is `running` with an `active_execution_id`; clear stale `active_execution_id` when open runs are failed out.
- Make dialog header action buttons compact on mobile (play + close).

## Test plan
- [ ] Open a board card on mobile width: play/close header buttons look compact
- [ ] While a card run is in progress, **Open live** is visible and opens the live canvas
- [ ] After the card reaches success/Done, **Open live** is gone
- [ ] Active column name renders as a pill/badge next to the status chip
- [ ] `pytest tests/test_board_run_service.py::TestFailOpenRuns` passes