### PR TITLE
Improve coding-agent PR titles and screenshot capture

### DIFF
--- a/backend/app/services/codex_runner_service.py
+++ b/backend/app/services/codex_runner_service.py
@@ -63,9 +63,12 @@ _CODEX_LOCAL_ONLY_RULES = (
     "or any remote/network tool to modify the repository — Heym performs every git and GitHub "
     "operation after you finish. If network access is available, use it only for read-only "
     "downloads or dependency lookups needed to complete the local file edits. For UI/frontend "
-    "visual changes, save at least one PNG screenshot under a gitignored path such as "
-    "`frontend/.e2e-artifacts/`; Heym uploads those images onto the pull request after you finish "
-    "(do not commit screenshot binaries into source)."
+    "visual changes you MUST save at least one PNG screenshot under a gitignored path such as "
+    "`frontend/.e2e-artifacts/` (or an equivalent gitignored artifacts directory). If frontend "
+    "dependencies are missing, you MAY run a package install (for example `bun install`, "
+    "`npm install`, or `pnpm install`) and start a short-lived preview/dev server solely to "
+    "capture the screenshot, then stop the server. Heym uploads those images onto the pull "
+    "request after you finish (do not commit screenshot binaries into source)."
 )
 
 _PR_SCREENSHOT_RELEASE_TAG = "codex-pr-assets"
@@ -913,7 +916,8 @@ class CodexRunnerService:
             "`status: needs_input` with one concise question. Otherwise implement the task "
             "and return `status: completed` with a summary and validation notes. Always set "
             "`pull_request_title` to a concise, complete one-line change description "
-            "(imperative mood, ideally <=72 characters) suitable as a commit subject.\n\n"
+            "(imperative mood, ideally <=72 characters) suitable as a commit/PR subject. "
+            "Never use placeholder titles such as Done, Fixed, or Update.\n\n"
             f"Task:\n{task_prompt}"
         )
 

--- a/backend/app/services/coding_agent/pr_publish.py
+++ b/backend/app/services/coding_agent/pr_publish.py
@@ -70,15 +70,68 @@ def git_identity_args(name: str, email: str) -> list[str]:
     return ["-c", f"user.name={name}", "-c", f"user.email={email}"]
 
 
+# Placeholder agent closings that must never become a GitHub PR/commit subject.
+_MEANINGLESS_TITLE_RE = re.compile(
+    r"^(?:"
+    r"done|ok|okay|fixed|completed|finished|ready|success|all done|lgtm|wip|"
+    r"changes?(?:\s+are)?\s+done|task(?:\s+is)?\s+complete(?:d)?"
+    r")[.!]?\s*$",
+    re.IGNORECASE,
+)
+_PR_TITLE_LINE_RE = re.compile(r"(?im)^\s*PR_TITLE:\s*(.+?)\s*$")
+
+
+def normalize_title_candidate(text: str) -> str:
+    """Collapse whitespace and strip a leading ``PR_TITLE:`` label if present."""
+    cleaned = re.sub(r"\s+", " ", str(text or "")).strip()
+    cleaned = re.sub(r"^PR_TITLE:\s*", "", cleaned, flags=re.IGNORECASE).strip()
+    return cleaned.strip("\"'`")
+
+
+def is_meaningful_commit_title(title: str) -> bool:
+    """Return False for empty/short/placeholder titles such as ``Done.``."""
+    normalized = normalize_title_candidate(title)
+    if len(normalized) < 8:
+        return False
+    return _MEANINGLESS_TITLE_RE.match(normalized) is None
+
+
+def extract_pr_title_line(summary: str) -> tuple[str, str]:
+    """Parse a trailing ``PR_TITLE: …`` line from an agent summary.
+
+    Returns ``(title, summary_without_title_line)``. When no line is present the
+    original summary is returned unchanged and the title is empty.
+    """
+    text = str(summary or "")
+    match = None
+    for candidate in _PR_TITLE_LINE_RE.finditer(text):
+        match = candidate
+    if match is None:
+        return "", text
+    title = normalize_title_candidate(match.group(1))
+    cleaned = (text[: match.start()] + text[match.end() :]).strip()
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return title, cleaned
+
+
 def commit_title(pull_request_title: str, summary: str, *, fallback: str) -> str:
