### PR TITLE
Good. The change is purely a Tailwind class change. To make a faithful mobile screenshot, the cleanest approach is to write a Playwright script that mocks the API responses (including auth) and serves the actual page. Let me see how the dev server's auth works:

### DIFF
--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -169,7 +169,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
 
 <template>
   <div class="space-y-4">
-    <div class="grid gap-3 grid-cols-2 md:grid-cols-5">
+    <div class="grid gap-3 grid-cols-1 md:grid-cols-5">
       <Card
         variant="flat"
         :hover="false"


### PR DESCRIPTION
Good. The change is purely a Tailwind class change. To make a faithful mobile screenshot, the cleanest approach is to write a Playwright script that mocks the API responses (including auth) and serves the actual page. Let me see how the dev server's auth works:

## Task

Fix the mobile layout for the traces tab 5-column header. The previous PR #381 incorrectly modified the detail dialog grids instead of the main traces tab header.

**Target File:** `frontend/src/components/Traces/TracesStatsHeader.vue`

**Required Change:**
Line 139: Change `<div class="grid gap-3 grid-cols-2 md:grid-cols-5">` to `<div class="grid gap-3 grid-cols-1 md:grid-cols-5">`

**Requirements:**
1. On mobile (default breakpoint): All 5 KPI cards (Calls, Tokens, Cost, Avg Latency, Error %) should stack vertically with each taking full width (grid-cols-1)
2. On desktop (md breakpoint and above): Keep the current 5-column layout unchanged (md:grid-cols-5)
3. Maintain current ordering of columns
4. No collapse/expand logic needed

**Context:**
- This is the main traces tab header, NOT the detail dialog
- The detail dialog changes from PR #381 should remain as-is
- Only modify the KPI cards grid in TracesStatsHeader.vue

