### PR TITLE
Pass Codex/OpenCode Docker CPU and memory limits from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,10 @@ HEYM_OTEL_EXPORTER_OTLP_HEADERS=
 HEYM_OTEL_SERVICE_NAME=heym
 HEYM_OTEL_TRACES_SAMPLER_RATIO=1.0
 HEYM_OTEL_CAPTURE_NODE_IO=false
+
+# Codex / OpenCode sibling runner resource limits (Docker deployments via deploy.sh)
+# Defaults match docker/heym-*-docker wrappers (2 CPU / 4g). Override in .env as needed.
+HEYM_CODEX_DOCKER_CPUS=2
+HEYM_CODEX_DOCKER_MEMORY=4g
+HEYM_OPENCODE_DOCKER_CPUS=2
+HEYM_OPENCODE_DOCKER_MEMORY=4g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,12 +82,16 @@ services:
       HEYM_CODEX_DOCKER_WORKSPACE_VOLUME: ${HEYM_CODEX_DOCKER_WORKSPACE_VOLUME:-heym-codex-workspaces}
       HEYM_CODEX_WORKSPACE_DIR: ${HEYM_CODEX_WORKSPACE_DIR:-/app/data/codex-workspaces}
       HEYM_CODEX_NETWORK_ACCESS: ${HEYM_CODEX_NETWORK_ACCESS:-true}
+      HEYM_CODEX_DOCKER_CPUS: ${HEYM_CODEX_DOCKER_CPUS:-2}
+      HEYM_CODEX_DOCKER_MEMORY: ${HEYM_CODEX_DOCKER_MEMORY:-4g}
       # OpenCode Go node: run the OpenCode CLI in a dedicated hardened sibling runner container
       # sharing the workspace named volume (mirrors the Codex setup).
       HEYM_OPENCODE_CLI_COMMAND: ${HEYM_OPENCODE_CLI_COMMAND:-/usr/local/bin/heym-opencode-docker}
       HEYM_OPENCODE_DOCKER_IMAGE: ${HEYM_OPENCODE_DOCKER_IMAGE:-heym-backend:local}
       HEYM_OPENCODE_DOCKER_WORKSPACE_VOLUME: ${HEYM_OPENCODE_DOCKER_WORKSPACE_VOLUME:-heym-opencode-workspaces}
       HEYM_OPENCODE_WORKSPACE_DIR: ${HEYM_OPENCODE_WORKSPACE_DIR:-/app/data/opencode-workspaces}
+      HEYM_OPENCODE_DOCKER_CPUS: ${HEYM_OPENCODE_DOCKER_CPUS:-2}
+      HEYM_OPENCODE_DOCKER_MEMORY: ${HEYM_OPENCODE_DOCKER_MEMORY:-4g}
       # Python tool sandbox: untrusted user tools run in a hardened, throwaway
       # sibling container (no network, no docker socket, read-only, non-root).
       # Empty image = auto-detect this backend image.


### PR DESCRIPTION
## Summary
- Forward `HEYM_CODEX_DOCKER_CPUS` / `HEYM_CODEX_DOCKER_MEMORY` and OpenCode equivalents into the backend container via `docker-compose.yml`
- Document the knobs in `.env.example` so `deploy.sh` / compose pick up operator overrides (e.g. `4` CPU / `16g`)

`deploy.sh` already sources `.env` before `docker compose`; no script change needed once compose passes the vars through.

## Test plan
- [ ] Set `HEYM_CODEX_DOCKER_CPUS=4` and `HEYM_CODEX_DOCKER_MEMORY=16g` (and OpenCode equivalents) in `.env`
- [ ] Run `./deploy.sh` or `docker compose up -d --force-recreate backend`
- [ ] Confirm env inside backend: `docker exec heym-backend printenv | grep -E 'HEYM_(CODEX|OPENCODE)_DOCKER_(CPUS|MEMORY)'`
- [ ] Run a Codex/OpenCode node and verify the sibling container was started with `--cpus 4` and `--memory 16g` (e.g. `docker inspect` on the runner)


Made with [Cursor](https://cursor.com)