-    """Prefer the dedicated PR title; else the first sentence of the summary; else ``fallback``."""
-    title = re.sub(r"\s+", " ", str(pull_request_title or "")).strip()
-    if title:
-        return title
-    normalized = re.sub(r"\s+", " ", str(summary or "")).strip()
-    if not normalized:
-        return fallback
-    return re.split(r"(?<=[.!?])\s", normalized, maxsplit=1)[0]
+    """Prefer a meaningful dedicated PR title; else a summary sentence; else ``fallback``.
+
+    Skips placeholder subjects such as ``Done.`` that coding agents often emit as
+    the first sentence of an otherwise useful summary.
+    """
+    extracted_title, summary_without_title = extract_pr_title_line(summary)
+    candidates: list[str] = [
+        normalize_title_candidate(pull_request_title),
+        extracted_title,
+    ]
+    normalized = re.sub(r"\s+", " ", str(summary_without_title or "")).strip()
+    if normalized:
+        candidates.extend(re.split(r"(?<=[.!?])\s+", normalized))
+    for candidate in candidates:
+        if is_meaningful_commit_title(candidate):
+            return normalize_title_candidate(candidate)
+    return fallback
 
 
 def commit_body(summary: str, validation: str) -> str:

--- a/backend/app/services/opencode_runner_service.py
+++ b/backend/app/services/opencode_runner_service.py
@@ -33,11 +33,15 @@ _LOCAL_ONLY_RULES = (
     "Heym already checked out the correct branch. Do NOT run git at all (no status, checkout, "
     "fetch, commit, push, or branch commands); do NOT use the GitHub API or any remote tool to "
     "modify the repository — Heym performs every git and GitHub operation after you finish. "
-    "Do NOT install package managers, run ./check.sh, bun/npm/pnpm install, or full "
-    "lint/typecheck/test suites — the runner container is memory-limited and Heym validates "
-    "changes after you finish. For UI/frontend visual changes, save at least one PNG screenshot "
-    "under a gitignored path such as `frontend/.e2e-artifacts/`; Heym uploads those images onto "
-    "the pull request afterward."
+    "For UI/frontend visual changes you MUST save at least one PNG screenshot under a "
+    "gitignored path such as `frontend/.e2e-artifacts/`. If frontend dependencies are missing, "
+    "you MAY run a package install (for example `bun install`, `npm install`, or `pnpm install`) "
+    "and start a short-lived preview/dev server solely to capture the UI, then stop the server. "
+    "Do not commit screenshot binaries into source; Heym uploads those images onto the pull "
+    "request afterward. "
+    "End your final assistant message with a dedicated line "
+    "`PR_TITLE: <imperative one-line change description, ideally <=72 chars>` — never use "
+    "placeholders such as Done, Fixed, or Update."
 )
 _MAX_ERROR_DETAIL_CHARS = 4000
 
@@ -167,7 +171,13 @@ class OpenCodeRunnerService:
                 summary = text
         if not summary:
             summary = "OpenCode completed without a final assistant message."
-        return OpenCodeRunResult(status="completed", summary=summary, raw_events=events)
+        pull_request_title, cleaned_summary = pr_publish.extract_pr_title_line(summary)
+        return OpenCodeRunResult(
+            status="completed",
+            summary=cleaned_summary,
+            pull_request_title=pull_request_title,
+            raw_events=events,
+        )
 
     @staticmethod
     def _event_assistant_text(event: dict) -> str:
@@ -373,9 +383,7 @@ class OpenCodeRunnerService:
         if cls._looks_like_event_stream(stdout):
             parts.append(
                 f"OpenCode exited with code {returncode} before successful completion. "
-                "The runner container may have been killed (OOM) or the session aborted "
-                "mid-step — avoid heavy ./check.sh / install / typecheck work inside the "
-                "OpenCode node; Heym validates after the run."
+                "The runner container may have been killed (OOM) or the session aborted mid-step."
             )
         elif not parts:
             detail = (stdout or "").strip() or f"OpenCode exec failed (exit code {returncode})"

