### PR TITLE
Make trace detail stat cards stack vertically on mobile

### DIFF
--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -911,7 +911,7 @@ onMounted(async () => {
         v-else
         class="space-y-4"
       >
-        <div class="grid gap-3 md:grid-cols-4">
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-4">
           <Card
             variant="flat"
             :hover="false"
@@ -971,7 +971,7 @@ onMounted(async () => {
           :spans="spans"
         />
 
-        <div class="grid gap-3 md:grid-cols-3">
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-3">
           <Card
             variant="flat"
             :hover="false"


### PR DESCRIPTION
Applied the mobile-layout fix to the trace detail stat cards in `frontend/src/components/Traces/TracesPanel.vue`.

What changed:
- Line 914: `<div class="grid gap-3 md:grid-cols-4">` → `<div class="grid grid-cols-1 gap-3 md:grid-cols-4">`
- Line 974: `<div class="grid gap-3 md:grid-cols-3">` → `<div class="grid grid-cols-1 gap-3 md:grid-cols-3">`

This makes the detail-dialog card grids stack vertically at full width on mobile while keeping the existing multi-column layout on `md` and wider screens.

Verification:
- `bun run lint:check` passed
- `bun run typecheck` passed
- Captured a mobile viewport screenshot showing the stacked cards: `frontend/.e2e-artifacts/traces-mobile-vertical-stack.png`

## Summary
Updates the two card grids in the Traces detail dialog so each column takes full width on mobile (`grid-cols-1`) while preserving the current desktop multi-column layout (`md:grid-cols-4` and `md:grid-cols-3`). The change matches the previous PR #380 intent and keeps the existing column order with no collapse/expand behavior.

## Task

Update the existing PR #380 branch (opencode/traces-mobile-vertical-stack) to fix the mobile layout for the traces tab. The task is to make the 5 columns in the traces tab stack vertically (full width) on mobile devices while keeping the desktop view unchanged.

Requirements:
1. On mobile (default breakpoint): All columns should stack vertically with each taking full width (grid-cols-1)
2. On desktop (md breakpoint and above): Keep the current multi-column layout unchanged
3. Maintain current ordering of columns
4. No collapse/expand logic needed on mobile

Files to modify:
- frontend/src/components/Traces/TracesPanel.vue

Specific changes needed:
1. Line 914: Change `<div class="grid gap-3 md:grid-cols-4">` to `<div class="grid grid-cols-1 gap-3 md:grid-cols-4">`
2. Line 974: Change `<div class="grid gap-3 md:grid-cols-3">` to `<div class="grid grid-cols-1 gap-3 md:grid-cols-3">`

These are the same changes that were made in the previous PR #380, which was closed but not merged. Update the existing branch with these changes.

Note: This is a UI change. If you need to take a screenshot for verification, save it to frontend/.e2e-artifacts/ but do not commit it. The screenshot should be named appropriately to show the mobile layout improvement.

## Screenshots

![pr-381-traces-mobile-vertical-stack.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-381-traces-mobile-vertical-stack.png)
