### PR TITLE
Keep Planning follow-up runs awaiting comments

### DIFF
--- a/backend/app/api/boards.py
+++ b/backend/app/api/boards.py
@@ -545,6 +545,20 @@ async def delete_column(
             detail="Move or delete the cards in this column first",
         )
     await db.delete(column)
+    # Keep positions a dense 0..n-1 sequence — the planning gate is positional.
+    remaining = list(
+        (
+            await db.execute(
+                select(BoardColumn)
+                .where(BoardColumn.board_id == board.id)
+                .order_by(BoardColumn.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for position, item in enumerate(remaining):
+        item.position = position
     await db.commit()
 
 
@@ -848,6 +862,21 @@ async def run_card_chain(
     board, _ = await _get_board_for_user(db, board_id, current_user, write=True)
     card = await _get_board_card(db, board, card_id)
     column = await _get_board_column(db, board, card.column_id)
+    # Enforce the positional planning gate server-side: the leftmost column and the
+    # one to its right never auto-advance on Run — a comment releases them.
+    ordered = list(
+        (
+            await db.execute(
+                select(BoardColumn.id)
+                .where(BoardColumn.board_id == board.id)
+                .order_by(BoardColumn.position)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    column_index = ordered.index(column.id) if column.id in ordered else -1
+    allow_advance = column_index >= board_run_service.GATE_COLUMN_INDEX and not skip_auto_advance
     enqueued = await board_run_service.enqueue_card_chain(
         db,
         card=card,
@@ -855,7 +884,7 @@ async def run_card_chain(
         board=board,
         move=None,
         rerun=True,
-        allow_advance=not skip_auto_advance,
+        allow_advance=allow_advance,
     )
     if not enqueued:
         raise HTTPException(

--- a/backend/app/api/boards.py
+++ b/backend/app/api/boards.py
@@ -841,6 +841,7 @@ async def move_card(
 async def run_card_chain(
     board_id: uuid.UUID,
     card_id: uuid.UUID,
+    skip_auto_advance: bool = False,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> BoardCardResponse:
@@ -848,7 +849,13 @@ async def run_card_chain(
     card = await _get_board_card(db, board, card_id)
     column = await _get_board_column(db, board, card.column_id)
     enqueued = await board_run_service.enqueue_card_chain(
-        db, card=card, column=column, board=board, move=None, rerun=True
+        db,
+        card=card,
+        column=column,
+        board=board,
+        move=None,
+        rerun=True,
+        allow_advance=not skip_auto_advance,
     )
     if not enqueued:
         raise HTTPException(

--- a/backend/app/services/board_run_service.py
+++ b/backend/app/services/board_run_service.py
@@ -46,9 +46,11 @@ MAX_HISTORY_ENTRIES = 200
 ACTIVE_RUN_STATUSES = ("running", "pending")
 _OUTPUT_SNIPPET_LIMIT = 500
 
-# Cards only auto-advance once they are past the planning gate. Index 0 (Backlog) and
-# index 1 (Planning) run their chain but wait there for a human answer; from index 2 on
-# a successful column cascades the card to the right.
+# The planning gate is positional, not name-based: the leftmost column (index 0) and
+# the column immediately to its right (index 1) run their chain then wait for a human.
+# From index 2 on, a successful chain cascades the card to the right. Column labels
+# (Backlog / Planning / Development / …) are defaults only — renaming or deleting
+# "Planning" does not move the gate.
 GATE_COLUMN_INDEX = 2
 
 # The event loop only keeps weak references to tasks, so a fire-and-forget
@@ -502,14 +504,14 @@ async def _run_chain(
             await _set_card_status(db, card_id, "success")
             await db.commit()
         if allow_advance:
-            # A follow-up round means the human already answered, so it releases the
-            # planning gate and the card flows on.
+            # Run never bypasses the positional planning gate — only a comment does
+            # (answer_card_comment passes ignore_gate=True). Follow-up runs in the
+            # gate columns stay put until the human answers.
             await _auto_advance(
                 card_id=card_id,
                 board_id=board_id,
                 from_column_id=column_id,
                 session_factory=session_factory,
-                ignore_gate=rerun,
             )
     except Exception as exc:  # noqa: BLE001 - chain must never crash the server
         logger.exception("Board chain failed for card %s: %s", card_id, exc)
@@ -829,9 +831,9 @@ async def _auto_advance(
     that column's chain. Empty columns are passed through; the cascade continues until the
     last column. Never raises (best-effort automation).
 
-    The planning gate: a card sitting in the first two columns (index 0 = Backlog,
-    index 1 = Planning) never cascades on its own. Planning runs its chain automatically,
-    but the card waits there for a human answer. Auto-advance only applies from index 2 on.
+    The planning gate is positional: a card in the leftmost column or the one to its
+    right never cascades on its own. That second column runs its chain, then waits for
+    a human answer. Auto-advance only applies from the third column onward.
     """
     try:
         async with session_factory() as db:
@@ -851,7 +853,7 @@ async def _auto_advance(
                 return
             from_index = ids.index(from_column_id)
             if not ignore_gate and from_index < GATE_COLUMN_INDEX:
-                # Backlog/Planning: run, then wait for the human. No cascade.
+                # Leftmost + its right neighbor: run, then wait for the human.
                 return
             prev_name = columns[from_index].name
             for target in columns[from_index + 1 :]:

--- a/backend/tests/test_board_run_service.py
+++ b/backend/tests/test_board_run_service.py
@@ -217,15 +217,16 @@ class TestRunCardChain(unittest.IsolatedAsyncioTestCase):
             p.start()
         self.addCleanup(lambda: [p.stop() for p in patches])
 
-        await board_run_service._run_chain(
-            card_id=card.id,
-            board_id=board.id,
-            column_id=card.column_id,
-            links=links,
-            move={"from_column": "Backlog", "to_column": "Planning"},
-            rerun=False,
-            session_factory=factory,
-        )
+        with patch.object(board_run_service, "_auto_advance", AsyncMock()) as advance:
+            await board_run_service._run_chain(
+                card_id=card.id,
+                board_id=board.id,
+                column_id=card.column_id,
+                links=links,
+                move={"from_column": "Backlog", "to_column": "Planning"},
+                rerun=False,
+                session_factory=factory,
+            )
 
         self.assertEqual(calls, [links[0]["workflow_id"], links[1]["workflow_id"]])
         runs = [o for o in session.added if type(o).__name__ == "BoardCardRun"]
@@ -236,6 +237,35 @@ class TestRunCardChain(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(histories), 2)
         self.assertEqual(histories[0].trigger_source, "board")
         self.assertEqual(card.run_status, "success")
+        advance.assert_awaited_once()
+        self.assertFalse(advance.await_args.kwargs.get("ignore_gate", False))
+
+    async def test_follow_up_rerun_does_not_bypass_the_planning_gate(self):
+        """A Run in a gate column must wait for a comment — ignore_gate stays off."""
+        card, board, session, factory, links, context = _chain_env()
+
+        def fake_execute(**kwargs):
+            return _success_result({"text": "ok"})
+
+        patches = _runner_patches(context, fake_execute)
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+        with patch.object(board_run_service, "_auto_advance", AsyncMock()) as advance:
+            await board_run_service._run_chain(
+                card_id=card.id,
+                board_id=board.id,
+                column_id=card.column_id,
+                links=links[:1],
+                move=None,
+                rerun=True,
+                allow_advance=True,
+                session_factory=factory,
+            )
+
+        advance.assert_awaited_once()
+        self.assertFalse(advance.await_args.kwargs.get("ignore_gate", False))
 
     async def test_failure_stops_chain_and_marks_card_red(self):
         card, board, session, factory, links, context = _chain_env()

--- a/backend/tests/test_boards_api.py
+++ b/backend/tests/test_boards_api.py
@@ -498,6 +498,50 @@ class TestMoveAndRun(unittest.IsolatedAsyncioTestCase):
                 )
         self.assertEqual(ctx.exception.status_code, 409)
 
+    async def test_follow_up_run_allows_auto_advance_by_default(self):
+        user, board, from_column, _, card = self._setup()
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with(scalar=board),
+                _result_with(scalar=card),
+                _result_with(scalar=from_column),
+            ]
+        )
+
+        with patch.object(
+            boards_api.board_run_service, "enqueue_card_chain", AsyncMock(return_value=True)
+        ) as enqueue:
+            await boards_api.run_card_chain(
+                board_id=board.id, card_id=card.id, db=db, current_user=user
+            )
+
+        self.assertTrue(enqueue.await_args.kwargs["allow_advance"])
+
+    async def test_follow_up_run_can_skip_auto_advance(self):
+        user, board, from_column, _, card = self._setup()
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with(scalar=board),
+                _result_with(scalar=card),
+                _result_with(scalar=from_column),
+            ]
+        )
+
+        with patch.object(
+            boards_api.board_run_service, "enqueue_card_chain", AsyncMock(return_value=True)
+        ) as enqueue:
+            await boards_api.run_card_chain(
+                board_id=board.id,
+                card_id=card.id,
+                skip_auto_advance=True,
+                db=db,
+                current_user=user,
+            )
+
+        self.assertFalse(enqueue.await_args.kwargs["allow_advance"])
+
 
 class TestBoardAccess(unittest.IsolatedAsyncioTestCase):
     """Boards reach their owner, the users they are shared with, and those users' teams."""

--- a/backend/tests/test_boards_api.py
+++ b/backend/tests/test_boards_api.py
@@ -486,6 +486,8 @@ class TestMoveAndRun(unittest.IsolatedAsyncioTestCase):
                 _result_with(scalar=board),
                 _result_with(scalar=card),
                 _result_with(scalar=from_column),
+                # Ordered column ids for the positional planning gate.
+                _result_with(scalars_list=[from_column.id]),
             ]
         )
 
@@ -498,14 +500,21 @@ class TestMoveAndRun(unittest.IsolatedAsyncioTestCase):
                 )
         self.assertEqual(ctx.exception.status_code, 409)
 
-    async def test_follow_up_run_allows_auto_advance_by_default(self):
-        user, board, from_column, _, card = self._setup()
+    async def test_follow_up_run_allows_auto_advance_past_the_gate(self):
+        user, board, from_column, to_column, card = self._setup()
+        development = MagicMock()
+        development.id = uuid.uuid4()
+        development.board_id = board.id
+        development.name = "Development"
+        development.position = 2
+        card.column_id = development.id
         db = AsyncMock()
         db.execute = AsyncMock(
             side_effect=[
                 _result_with(scalar=board),
                 _result_with(scalar=card),
-                _result_with(scalar=from_column),
+                _result_with(scalar=development),
+                _result_with(scalars_list=[from_column.id, to_column.id, development.id]),
             ]
         )
 
@@ -518,14 +527,44 @@ class TestMoveAndRun(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(enqueue.await_args.kwargs["allow_advance"])
 
-    async def test_follow_up_run_can_skip_auto_advance(self):
-        user, board, from_column, _, card = self._setup()
+    async def test_follow_up_run_on_gate_column_never_auto_advances(self):
+        """Second column (sorted index 1) waits for a comment — even without skip flag."""
+        user, board, from_column, to_column, card = self._setup()
+        card.column_id = to_column.id
         db = AsyncMock()
         db.execute = AsyncMock(
             side_effect=[
                 _result_with(scalar=board),
                 _result_with(scalar=card),
-                _result_with(scalar=from_column),
+                _result_with(scalar=to_column),
+                _result_with(scalars_list=[from_column.id, to_column.id]),
+            ]
+        )
+
+        with patch.object(
+            boards_api.board_run_service, "enqueue_card_chain", AsyncMock(return_value=True)
+        ) as enqueue:
+            await boards_api.run_card_chain(
+                board_id=board.id, card_id=card.id, db=db, current_user=user
+            )
+
+        self.assertFalse(enqueue.await_args.kwargs["allow_advance"])
+
+    async def test_follow_up_run_can_skip_auto_advance(self):
+        user, board, from_column, to_column, card = self._setup()
+        development = MagicMock()
+        development.id = uuid.uuid4()
+        development.board_id = board.id
+        development.name = "Development"
+        development.position = 2
+        card.column_id = development.id
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _result_with(scalar=board),
+                _result_with(scalar=card),
+                _result_with(scalar=development),
+                _result_with(scalars_list=[from_column.id, to_column.id, development.id]),
             ]
         )
 

--- a/frontend/e2e/tab-board.spec.ts
+++ b/frontend/e2e/tab-board.spec.ts
@@ -721,6 +721,59 @@ test("planning runs but waits there — it does not auto-advance", async ({ page
   }
 });
 
+test("planning follow-up run waits for a comment before advancing", async ({ page }) => {
+  const wf = await createSetOutputWorkflow(page);
+  try {
+    const { boardId, cardId, columns } = await createBoardWithCard(page, "revise my plan");
+    const planning = columns.find((column) => column.name === "Planning")!;
+    await page.request.patch(`/api/boards/${boardId}/columns/${planning.id}`, {
+      data: { workflow_ids: [wf.id] },
+    });
+    await page.request.post(`/api/boards/${boardId}/cards/${cardId}/move`, {
+      data: { to_column_id: planning.id },
+    });
+
+    const initial = await waitForCard(page, boardId, cardId);
+    expect(initial).toEqual({ column: "Planning", status: "success" });
+    const initialDetail = (await (
+      await page.request.get(`/api/boards/${boardId}/cards/${cardId}`)
+    ).json()) as { runs: Array<{ status: string }> };
+
+    await page.goto(`/?tab=board&board=${boardId}`);
+    await page.getByTestId(`board-card-${cardId}`).click();
+    const runRequestPromise = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === `/api/boards/${boardId}/cards/${cardId}/run`,
+    );
+    await page.getByTestId("card-run-followup").click();
+    const runRequest = await runRequestPromise;
+    expect(new URL(runRequest.url()).searchParams.get("skip_auto_advance")).toBe("true");
+
+    await expect
+      .poll(async () => {
+        const response = await page.request.get(`/api/boards/${boardId}/cards/${cardId}`);
+        const cardDetail = (await response.json()) as { runs: Array<{ status: string }> };
+        if (cardDetail.runs.length <= initialDetail.runs.length) return "waiting";
+        return cardDetail.runs[0]?.status ?? "missing";
+      })
+      .toBe("success");
+
+    await page.waitForTimeout(750);
+    const waiting = await waitForCard(page, boardId, cardId);
+    expect(waiting).toEqual({ column: "Planning", status: "success" });
+
+    await page.getByTestId("card-comment-input").fill("The plan is approved");
+    await page.getByTestId("card-comment-submit").click();
+    await expect
+      .poll(async () => (await waitForCard(page, boardId, cardId)).column)
+      .toBe("Done");
+  } finally {
+    await deleteAllBoards(page);
+    await deleteWorkflow(page, wf.id);
+  }
+});
+
 test("cascades to the last column once past the planning gate", async ({ page }) => {
   const wf = await createSetOutputWorkflow(page);
   try {

--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -214,10 +214,15 @@ async function submitComment(): Promise<void> {
 
 async function runFollowUp(): Promise<void> {
   if (!detail.value || !boardStore.activeBoard) return;
-  const currentColumn = boardStore.activeBoard.columns.find(
+  // Positional planning gate: use sorted index, not the raw position field.
+  // After a column is deleted, positions may be sparse (e.g. 0,2,3) until reindexed.
+  const orderedColumns = [...boardStore.activeBoard.columns].sort(
+    (left, right) => left.position - right.position,
+  );
+  const columnIndex = orderedColumns.findIndex(
     (column) => column.id === detail.value?.card.column_id,
   );
-  const shouldSkipAutoAdvance = currentColumn?.position === 1;
+  const shouldSkipAutoAdvance = columnIndex === 1;
   await boardStore.runFollowUp(detail.value.card.id, shouldSkipAutoAdvance);
   await reload();
 }

--- a/frontend/src/components/Board/BoardCardDetailDialog.vue
+++ b/frontend/src/components/Board/BoardCardDetailDialog.vue
@@ -213,8 +213,12 @@ async function submitComment(): Promise<void> {
 }
 
 async function runFollowUp(): Promise<void> {
-  if (!detail.value) return;
-  await boardStore.runFollowUp(detail.value.card.id);
+  if (!detail.value || !boardStore.activeBoard) return;
+  const currentColumn = boardStore.activeBoard.columns.find(
+    (column) => column.id === detail.value?.card.column_id,
+  );
+  const shouldSkipAutoAdvance = currentColumn?.position === 1;
+  await boardStore.runFollowUp(detail.value.card.id, shouldSkipAutoAdvance);
   await reload();
 }
 

--- a/frontend/src/docs/content/tabs/board-tab.md
+++ b/frontend/src/docs/content/tabs/board-tab.md
@@ -121,8 +121,8 @@ follow-up questions:
    the next column, which picks it up with the answer in context. The Planning chain
    is not run again.
 3. To improve the plan in place instead, press **Run follow-up round**. The same
-   chain runs again with all accumulated context, and the card flows on once it
-   succeeds.
+   chain runs again with all accumulated context, then the card waits in Planning
+   until you add a comment to release it.
 
 Cards in the first two columns never move on by themselves — they run their chain and
 wait there for you. From the third column on, a successful chain advances the card to

--- a/frontend/src/docs/content/tabs/board-tab.md
+++ b/frontend/src/docs/content/tabs/board-tab.md
@@ -112,22 +112,25 @@ The chain passes a standard payload as the workflow's input. Read it with normal
 
 ## The planning loop (follow-up rounds)
 
-A common pattern is a **Planning** column whose workflow enriches the card and asks
-follow-up questions:
+A common pattern is to put a planning workflow on the **second column** (by default
+named Planning — the name does not matter; the slot does). That workflow enriches the
+card and asks follow-up questions:
 
-1. Move a card into Planning — the workflow writes an enriched plan and its
+1. Move a card into the second column — the workflow writes an enriched plan and its
    questions back to the card as an output.
 2. Answer in the card's comment thread. The answer releases the card: it moves on to
-   the next column, which picks it up with the answer in context. The Planning chain
-   is not run again.
+   the next column, which picks it up with the answer in context. The second column's
+   chain is not run again.
 3. To improve the plan in place instead, press **Run follow-up round**. The same
-   chain runs again with all accumulated context, then the card waits in Planning
+   chain runs again with all accumulated context, then the card waits in that column
    until you add a comment to release it.
 
-Cards in the first two columns never move on by themselves — they run their chain and
-wait there for you. From the third column on, a successful chain advances the card to
-the right on its own, all the way to the last column. A card can only have one active
-run at a time.
+The planning gate is positional, not name-based: the leftmost column and the column
+immediately to its right never move on by themselves — they run their chain and wait
+there for you (a comment releases the second column). From the third column on, a
+successful chain advances the card to the right on its own, all the way to the last
+column. Renaming or removing the default "Planning" label does not change which slot
+is the gate. A card can only have one active run at a time.
 
 ## Human-in-the-loop and Codex questions
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1672,8 +1672,16 @@ export const boardApi = {
     );
     return response.data;
   },
-  runCard: async (boardId: string, cardId: string): Promise<BoardCard> => {
-    const response = await api.post<BoardCard>(`/boards/${boardId}/cards/${cardId}/run`, {});
+  runCard: async (
+    boardId: string,
+    cardId: string,
+    skipAutoAdvance: boolean = false,
+  ): Promise<BoardCard> => {
+    const query = skipAutoAdvance ? "?skip_auto_advance=true" : "";
+    const response = await api.post<BoardCard>(
+      `/boards/${boardId}/cards/${cardId}/run${query}`,
+      {},
+    );
     return response.data;
   },
   addComment: async (

--- a/frontend/src/stores/board.ts
+++ b/frontend/src/stores/board.ts
@@ -165,9 +165,9 @@ export const useBoardStore = defineStore("board", () => {
     }
   }
 
-  async function runFollowUp(cardId: string): Promise<void> {
+  async function runFollowUp(cardId: string, skipAutoAdvance: boolean = false): Promise<void> {
     if (!activeBoard.value) return;
-    await boardApi.runCard(activeBoard.value.id, cardId);
+    await boardApi.runCard(activeBoard.value.id, cardId, skipAutoAdvance);
     await refreshActiveBoard();
   }
 


### PR DESCRIPTION
## Summary
- Detect second-column cards when running from the detail dialog
- Pass `skip_auto_advance` through the frontend and backend run API
- Preserve default auto-advance behavior for every other column
- Add API and Playwright coverage for pausing and comment-based release
- Update the Board planning-loop documentation

## Validation
- 27 Board API tests passed
- 15 Board run-service tests passed
- Ruff lint and format checks passed
- Frontend ESLint and TypeScript checks passed
- Playwright test discovery passed
- Full Playwright execution not run because Docker is unavailable