### PR TITLE
Improve OpenCode PR title, description, and screenshot discovery

### DIFF
--- a/backend/app/services/coding_agent/pr_publish.py
+++ b/backend/app/services/coding_agent/pr_publish.py
@@ -8,12 +8,15 @@ seam (so their unit tests can mock the seam on the runner instance).
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import quote, urlparse, urlunparse
 
 from app.services.github_service import GitHubService
+
+logger = logging.getLogger(__name__)
 
 # --- PR screenshot constants (shared) ---
 PR_SCREENSHOT_SUFFIXES: frozenset[str] = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif"})
@@ -177,6 +180,7 @@ def discover_pr_screenshots(
 ) -> list[Path]:
     """Find local UI screenshots left on disk (gitignored / untracked only)."""
     root = workspace.resolve()
+    logger.debug("Discovering PR screenshots under %s", root)
     tracked = {
         line.strip().replace("\\", "/")
         for line in git_output(["git", "ls-files"], workspace).splitlines()
@@ -197,31 +201,53 @@ def discover_pr_screenshots(
         except ValueError:
             return
         if relative in tracked:
+            logger.debug("Skipping tracked screenshot: %s", relative)
             return
         try:
-            if path.stat().st_size > PR_SCREENSHOT_MAX_BYTES:
+            size = path.stat().st_size
+            if size > PR_SCREENSHOT_MAX_BYTES:
+                logger.debug("Skipping oversized screenshot: %s (%d bytes)", relative, size)
                 return
         except OSError:
             return
+        logger.debug("Found screenshot: %s", relative)
         seen.add(path)
         candidates.append(resolved)
 
     artifact_dirs = [
         root / "frontend" / ".e2e-artifacts",
         root / ".e2e-artifacts",
+        root / "screenshots",
+        root / "frontend" / "screenshots",
+        root / "e2e" / "screenshots",
+        root / "test" / "screenshots",
+        root / "tests" / "screenshots",
+        root / "artifacts",
+        root / "frontend" / "artifacts",
     ]
     for artifact_dir in artifact_dirs:
         if artifact_dir.is_dir():
+            logger.debug("Scanning screenshot directory: %s", artifact_dir)
             for path in artifact_dir.rglob("*"):
                 consider(path)
 
-    for path in root.glob("*screenshot*"):
-        consider(path)
-    for path in root.glob("*/*screenshot*"):
-        consider(path)
+    # Case-insensitive search for files and directories whose names contain "screenshot".
+    # Limit depth to avoid expensive full repository traversal.
+    for depth in range(1, 5):
+        pattern = "/".join(["*"] * depth)
+        for path in root.glob(pattern):
+            if "screenshot" in path.name.lower():
+                consider(path)
 
     candidates.sort(key=lambda item: item.as_posix())
-    return candidates[:PR_SCREENSHOT_MAX_FILES]
+    selected = candidates[:PR_SCREENSHOT_MAX_FILES]
+    logger.info(
+        "Discovered %d PR screenshot candidate(s) in %s (returning %d)",
+        len(candidates),
+        root,
+        len(selected),
+    )
+    return selected
 
 
 def ensure_pr_screenshot_release(

--- a/backend/app/services/opencode_runner_service.py
+++ b/backend/app/services/opencode_runner_service.py
@@ -11,6 +11,7 @@ is never placed inside the OpenCode process/container.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -22,6 +23,8 @@ from app.config import settings
 from app.services.coding_agent import pr_publish
 from app.services.github_service import GitHubService
 from app.services.opencode_catalog import OPENCODE_DEFAULT_MODEL, OPENCODE_ZEN_BASE_URL
+
+logger = logging.getLogger(__name__)
 
 _REMOTE_PUBLISH_MODES: frozenset[str] = frozenset(
     {"draft_pr", "open_pr", "commit_push", "direct_commit", "update_existing_pr"}
@@ -39,9 +42,17 @@ _LOCAL_ONLY_RULES = (
     "and start a short-lived preview/dev server solely to capture the UI, then stop the server. "
     "Do not commit screenshot binaries into source; Heym uploads those images onto the pull "
     "request afterward. "
-    "End your final assistant message with a dedicated line "
+    "PR metadata is MANDATORY. End your final assistant message with a dedicated line "
     "`PR_TITLE: <imperative one-line change description, ideally <=72 chars>` — never use "
-    "placeholders such as Done, Fixed, or Update."
+    "placeholders such as Done, Fixed, Update, or Completed. "
+    "A good PR title is specific and action-oriented, e.g. "
+    "`PR_TITLE: Fix OpenCode fallback summary when no assistant message is returned` or "
+    "`PR_TITLE: Add case-insensitive screenshot discovery for OpenCode PRs`. "
+    "Bad titles are generic or incomplete, e.g. `PR_TITLE: Fix issue`, `PR_TITLE: Update code`, "
+    "`PR_TITLE: Done`, or `PR_TITLE: Apply changes`. "
+    "After the PR_TITLE line, provide a concise PR description that explains what changed and "
+    "why, using a `## Summary` section. If you saved screenshots, mention their file paths so "
+    "they can be attached automatically."
 )
 _MAX_ERROR_DETAIL_CHARS = 4000
 
@@ -151,7 +162,7 @@ class OpenCodeRunnerService:
         config_path.chmod(0o600)
 
     # --- output parsing ---
-    def parse_events(self, stdout: str) -> OpenCodeRunResult:
+    def parse_events(self, stdout: str, task_prompt: str = "") -> OpenCodeRunResult:
         events: list[dict] = []
         summary = ""
         for raw in (stdout or "").splitlines():
@@ -169,7 +180,7 @@ class OpenCodeRunnerService:
             if text:
                 summary = text
         if not summary:
-            summary = "OpenCode completed without a final assistant message."
+            summary = self._fallback_summary(task_prompt)
         pull_request_title, cleaned_summary = pr_publish.extract_pr_title_line(summary)
         return OpenCodeRunResult(
             status="completed",
@@ -177,6 +188,57 @@ class OpenCodeRunnerService:
             pull_request_title=pull_request_title,
             raw_events=events,
         )
+
+    @staticmethod
+    def _fallback_summary(task_prompt: str) -> str:
+        """Build a useful fallback summary from the task prompt when the agent is silent."""
+        prompt = str(task_prompt or "").strip()
+        if not prompt:
+            return "OpenCode completed without a final assistant message."
+        first_line = prompt.splitlines()[0].strip()
+        # Take a reasonable fragment so the summary is readable but not the whole prompt.
+        snippet = first_line[:200].strip()
+        if len(snippet) < 8:
+            return "OpenCode completed without a final assistant message."
+        return f"OpenCode completed the requested task: {snippet}"
+
+    def _normalize_pr_metadata(self, result: OpenCodeRunResult, task_prompt: str) -> None:
+        """Ensure PR title and body are meaningful and informative before publishing."""
+        result.pull_request_title = self._ensure_meaningful_pr_title(result, task_prompt)
+        result.pull_request_body = self._ensure_pr_body(result, task_prompt)
+
+    def _ensure_meaningful_pr_title(self, result: OpenCodeRunResult, task_prompt: str) -> str:
+        """Return a meaningful PR title, deriving one from context if the agent's title is weak."""
+        candidates = [
+            result.pull_request_title,
+            result.summary,
+        ]
+        for candidate in candidates:
+            title = pr_publish.normalize_title_candidate(candidate)
+            if pr_publish.is_meaningful_commit_title(title):
+                return title
+        prompt = str(task_prompt or "").strip()
+        if prompt:
+            first_line = prompt.splitlines()[0].strip()
+            if len(first_line) >= 8:
+                return pr_publish.normalize_title_candidate(first_line)
+        return "Apply OpenCode changes"
+
+    def _ensure_pr_body(self, result: OpenCodeRunResult, task_prompt: str) -> str:
+        """Return a PR body with adequate context; enhance a short or missing body."""
+        body = str(result.pull_request_body or "").strip()
+        summary = str(result.summary or "").strip()
+        prompt = str(task_prompt or "").strip()
+        if len(body) >= 60 and body != summary:
+            return body
+        parts: list[str] = []
+        if summary and summary != body:
+            parts.append(summary)
+        if prompt:
+            parts.append(f"## Task\n\n{prompt}")
+        if not parts:
+            return ""
+        return "\n\n".join(parts)
 
     @staticmethod
     def _event_assistant_text(event: dict) -> str:
@@ -285,7 +347,8 @@ class OpenCodeRunnerService:
             home, api_key=request.api_key, base_url=request.base_url, model=model
         )
         stdout = self._exec_opencode(workspace, home, request, model)
-        result = self.parse_events(stdout)
+        result = self.parse_events(stdout, task_prompt=request.task_prompt)
+        self._normalize_pr_metadata(result, request.task_prompt)
         result.workspace_path = str(workspace)
         result.branch_name = request.branch_name
         result.diff = self._git_output(["git", "diff", "--binary"], workspace)
@@ -570,10 +633,14 @@ class OpenCodeRunnerService:
         draft: bool,
     ) -> str | None:
         owner, repo = pr_publish.parse_github_owner_repo(request.repository_url)
-        title = pr_publish.commit_title(
-            result.pull_request_title, result.summary, fallback="Apply OpenCode changes"
-        )
-        pr_body = str(result.pull_request_body or "").strip() or result.summary or None
+        title = result.pull_request_title or "Apply OpenCode changes"
+        if not pr_publish.is_meaningful_commit_title(title):
+            logger.warning(
+                "OpenCode PR title is missing or low quality; creating PR with title: %s", title
+            )
+        pr_body = result.pull_request_body or None
+        if not pr_body:
+            logger.warning("OpenCode PR body is empty; creating PR without a description")
         gh = GitHubService(request.github_config)
         try:
             pr = gh.create_pull_request(

--- a/backend/tests/test_coding_agent_pr_publish.py
+++ b/backend/tests/test_coding_agent_pr_publish.py
@@ -114,6 +114,44 @@ class TestPrPublishHelpers(unittest.TestCase):
             found = pr_publish.discover_pr_screenshots(workspace, lambda _cmd, _ws: "")
             self.assertEqual([p.resolve() for p in found], [shot.resolve()])
 
+    def test_discover_finds_case_insensitive_screenshot_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            shot = workspace / "ScreenShot-Mobile.png"
+            shot.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+            found = pr_publish.discover_pr_screenshots(workspace, lambda _cmd, _ws: "")
+            self.assertEqual([p.resolve() for p in found], [shot.resolve()])
+
+    def test_discover_finds_common_screenshot_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            shot = workspace / "e2e" / "screenshots" / "after.png"
+            shot.parent.mkdir(parents=True)
+            shot.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+            found = pr_publish.discover_pr_screenshots(workspace, lambda _cmd, _ws: "")
+            self.assertEqual([p.resolve() for p in found], [shot.resolve()])
+
+    def test_discover_skips_tracked_screenshots(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            shot = workspace / "docs" / "screenshots" / "login.png"
+            shot.parent.mkdir(parents=True)
+            shot.write_bytes(b"tracked")
+            found = pr_publish.discover_pr_screenshots(
+                workspace, lambda _cmd, _ws: "docs/screenshots/login.png\n"
+            )
+            self.assertEqual(found, [])
+
+    def test_discover_respects_max_file_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            for index in range(7):
+                shot = workspace / "frontend" / ".e2e-artifacts" / f"ui-{index}.png"
+                shot.parent.mkdir(parents=True, exist_ok=True)
+                shot.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+            found = pr_publish.discover_pr_screenshots(workspace, lambda _cmd, _ws: "")
+            self.assertEqual(len(found), pr_publish.PR_SCREENSHOT_MAX_FILES)
+
     def test_upload_and_inject_uses_gh(self):
         gh = MagicMock()
         gh.get_release_by_tag.side_effect = ValueError("Not Found")

--- a/backend/tests/test_opencode_runner_service.py
+++ b/backend/tests/test_opencode_runner_service.py
@@ -2,11 +2,15 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.config import settings
 from app.services.coding_agent import pr_publish
-from app.services.opencode_runner_service import OpenCodeRunnerService, OpenCodeRunRequest
+from app.services.opencode_runner_service import (
+    OpenCodeRunnerService,
+    OpenCodeRunRequest,
+    OpenCodeRunResult,
+)
 
 _WS = Path("/tmp/heym-oc-ws/run1")
 
@@ -48,6 +52,21 @@ class TestOpenCodeRunCommand(unittest.TestCase):
         self.assertIn("PR_TITLE:", cmd[-1])
         self.assertNotIn("./check.sh", cmd[-1])
         self.assertNotIn("Do NOT install package managers", cmd[-1])
+
+    def test_run_command_emphasizes_mandatory_pr_title(self):
+        cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
+        prompt = cmd[-1]
+        self.assertIn("PR metadata is MANDATORY", prompt)
+        self.assertIn("good PR title is specific", prompt)
+        self.assertIn("Bad titles are generic", prompt)
+        self.assertIn("## Summary", prompt)
+
+    def test_run_command_includes_screenshot_instructions(self):
+        cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
+        prompt = cmd[-1]
+        self.assertIn("MUST save at least one PNG screenshot", prompt)
+        self.assertIn("frontend/.e2e-artifacts/", prompt)
+        self.assertIn("Do not commit screenshot binaries", prompt)
 
     def test_run_command_pins_workspace_dir(self):
         cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
@@ -138,6 +157,71 @@ class TestOpenCodeParser(unittest.TestCase):
         self.assertEqual(result.status, "completed")
         self.assertTrue(result.summary)
 
+    def test_parse_uses_task_prompt_for_fallback_summary(self):
+        result = self.svc.parse_events("", task_prompt="Fix the OpenCode fallback summary logic")
+        self.assertIn("OpenCode completed the requested task", result.summary)
+        self.assertIn("Fix the OpenCode fallback summary logic", result.summary)
+
+    def test_parse_fallback_summary_avoids_generic_message_when_prompt_present(self):
+        result = self.svc.parse_events("", task_prompt="Add case-insensitive screenshot discovery")
+        self.assertNotEqual(result.summary, "OpenCode completed without a final assistant message.")
+        self.assertIn("Add case-insensitive screenshot discovery", result.summary)
+
+    def test_parse_empty_task_prompt_falls_back_to_generic_message(self):
+        result = self.svc.parse_events("", task_prompt="")
+        self.assertEqual(result.summary, "OpenCode completed without a final assistant message.")
+
+
+class TestOpenCodePrMetadataNormalization(unittest.TestCase):
+    def setUp(self):
+        self.svc = OpenCodeRunnerService(workspace_root="/tmp/heym-oc-ws")
+
+    def test_ensure_meaningful_pr_title_prefers_agent_title(self):
+        result = OpenCodeRunResult(
+            summary="Did some work.",
+            pull_request_title="Fix OpenCode fallback summary logic",
+        )
+        title = self.svc._ensure_meaningful_pr_title(result, "some task")
+        self.assertEqual(title, "Fix OpenCode fallback summary logic")
+
+    def test_ensure_meaningful_pr_title_skips_placeholder(self):
+        result = OpenCodeRunResult(summary="Done.", pull_request_title="Done")
+        title = self.svc._ensure_meaningful_pr_title(result, "Fix OpenCode fallback summary logic")
+        self.assertEqual(title, "Fix OpenCode fallback summary logic")
+
+    def test_ensure_meaningful_pr_title_derives_from_summary(self):
+        result = OpenCodeRunResult(
+            summary="Implemented the mobile drawer fix.", pull_request_title=""
+        )
+        title = self.svc._ensure_meaningful_pr_title(result, "fix ui")
+        self.assertEqual(title, "Implemented the mobile drawer fix.")
+
+    def test_ensure_meaningful_pr_title_last_resort_fallback(self):
+        result = OpenCodeRunResult(summary="Done.", pull_request_title="")
+        title = self.svc._ensure_meaningful_pr_title(result, "")
+        self.assertEqual(title, "Apply OpenCode changes")
+
+    def test_ensure_pr_body_enhances_short_body_with_task(self):
+        result = OpenCodeRunResult(summary="Done.", pull_request_body="")
+        body = self.svc._ensure_pr_body(result, "Fix OpenCode fallback summary logic")
+        self.assertIn("## Task", body)
+        self.assertIn("Fix OpenCode fallback summary logic", body)
+
+    def test_ensure_pr_body_keeps_existing_long_body(self):
+        long_body = "This is a sufficiently long PR body with enough context to remain unchanged."
+        result = OpenCodeRunResult(
+            summary="Summary text.",
+            pull_request_body=long_body,
+        )
+        body = self.svc._ensure_pr_body(result, "task prompt")
+        self.assertEqual(body, long_body)
+
+    def test_normalize_pr_metadata_mutates_result(self):
+        result = OpenCodeRunResult(summary="Done.", pull_request_title="Update")
+        self.svc._normalize_pr_metadata(result, "Fix OpenCode fallback summary logic")
+        self.assertEqual(result.pull_request_title, "Fix OpenCode fallback summary logic")
+        self.assertIn("## Task", result.pull_request_body)
+
 
 class TestOpenCodeExecFailureFormatting(unittest.TestCase):
     def test_event_stream_is_not_dumped_as_error(self) -> None:
@@ -172,6 +256,42 @@ class TestOpenCodeExecFailureFormatting(unittest.TestCase):
     def test_plain_stderr_is_preserved(self) -> None:
         detail = OpenCodeRunnerService._format_exec_failure(1, "", "opencode: command failed")
         self.assertEqual(detail, "opencode: command failed")
+
+
+class TestOpenCodeCreatePr(unittest.TestCase):
+    def setUp(self):
+        self.runner = OpenCodeRunnerService(workspace_root="/tmp/heym-oc-ws")
+        self.workspace = Path("/tmp/ws")
+        self.request = _request(publish_mode="open_pr", branch_name="opencode/run")
+
+    def test_create_pr_enhances_weak_title_and_body(self):
+        result = OpenCodeRunResult(
+            status="completed",
+            summary="Done.",
+            pull_request_title="Update",
+            pull_request_body="",
+            changed_files=["a.vue"],
+        )
+        self.runner._normalize_pr_metadata(result, self.request.task_prompt)
+        gh = MagicMock()
+        gh.create_pull_request.return_value = {
+            "number": 1,
+            "html_url": "https://github.com/acme/app/pull/1",
+        }
+
+        with patch("app.services.opencode_runner_service.GitHubService", return_value=gh) as gh_cls:
+            url = self.runner._create_pr(
+                self.workspace, self.request, result, "opencode/run", draft=False
+            )
+
+        self.assertEqual(url, "https://github.com/acme/app/pull/1")
+        gh_cls.assert_called()
+        title = gh.create_pull_request.call_args.args[2]
+        body = gh.create_pull_request.call_args.kwargs["body"]
+        self.assertNotEqual(title, "Update")
+        self.assertIn("fix the tests", title.lower())
+        self.assertIn("## Task", body)
+        self.assertIn("fix the tests", body.lower())
 
 
 class TestOpenCodePushBranch(unittest.TestCase):


### PR DESCRIPTION
Implemented the OpenCode Go node PR metadata and screenshot improvements.

**Changed files:**
- `backend/app/services/opencode_runner_service.py`
  - Rewrote `_LOCAL_ONLY_RULES` to make `PR_TITLE:` mandatory, show good/bad title examples, require a `## Summary` description, and make screenshot instructions more prominent.
  - Updated `parse_events()` to accept `task_prompt` and use `_fallback_summary()` for a meaningful summary when OpenCode returns no final assistant message.
  - Added `_normalize_pr_metadata()`, `_ensure_meaningful_pr_title()`, and `_ensure_pr_body()` to validate/enrich PR titles and bodies before publishing.
  - Updated `_create_pr()` to log warnings when fallback/low-quality titles or empty bodies are used.
  - Wired `run_task()` to pass `task_prompt` into parsing and normalize metadata before publish.

- `backend/app/services/coding_agent/pr_publish.py`
  - Added `logger` and debug/info logging inside `discover_pr_screenshots()`.
  - Expanded screenshot search to common directories (`screenshots`, `e2e/screenshots`, `test/screenshots`, `tests/screenshots`, `artifacts`, etc.).
  - Added bounded, case-insensitive search for paths containing “screenshot”.

- `backend/tests/test_opencode_runner_service.py`
  - Added tests for enhanced prompt content, fallback summary logic, PR title/body normalization, and `_create_pr()` enrichment.

- `backend/tests/test_coding_agent_pr_publish.py`
  - Added tests for case-insensitive screenshot discovery, common screenshot directories, tracked-file skipping, and max-file cap.

**Verification:**
- Ran targeted tests: 80 passed (`test_opencode_runner_service.py`, `test_coding_agent_pr_publish.py`, `test_codex_pr_screenshots.py`, `test_codex_publish_modes.py`).
- Ran `ruff format` and `ruff check` on changed files — all clean.
- Ran line-limit guard — OK.
- Full backend test suite had 2 unrelated environment failures (`test_clarify_protocol_prompt.py` cwd issue, `test_playwright_security.py` venv path issue). All 2,285 other tests passed.
- `./check.sh` could not be run end-to-end because `bun` is not installed in this environment and the workspace venv is read-only; I ran the applicable backend portions directly.