--- a/backend/tests/test_codex_publish_modes.py
+++ b/backend/tests/test_codex_publish_modes.py
@@ -62,6 +62,8 @@ class TestPublishModeConstants(unittest.TestCase):
         self.assertIn("GitHub API", prompt)
         self.assertIn("Heym performs every git", prompt)
         self.assertIn("frontend/.e2e-artifacts/", prompt)
+        self.assertIn("bun install", prompt)
+        self.assertIn("Never use placeholder titles", prompt)
         self.assertIn("translate the readme", prompt)
 
     def test_resume_prompt_forbids_git_and_github(self) -> None:
@@ -97,6 +99,17 @@ class TestCommitMessage(unittest.TestCase):
             summary="README.md translated. Headings, tables, notes localized; commands preserved.",
         )
         self.assertEqual(CodexRunnerService._commit_title(result), "README.md translated.")
+
+    def test_commit_title_skips_placeholder_done(self) -> None:
+        result = CodexRunResult(
+            status="completed",
+            summary="Done. Reorder the mobile chat header actions.",
+            pull_request_title="Done.",
+        )
+        self.assertEqual(
+            CodexRunnerService._commit_title(result),
+            "Reorder the mobile chat header actions.",
+        )
 
     def test_commit_body_has_full_summary_and_validation(self) -> None:
         result = CodexRunResult(

--- a/backend/tests/test_coding_agent_pr_publish.py
+++ b/backend/tests/test_coding_agent_pr_publish.py
@@ -53,8 +53,48 @@ class TestPrPublishHelpers(unittest.TestCase):
             pr_publish.commit_title("", "Fix the bug. More detail.", fallback="fb"), "Fix the bug."
         )
 
+    def test_commit_title_skips_placeholder_done(self):
+        self.assertEqual(
+            pr_publish.commit_title(
+                "",
+                "Done. Move the chat list toggle before History on mobile.",
+                fallback="Apply changes",
+            ),
+            "Move the chat list toggle before History on mobile.",
+        )
+
+    def test_commit_title_skips_placeholder_pr_title(self):
+        self.assertEqual(
+            pr_publish.commit_title(
+                "Done.",
+                "Close the mobile sidebar after selecting a chat.",
+                fallback="Apply changes",
+            ),
+            "Close the mobile sidebar after selecting a chat.",
+        )
+
+    def test_commit_title_uses_pr_title_line(self):
+        self.assertEqual(
+            pr_publish.commit_title(
+                "",
+                "Implemented the mobile drawer fix.\n\nPR_TITLE: Reorder mobile chat header actions",
+                fallback="Apply changes",
+            ),
+            "Reorder mobile chat header actions",
+        )
+
     def test_commit_title_fallback(self):
         self.assertEqual(pr_publish.commit_title("", "", fallback="Apply changes"), "Apply changes")
+        self.assertEqual(
+            pr_publish.commit_title("Done.", "Done.", fallback="Apply changes"), "Apply changes"
+        )
+
+    def test_extract_pr_title_line(self):
+        title, summary = pr_publish.extract_pr_title_line(
+            "Finished the work.\nPR_TITLE: Fix mobile chat drawer\n"
+        )
+        self.assertEqual(title, "Fix mobile chat drawer")
+        self.assertEqual(summary, "Finished the work.")
 
     def test_pr_number_from_url(self):
         self.assertEqual(pr_publish.pr_number_from_url("https://github.com/a/b/pull/42"), 42)

--- a/backend/tests/test_opencode_runner_service.py
+++ b/backend/tests/test_opencode_runner_service.py
@@ -45,7 +45,10 @@ class TestOpenCodeRunCommand(unittest.TestCase):
         self.assertNotIn("--variant", cmd)
         self.assertIn("Task:", cmd[-1])
         self.assertIn("Do NOT run git", cmd[-1])
