### PR TITLE
Install Bun in backend Dockerfile to enable frontend checks in containers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ARG HEYM_CODEX_CLI_VERSION=latest
 RUN npm install -g @openai/codex@${HEYM_CODEX_CLI_VERSION}
 
+# Bun (required for frontend lint/typecheck from this image, e.g. opencode isolated execution).
+RUN curl -fsSL https://bun.sh/install | bash \
+    && ln -sf /root/.bun/bin/bun /usr/local/bin/bun \
+    && bun --version
+
 # OpenCode CLI (Go) required by the OpenCode Go node. The runner executes it inside a hardened
 # sibling container of this same image. Pin via the HEYM_OPENCODE_CLI_VERSION build arg; the
 # installer resolves "latest" only when VERSION is unset (passing VERSION=latest looks up a literal


### PR DESCRIPTION
## Summary
The `check.sh` script relies on Bun for frontend linting and type-checking (`bun run lint` / `bun run typecheck`), but the backend Docker image previously did not install Bun. In isolated/opencode container execution this caused `bun: command not found` failures when running `check.sh`.

Updated `backend/Dockerfile` to install the official Bun binary after the existing Node.js/npm installation by:

- Running `curl -fsSL https://bun.sh/install | bash`
- Symlinking `/root/.bun/bin/bun` to `/usr/local/bin/bun` so it is available on `PATH`
- Verifying the installation with `bun --version`

This follows the same symlink pattern already used for the OpenCode CLI in the same Dockerfile and does not affect any other files.

## Task

Fix the 'frontend checks unavailable because Bun is not installed' error by installing Bun in the backend Dockerfile.

## Problem
The `check.sh` script requires Bun to run frontend checks (`bun run lint` and `bun run typecheck`), but Bun is not installed in the opencode isolated container environment. This causes the script to fail with 'bun: command not found' when run in container-based environments.

## Solution
Install Bun in the `backend/Dockerfile` so it's available in the opencode isolated container and all environments based on the backend Docker image.

## Implementation Requirements
1. Modify `backend/Dockerfile` to install Bun using the official installation method
2. Install Bun after the existing Node.js/npm installation (around line 10-12)
3. Use the official Bun installation script: `curl -fsSL https://bun.sh/install | bash`
4. Ensure Bun is added to PATH by updating the PATH environment variable or creating appropriate symlinks
5. Follow the existing pattern in the Dockerfile for tool installations
6. Do not modify any other files or refactor existing code

## Verification
After installation, verify that:
- Bun is accessible in the container PATH
- `bun --version` works correctly
- The `check.sh` script can successfully run frontend checks in the container environment

## Context
- The backend Dockerfile already installs Node.js and npm
- The project uses Bun as the primary frontend package manager
- Multiple PRs have reported this issue (e.g., #377, #338, #94)
- The opencode runner uses the same Docker image (`heym-backend:local`) for isolated execution

## Files to Modify
- `backend/Dockerfile` - Add Bun installation after Node.js/npm installation