### PR TITLE
Add mobile touch support to execution log panel resize handle

### DIFF
--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -541,6 +541,34 @@ function startResize(e: MouseEvent): void {
   document.addEventListener("mouseup", onMouseUp);
 }
 
+let touchStartY = 0;
+let touchStartHeight = 0;
+
+function startResizeTouch(e: TouchEvent): void {
+  if (!e.touches || e.touches.length === 0) return;
+  isResizing.value = true;
+  touchStartY = e.touches[0].clientY;
+  touchStartHeight = panelHeight.value;
+}
+
+function onResizeTouch(e: TouchEvent): void {
+  if (!isResizing.value || !e.touches || e.touches.length === 0) return;
+  const delta = touchStartY - e.touches[0].clientY;
+  const newHeight = touchStartHeight + delta;
+  panelHeight.value = Math.min(maxHeight, Math.max(minHeight, newHeight));
+  isCollapsed.value = panelHeight.value <= collapsedHeight;
+}
+
+function onResizeTouchEnd(): void {
+  if (!isResizing.value) return;
+  isResizing.value = false;
+  if (panelHeight.value <= collapsedHeight + 20) {
+    panelHeight.value = collapsedHeight;
+    isCollapsed.value = true;
+  }
+  workflowStore.setDebugPanelHeight(panelHeight.value);
+}
+
 function toggleCollapse(): void {
   if (isCollapsed.value) {
     panelHeight.value = maxHeight;
@@ -1540,6 +1568,10 @@ onUnmounted(() => {
   unsubDismissOverlays = null;
   window.removeEventListener("keydown", handleDebugPanelWindowKeyDown, true);
   window.removeEventListener("keydown", handleDownloadDialogKeyDown, true);
+  if (isResizing.value) {
+    isResizing.value = false;
+    workflowStore.setDebugPanelHeight(panelHeight.value);
+  }
 });
 
 function toggleAiPanel(): void {
@@ -2517,9 +2549,12 @@ function renderContent(content: string): string {
     :style="{ height: `${panelHeight}px` }"
   >
     <div
-      class="h-3 min-h-[44px] cursor-ns-resize hover:bg-primary/20 transition-colors flex items-center justify-center group md:h-1.5"
+      class="debug-panel-resize-handle h-3 min-h-[44px] cursor-ns-resize hover:bg-primary/20 transition-colors flex items-center justify-center group md:h-1.5"
       :class="isResizing && 'bg-primary/30'"
       @mousedown="startResize"
+      @touchstart.prevent="startResizeTouch"
+      @touchmove.prevent="onResizeTouch"
+      @touchend.prevent="onResizeTouchEnd"
     >
       <GripHorizontal class="w-8 h-3 text-muted-foreground/50 group-hover:text-muted-foreground" />
     </div>
@@ -3667,6 +3702,10 @@ function renderContent(content: string): string {
 </template>
 
 <style scoped>
+.debug-panel-resize-handle {
+  touch-action: none;
+}
+
 .ai-panel {
   position: fixed;
   right: 24px;


### PR DESCRIPTION
All changes are clean. The only modified source file is `frontend/src/components/Panels/DebugPanel.vue`.

Summary of changes to `DebugPanel.vue`:
- Added `startResizeTouch`, `onResizeTouch`, `onResizeTouchEnd` handlers using `e.touches[0].clientY`, mirroring the mouse logic with the same `minHeight`/`maxHeight`/`collapsedHeight` constraints and calling `workflowStore.setDebugPanelHeight` on touch end.
- Added `@touchstart.prevent`, `@touchmove.prevent`, `@touchend.prevent` listeners on the resize handle (mouse handlers untouched).
- Added a `debug-panel-resize-handle` class with `touch-action: none` to prevent browser scroll interference.
- Extended `onUnmounted` to finalize panel height if a touch drag is interrupted.
- Captured two PNG screenshots under `frontend/.e2e-artifacts/` (gitignored) showing the panel before and after a simulated touch-drag.

## Screenshots

![pr-365-touch-resize-handle-after-drag.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-365-touch-resize-handle-after-drag.png)

![pr-365-touch-resize-handle-initial-1.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-365-touch-resize-handle-initial-1.png)
