### PR TITLE
Fix mobile Drive tab header layout in DrivePanel.vue

### DIFF
--- a/frontend/src/components/Drive/DrivePanel.vue
+++ b/frontend/src/components/Drive/DrivePanel.vue
@@ -352,27 +352,28 @@ onBeforeUnmount(() => {
     </div>
 
     <!-- Header -->
-    <div class="flex items-center justify-between gap-3">
-      <div class="flex items-center gap-2">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div class="flex items-center gap-2 shrink-0">
         <HardDrive class="w-5 h-5 text-muted-foreground" />
         <h2 class="text-lg font-semibold">
           Drive
         </h2>
-        <span class="text-xs text-muted-foreground">({{ total }} files)</span>
+        <span class="text-xs text-muted-foreground whitespace-nowrap">({{ total }} files)</span>
       </div>
-      <div class="flex flex-wrap items-center justify-end gap-2">
-        <div class="relative">
+      <div class="grid grid-cols-[1fr_auto_auto] items-center gap-2 sm:flex sm:flex-wrap sm:justify-end">
+        <div class="relative min-w-0">
           <Search class="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
           <Input
             v-model="searchQuery"
             placeholder="Search files..."
-            class="pl-8 h-8 text-xs w-48"
+            class="pl-8 h-8 text-xs w-full sm:w-48"
           />
         </div>
         <Button
           size="sm"
           variant="ghost"
           :disabled="loading"
+          class="px-2 sm:px-4"
           @click="loadFiles"
         >
           <RefreshCw
@@ -386,6 +387,7 @@ onBeforeUnmount(() => {
           variant="destructive"
           :loading="clearing"
           :disabled="loading || clearing"
+          class="px-2 sm:px-4"
           @click="clearAllFiles"
         >
           <Trash2 class="w-3.5 h-3.5" />


### PR DESCRIPTION
Fixed the mobile Drive tab header layout in `frontend/src/components/Drive/DrivePanel.vue`.

## Summary
- **Title + counter on one line:** changed the header wrapper to `flex flex-col sm:flex-row` and added `shrink-0` / `whitespace-nowrap` to the title/counter group so "(5 files)" no longer wraps on mobile.
- **Search + actions aligned:** replaced the mobile control row with `grid grid-cols-[1fr_auto_auto]` so the search input, refresh button, and Clear All button share a single aligned row. Desktop keeps the original `sm:flex sm:flex-wrap sm:justify-end` layout.
- **Reduced button size on mobile:** added `px-2 sm:px-4` to the refresh and Clear All buttons to shrink their width on small screens without affecting desktop.
- **Search input responsive width:** changed the search input from fixed `w-48` to `w-full sm:w-48` so it fills the grid column on mobile.

Verified with `bun run lint:check` and `bun run typecheck` (both pass).

Screenshot saved at: `frontend/.e2e-artifacts/drive-mobile-header.png`

## Task

Fix the mobile drive tab header layout in frontend/src/components/Drive/DrivePanel.vue

Specific Requirements:
1. The "5 files" text is causing an unnecessary line break on mobile. The header title and counter should be aligned on a single line using flexbox.
2. The "Search" and "Clear All" fields are placed unevenly on mobile. They should be aligned within the same grid, and the button size should be reduced.
3. IMPORTANT: Only update the mobile view. Do not change the desktop layout.

Current Issues:
- Header section (lines ~139-165) needs mobile-specific styling
- The title "Drive" and file counter "({{ total }} files)" are wrapping on mobile
- Search input and Clear All button are not properly aligned on mobile

Expected Changes:
- Add mobile-specific classes to keep header title and counter on one line
- Use flexbox for proper alignment on mobile
- Reduce button sizes for mobile
- Ensure Search and Clear All are aligned in a grid on mobile
- Desktop layout should remain unchanged

## Screenshots

![pr-379-drive-mobile-header.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-379-drive-mobile-header.png)