-        self.assertIn("./check.sh", cmd[-1])
+        self.assertIn("bun install", cmd[-1])
+        self.assertIn("PR_TITLE:", cmd[-1])
+        self.assertNotIn("./check.sh", cmd[-1])
+        self.assertNotIn("Do NOT install package managers", cmd[-1])
 
     def test_run_command_pins_workspace_dir(self):
         cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
@@ -112,6 +115,21 @@ class TestOpenCodeParser(unittest.TestCase):
         stdout = "not json\n" + json.dumps({"role": "assistant", "text": "Done."})
         self.assertEqual(self.svc.parse_events(stdout).summary, "Done.")
 
+    def test_parse_extracts_pr_title_line(self):
+        stdout = json.dumps(
+            {
+                "role": "assistant",
+                "text": (
+                    "Moved the chat list toggle before History.\n\n"
+                    "PR_TITLE: Reorder mobile chat header actions"
+                ),
+            }
+        )
+        result = self.svc.parse_events(stdout)
+        self.assertEqual(result.pull_request_title, "Reorder mobile chat header actions")
+        self.assertEqual(result.summary, "Moved the chat list toggle before History.")
+        self.assertNotIn("PR_TITLE:", result.summary)
+
     def test_parse_ignores_user_role(self):
         stdout = json.dumps({"role": "user", "text": "the task"})
         self.assertNotEqual(self.svc.parse_events(stdout).summary, "the task")
@@ -150,6 +168,7 @@ class TestOpenCodeExecFailureFormatting(unittest.TestCase):
         self.assertIn("heap out of memory", detail)
         self.assertIn("exited with code 137", detail)
         self.assertIn("OOM", detail)
+        self.assertNotIn("avoid heavy ./check.sh", detail)
 
     def test_plain_stderr_is_preserved(self) -> None:
         detail = OpenCodeRunnerService._format_exec_failure(1, "", "opencode: command failed")

--- a/frontend/src/docs/content/nodes/codex-node.md
+++ b/frontend/src/docs/content/nodes/codex-node.md
@@ -80,7 +80,7 @@ OpenAI references:
 
 ## UI screenshots on pull requests
 
-For UI/frontend tasks, Codex should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`codex-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description. 
+For UI/frontend tasks, Codex should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, Codex may run `bun install` (or npm/pnpm install) and start a short-lived preview/`bun run dev` solely to capture the UI. After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`codex-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description. Codex must also set a meaningful `pull_request_title` (never placeholders such as `Done.`). 
 
 ## Follow-up Questions
 

--- a/frontend/src/docs/content/nodes/opencode-go-node.md
+++ b/frontend/src/docs/content/nodes/opencode-go-node.md
@@ -76,7 +76,9 @@ OpenCode Go's model roster changes often, so the **Model** field is populated li
 
 ## UI screenshots on pull requests
 
-For UI/frontend tasks, OpenCode should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`opencode-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description.
+For UI/frontend tasks, OpenCode should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, the runner prompt allows a targeted package install (for example `bun install`) plus a short-lived preview/`bun run dev` solely to capture the UI. After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`opencode-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description.
+
+OpenCode is also instructed to end with a `PR_TITLE: …` line so Heym can open the pull request with a meaningful subject instead of placeholders such as `Done.`
 
 ## As an agent tool
 


### PR DESCRIPTION
## Summary
- Reject placeholder PR/commit subjects like `Done.` and prefer the next meaningful summary sentence (shared by Codex and OpenCode).
- Teach OpenCode to emit a `PR_TITLE:` line, parse it into the PR subject, and allow package installs so UI screenshots can be captured when dependencies are missing.
- Drop the heym-repo-specific `./check.sh` ban from OpenCode prompts so distributed runners do not hardcode this project's check script.

## Test plan
- [x] `uv run pytest tests/test_coding_agent_pr_publish.py tests/test_opencode_runner_service.py tests/test_codex_publish_modes.py`
- [ ] Open an OpenCode/Codex UI PR and confirm the title is descriptive (not `Done.`)
- [ ] Confirm a UI task can install frontend deps and attach a screenshot when `node_modules` is absent


Made with [Cursor](https://cursor.com)