### PR TITLE
OpenCode completed the requested task: Update the TracesPanel.vue component to make the 5 columns in the traces tab stack vertically (full width) on mobile devices while keeping the desktop view unchanged.

### DIFF
--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -911,7 +911,7 @@ onMounted(async () => {
         v-else
         class="space-y-4"
       >
-        <div class="grid gap-3 md:grid-cols-4">
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-4">
           <Card
             variant="flat"
             :hover="false"
@@ -971,7 +971,7 @@ onMounted(async () => {
           :spans="spans"
         />
 
-        <div class="grid gap-3 md:grid-cols-3">
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
           <Card
             variant="flat"
             :hover="false"


### PR DESCRIPTION
OpenCode completed the requested task: Update the TracesPanel.vue component to make the 5 columns in the traces tab stack vertically (full width) on mobile devices while keeping the desktop view unchanged.

## Task

Update the TracesPanel.vue component to make the 5 columns in the traces tab stack vertically (full width) on mobile devices while keeping the desktop view unchanged.

**Requirements:**
1. On mobile (default breakpoint): All columns should stack vertically with each taking full width (grid-cols-1)
2. On desktop (md breakpoint and above): Keep the current multi-column layout unchanged
3. Maintain current ordering of columns
4. No collapse/expand logic needed on mobile

**Files to modify:**
- `frontend/src/components/Traces/TracesPanel.vue`

**Specific changes needed:**
1. In the filter section (around line 447-452), ensure the grid has `grid-cols-1` as the default (mobile) class
2. In the detail cards section (around line 543-546), ensure the grid has `grid-cols-1` as the default (mobile) class
3. Keep all existing `sm:`, `md:` responsive classes for tablet and desktop views
4. The current code already has some responsive classes, but verify they properly stack on mobile

**Testing:**
- Test on mobile viewport to ensure all 5 columns stack vertically
- Test on desktop to ensure the layout remains unchanged
- Verify the ordering is preserved

**Note:** This is a UI change, so if you need to take a screenshot for verification, save it to `frontend/.e2e-artifacts/` but do not commit it.