### PR TITLE
Sanitize execution history JSON for PostgreSQL

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -74,6 +74,7 @@ _ITEM_DOT_PATH_RE = re.compile(r"^item(?:\.[a-zA-Z_][a-zA-Z0-9_]*)+$")
 _ITEM_REF_IN_TEMPLATE_RE = re.compile(r"item\.[a-zA-Z_][a-zA-Z0-9_]*\b(?!\()")
 _DOLLAR_NAME_RE = re.compile(r"\$([a-zA-Z_][a-zA-Z0-9_]*)")
 _ITEM_EXPRESSION_STRING_START_RE = re.compile(r"\.(?:distinctBy|distinct_by|filter|map|sort)\(\s*$")
+_POSTGRES_UNSAFE_JSON_STRING_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\ud800-\udfff]")
 
 _SLUG_RE = re.compile(r"[^a-zA-Z0-9]+")
 _EXECUTION_CONTEXT_INPUT_KEY = "__heym_execution_context"
@@ -1551,11 +1552,16 @@ def _wrap_value(value: object) -> object:
 
 
 def _to_json_compatible(value: object) -> object:
-    """Convert expression wrapper types back to plain JSON-safe containers."""
+    """Convert wrappers and recursively sanitize values for PostgreSQL JSON fields."""
     if isinstance(value, DotDict):
-        return {key: _to_json_compatible(item) for key, item in dict.items(value)}
+        return {
+            _to_json_compatible_key(key): _to_json_compatible(item)
+            for key, item in dict.items(value)
+        }
     if isinstance(value, dict):
-        return {key: _to_json_compatible(item) for key, item in value.items()}
+        return {
+            _to_json_compatible_key(key): _to_json_compatible(item) for key, item in value.items()
+        }
     if isinstance(value, DotList):
         return [_to_json_compatible(item) for item in list(value)]
     if isinstance(value, list):
@@ -1567,10 +1573,22 @@ def _to_json_compatible(value: object) -> object:
     if isinstance(value, DotFloat):
         return float(value)
     if isinstance(value, DotStr):
-        return str(value)
+        return _sanitize_json_string(str(value))
     if isinstance(value, DotDateTime):
         return value.toISO()
+    if isinstance(value, str):
+        return _sanitize_json_string(value)
     return value
+
+
+def _to_json_compatible_key(key: object) -> object:
+    if isinstance(key, str):
+        return _sanitize_json_string(str(key))
+    return key
+
+
+def _sanitize_json_string(value: str) -> str:
+    return _POSTGRES_UNSAFE_JSON_STRING_RE.sub("", value)
 
 
 @dataclass

--- a/backend/tests/test_board_run_service.py
+++ b/backend/tests/test_board_run_service.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import uuid
 from datetime import datetime, timezone
@@ -239,6 +240,38 @@ class TestRunCardChain(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(card.run_status, "success")
         advance.assert_awaited_once()
         self.assertFalse(advance.await_args.kwargs.get("ignore_gate", False))
+
+    async def test_execution_history_removes_null_bytes_from_all_json_fields(self) -> None:
+        card, board, session, factory, links, context = _chain_env()
+        card.title = "T\u0000itle"
+
+        def fake_execute(**_kwargs: object) -> SimpleNamespace:
+            result = _success_result({"nested": ["out\u0000put"]})
+            result.node_results = [{"output": {"text": "node\u0000result"}}]
+            return result
+
+        patches = _runner_patches(context, fake_execute)
+        for p in patches:
+            p.start()
+        self.addCleanup(lambda: [p.stop() for p in patches])
+
+        with patch.object(board_run_service, "_auto_advance", AsyncMock()):
+            await board_run_service._run_chain(
+                card_id=card.id,
+                board_id=board.id,
+                column_id=card.column_id,
+                links=links[:1],
+                move=None,
+                rerun=True,
+                session_factory=factory,
+            )
+
+        history = next(o for o in session.added if type(o).__name__ == "ExecutionHistory")
+        self.assertEqual(history.inputs["card"]["title"], "Title")
+        self.assertEqual(history.outputs, {"nested": ["output"]})
+        self.assertEqual(history.node_results[0]["output"]["text"], "noderesult")
+        serialized = json.dumps([history.inputs, history.outputs, history.node_results])
+        self.assertNotIn(r"\u0000", serialized)
 
     async def test_follow_up_rerun_does_not_bypass_the_planning_gate(self):
         """A Run in a gate column must wait for a comment — ignore_gate stays off."""

--- a/backend/tests/test_workflow_json_compatibility.py
+++ b/backend/tests/test_workflow_json_compatibility.py
@@ -4,6 +4,7 @@ import unittest
 from app.services.workflow_executor import (
     DotDict,
     DotList,
+    DotStr,
     NodeResult,
     SubWorkflowExecution,
     _serialize_node_result,
@@ -25,6 +26,37 @@ class WorkflowJsonCompatibilityTests(unittest.TestCase):
 
         self.assertEqual(plain, {"items": [{"value": 1}], "keys": ["a", "b"]})
         json.dumps(plain)
+
+    def test_postgresql_unsafe_characters_are_sanitized_recursively(self) -> None:
+        wrapped = DotDict(
+            {
+                "unsafe\u0000key": DotList(
+                    [
+                        DotStr("null\u0000byte"),
+                        {"controls": "before\u0001\u0008\u000b\u001f\u007f\u0080\u009fafter"},
+                        {"surrogate": "before\ud800after"},
+                    ]
+                ),
+                "whitespace": "tab\tnewline\nreturn\r",
+            }
+        )
+
+        plain = _to_json_compatible(wrapped)
+
+        self.assertEqual(
+            plain,
+            {
+                "unsafekey": [
+                    "nullbyte",
+                    {"controls": "beforeafter"},
+                    {"surrogate": "beforeafter"},
+                ],
+                "whitespace": "tab\tnewline\nreturn\r",
+            },
+        )
+        serialized = json.dumps(plain)
+        self.assertNotIn(r"\u0000", serialized)
+        self.assertNotIn(r"\ud800", serialized)
 
     def test_node_result_serialization_removes_dot_wrappers(self) -> None:
         result = NodeResult(


### PR DESCRIPTION
## Summary
- strip PostgreSQL-unsafe control characters and lone surrogates from JSON strings
- sanitize nested dictionary values, lists, and dictionary keys
- cover board-run ExecutionHistory inputs, outputs, and node results

## Validation
- focused backend tests: 22 passed
- backend Ruff formatting and lint: passed
- full backend suite: 2,288 passed; the sole sandbox path failure passed with a writable workspace override
- frontend checks unavailable because Bun is not installed