### PR TITLE
Fix Traces tab mobile KPI and Trace Details header

### DIFF
--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -634,7 +634,7 @@ onMounted(async () => {
           Inspect AI assistant and workflow LLM calls in one place.
         </p>
       </div>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-2 w-full md:w-auto">
         <Button
           variant="outline"
           size="sm"
@@ -655,6 +655,7 @@ onMounted(async () => {
         <Button
           variant="destructive"
           size="sm"
+          class="ml-auto md:ml-0"
           :loading="clearing"
           :disabled="traces.length === 0"
           @click="clearTraces"

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -847,37 +847,37 @@ onMounted(async () => {
       @close="closeDetail"
     >
       <template #header-actions>
-        <div class="flex flex-col gap-2 w-full sm:flex-row sm:items-center sm:flex-wrap sm:w-auto">
-          <div class="flex items-center gap-1 w-full sm:w-auto">
+        <div class="flex items-center justify-between sm:justify-start gap-2 w-full sm:w-auto flex-wrap">
+          <div class="flex items-center gap-1">
             <Button
               variant="outline"
               size="sm"
-              class="h-9 px-2 flex-1 sm:flex-none md:h-7 text-xs"
+              class="h-7 w-7 p-0 sm:w-auto sm:px-2 shrink-0 text-xs"
               :disabled="!hasPreviousTrace || detailLoading"
               @click="goToPreviousTrace"
             >
-              <ChevronLeft class="w-3 h-3 md:w-4 md:h-4" />
+              <ChevronLeft class="w-3.5 h-3.5" />
               <span class="hidden sm:inline">Prev</span>
             </Button>
-            <span class="text-xs text-muted-foreground px-2 whitespace-nowrap shrink-0">
+            <span class="text-xs text-muted-foreground px-1 whitespace-nowrap">
               {{ tracePositionLabel }}
             </span>
             <Button
               variant="outline"
               size="sm"
-              class="h-9 px-2 flex-1 sm:flex-none md:h-7 text-xs"
+              class="h-7 w-7 p-0 sm:w-auto sm:px-2 shrink-0 text-xs"
               :disabled="!hasNextTrace || detailLoading"
               @click="goToNextTrace"
             >
               <span class="hidden sm:inline">Next</span>
-              <ChevronRight class="w-3 h-3 md:w-4 md:h-4" />
+              <ChevronRight class="w-3.5 h-3.5" />
             </Button>
           </div>
           <Button
             v-if="selectedTrace?.workflow_id"
             variant="outline"
             size="sm"
-            class="h-9 w-full sm:w-auto md:h-7 text-xs"
+            class="h-7 text-xs shrink-0"
             @click="goToWorkflow"
           >
             <ExternalLink class="w-3 h-3 mr-1" />

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -841,7 +841,7 @@ onMounted(async () => {
     <Dialog
       :open="detailOpen"
       title="Trace Details"
-      title-class="text-base sm:text-base md:text-lg"
+      title-class="text-lg sm:text-lg md:text-xl"
       size="3xl"
       allow-fullscreen
       default-fullscreen

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -844,47 +844,46 @@ onMounted(async () => {
       size="3xl"
       allow-fullscreen
       default-fullscreen
+      hide-fullscreen-toggle-on-mobile
       @close="closeDetail"
     >
       <template #header-actions>
-        <div class="flex items-center justify-between sm:justify-start gap-2 w-full sm:w-auto flex-wrap">
-          <div class="flex items-center gap-1">
-            <Button
-              variant="outline"
-              size="sm"
-              class="h-7 w-7 p-0 sm:w-auto sm:px-2 shrink-0 text-xs"
-              :disabled="!hasPreviousTrace || detailLoading"
-              @click="goToPreviousTrace"
-            >
-              <ChevronLeft class="w-3.5 h-3.5" />
-              <span class="hidden sm:inline">Prev</span>
-            </Button>
-            <span class="text-xs text-muted-foreground px-1 whitespace-nowrap">
-              {{ tracePositionLabel }}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              class="h-7 w-7 p-0 sm:w-auto sm:px-2 shrink-0 text-xs"
-              :disabled="!hasNextTrace || detailLoading"
-              @click="goToNextTrace"
-            >
-              <span class="hidden sm:inline">Next</span>
-              <ChevronRight class="w-3.5 h-3.5" />
-            </Button>
-          </div>
-          <Button
-            v-if="selectedTrace?.workflow_id"
-            variant="outline"
-            size="sm"
-            class="h-7 text-xs shrink-0"
-            @click="goToWorkflow"
+        <div class="inline-flex items-center h-8 rounded-lg border border-border bg-muted/50 overflow-hidden">
+          <button
+            type="button"
+            class="flex items-center justify-center h-8 w-8 text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-35 transition-colors"
+            :disabled="!hasPreviousTrace || detailLoading"
+            aria-label="Previous trace"
+            @click="goToPreviousTrace"
           >
-            <ExternalLink class="w-3 h-3 mr-1" />
-            <span class="hidden sm:inline">Go to Workflow</span>
-            <span class="sm:hidden">Workflow</span>
-          </Button>
+            <ChevronLeft class="w-4 h-4" />
+          </button>
+          <span class="h-8 min-w-[4.25rem] px-2 inline-flex items-center justify-center text-xs font-medium tabular-nums text-foreground border-x border-border bg-background/60">
+            {{ tracePositionLabel }}
+          </span>
+          <button
+            type="button"
+            class="flex items-center justify-center h-8 w-8 text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-35 transition-colors"
+            :disabled="!hasNextTrace || detailLoading"
+            aria-label="Next trace"
+            @click="goToNextTrace"
+          >
+            <ChevronRight class="w-4 h-4" />
+          </button>
         </div>
+      </template>
+      <template #header-trailing>
+        <Button
+          v-if="selectedTrace?.workflow_id"
+          variant="outline"
+          size="sm"
+          class="!h-8 !min-h-8 !px-2.5 text-xs shrink-0"
+          @click="goToWorkflow"
+        >
+          <ExternalLink class="w-3 h-3 mr-1" />
+          <span class="hidden sm:inline">Go to Workflow</span>
+          <span class="sm:hidden">Workflow</span>
+        </Button>
       </template>
       <div
         v-if="detailLoading"

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -847,25 +847,25 @@ onMounted(async () => {
       @close="closeDetail"
     >
       <template #header-actions>
-        <div class="flex items-center gap-2 flex-wrap">
-          <div class="flex items-center gap-1">
+        <div class="flex flex-col gap-2 w-full sm:flex-row sm:items-center sm:flex-wrap sm:w-auto">
+          <div class="flex items-center gap-1 w-full sm:w-auto">
             <Button
               variant="outline"
               size="sm"
-              class="h-9 px-2 md:h-7 text-xs"
+              class="h-9 px-2 flex-1 sm:flex-none md:h-7 text-xs"
               :disabled="!hasPreviousTrace || detailLoading"
               @click="goToPreviousTrace"
             >
               <ChevronLeft class="w-3 h-3 md:w-4 md:h-4" />
               <span class="hidden sm:inline">Prev</span>
             </Button>
-            <span class="text-xs text-muted-foreground px-1 whitespace-nowrap">
+            <span class="text-xs text-muted-foreground px-2 whitespace-nowrap shrink-0">
               {{ tracePositionLabel }}
             </span>
             <Button
               variant="outline"
               size="sm"
-              class="h-9 px-2 md:h-7 text-xs"
+              class="h-9 px-2 flex-1 sm:flex-none md:h-7 text-xs"
               :disabled="!hasNextTrace || detailLoading"
               @click="goToNextTrace"
             >
@@ -877,7 +877,7 @@ onMounted(async () => {
             v-if="selectedTrace?.workflow_id"
             variant="outline"
             size="sm"
-            class="h-9 md:h-7 text-xs"
+            class="h-9 w-full sm:w-auto md:h-7 text-xs"
             @click="goToWorkflow"
           >
             <ExternalLink class="w-3 h-3 mr-1" />

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -841,6 +841,7 @@ onMounted(async () => {
     <Dialog
       :open="detailOpen"
       title="Trace Details"
+      title-class="text-base sm:text-base md:text-lg"
       size="3xl"
       allow-fullscreen
       default-fullscreen
@@ -848,28 +849,40 @@ onMounted(async () => {
       @close="closeDetail"
     >
       <template #header-actions>
-        <div class="inline-flex items-center h-8 rounded-lg border border-border bg-muted/50 overflow-hidden">
-          <button
-            type="button"
-            class="flex items-center justify-center h-8 w-8 text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-35 transition-colors"
-            :disabled="!hasPreviousTrace || detailLoading"
-            aria-label="Previous trace"
-            @click="goToPreviousTrace"
+        <div class="inline-flex items-center gap-2">
+          <div class="inline-flex items-center h-8 rounded-lg border border-border bg-muted/50 overflow-hidden">
+            <button
+              type="button"
+              class="flex items-center justify-center h-8 w-8 text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-35 transition-colors"
+              :disabled="!hasPreviousTrace || detailLoading"
+              aria-label="Previous trace"
+              @click="goToPreviousTrace"
+            >
+              <ChevronLeft class="w-4 h-4" />
+            </button>
+            <span class="h-8 min-w-[4.25rem] px-2 inline-flex items-center justify-center text-xs font-medium tabular-nums text-foreground border-x border-border bg-background/60">
+              {{ tracePositionLabel }}
+            </span>
+            <button
+              type="button"
+              class="flex items-center justify-center h-8 w-8 text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-35 transition-colors"
+              :disabled="!hasNextTrace || detailLoading"
+              aria-label="Next trace"
+              @click="goToNextTrace"
+            >
+              <ChevronRight class="w-4 h-4" />
+            </button>
+          </div>
+          <Button
+            v-if="selectedTrace?.workflow_id"
+            variant="outline"
+            size="sm"
+            class="!h-8 !min-h-8 !px-2.5 text-xs shrink-0 hidden sm:inline-flex"
+            @click="goToWorkflow"
           >
-            <ChevronLeft class="w-4 h-4" />
-          </button>
-          <span class="h-8 min-w-[4.25rem] px-2 inline-flex items-center justify-center text-xs font-medium tabular-nums text-foreground border-x border-border bg-background/60">
-            {{ tracePositionLabel }}
-          </span>
-          <button
-            type="button"
-            class="flex items-center justify-center h-8 w-8 text-foreground hover:bg-accent disabled:pointer-events-none disabled:opacity-35 transition-colors"
-            :disabled="!hasNextTrace || detailLoading"
-            aria-label="Next trace"
-            @click="goToNextTrace"
-          >
-            <ChevronRight class="w-4 h-4" />
-          </button>
+            <ExternalLink class="w-3 h-3 mr-1" />
+            Go to Workflow
+          </Button>
         </div>
       </template>
       <template #header-trailing>
@@ -877,12 +890,11 @@ onMounted(async () => {
           v-if="selectedTrace?.workflow_id"
           variant="outline"
           size="sm"
-          class="!h-8 !min-h-8 !px-2.5 text-xs shrink-0"
+          class="!h-8 !min-h-8 !px-2.5 text-xs shrink-0 sm:hidden"
           @click="goToWorkflow"
         >
           <ExternalLink class="w-3 h-3 mr-1" />
-          <span class="hidden sm:inline">Go to Workflow</span>
-          <span class="sm:hidden">Workflow</span>
+          Workflow
         </Button>
       </template>
       <div

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -169,64 +169,66 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
 
 <template>
   <div class="space-y-4">
-    <div class="grid gap-3 grid-cols-1 md:grid-cols-5">
+    <div class="grid grid-cols-5 gap-2 md:gap-3">
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="p-2 md:p-3 min-w-0"
       >
-        <div class="text-xs text-muted-foreground">
+        <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           Calls
         </div>
-        <div class="mt-1 text-xl font-semibold">
+        <div class="mt-1 text-sm md:text-xl font-semibold truncate">
           {{ loading ? "…" : fmtNum(kpis?.total_calls ?? 0) }}
         </div>
       </Card>
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="p-2 md:p-3 min-w-0"
       >
-        <div class="text-xs text-muted-foreground">
+        <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           Tokens
         </div>
-        <div class="mt-1 text-xl font-semibold">
+        <div class="mt-1 text-sm md:text-xl font-semibold truncate">
           {{ loading ? "…" : fmtNum(kpis?.total_tokens ?? 0) }}
         </div>
       </Card>
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="p-2 md:p-3 min-w-0"
       >
-        <div class="text-xs text-muted-foreground">
+        <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           Cost
         </div>
-        <div class="mt-1 text-xl font-semibold">
+        <div class="mt-1 text-sm md:text-xl font-semibold truncate">
           {{ loading ? "…" : fmtCost(kpis?.total_cost_usd ?? "0") }}
         </div>
       </Card>
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="p-2 md:p-3 min-w-0"
       >
-        <div class="text-xs text-muted-foreground">
-          Avg Latency
+        <div class="text-[10px] md:text-xs text-muted-foreground truncate">
+          <span class="md:hidden">Lat.</span>
+          <span class="hidden md:inline">Avg Latency</span>
         </div>
-        <div class="mt-1 text-xl font-semibold">
+        <div class="mt-1 text-sm md:text-xl font-semibold truncate">
           {{ loading ? "…" : fmtMs(kpis?.avg_latency_ms ?? 0) }}
         </div>
       </Card>
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="p-2 md:p-3 min-w-0"
       >
-        <div class="text-xs text-muted-foreground">
-          Error %
+        <div class="text-[10px] md:text-xs text-muted-foreground truncate">
+          <span class="md:hidden">Err%</span>
+          <span class="hidden md:inline">Error %</span>
         </div>
-        <div class="mt-1 text-xl font-semibold">
+        <div class="mt-1 text-sm md:text-xl font-semibold truncate">
           {{ loading ? "…" : `${(kpis?.error_pct ?? 0).toFixed(1)}%` }}
         </div>
       </Card>

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -169,11 +169,11 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
 
 <template>
   <div class="space-y-4">
-    <div class="grid gap-3 grid-cols-2 md:grid-cols-5">
+    <div class="grid gap-3 grid-cols-6 md:grid-cols-5">
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="col-span-2 p-3 md:col-span-1"
       >
         <div class="text-xs text-muted-foreground">
           Calls
@@ -185,7 +185,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="col-span-2 p-3 md:col-span-1"
       >
         <div class="text-xs text-muted-foreground">
           Tokens
@@ -197,7 +197,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="col-span-2 p-3 md:col-span-1"
       >
         <div class="text-xs text-muted-foreground">
           Cost
@@ -209,7 +209,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="col-span-3 p-3 md:col-span-1"
       >
         <div class="text-xs text-muted-foreground">
           Avg Latency
@@ -221,7 +221,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-3"
+        class="col-span-3 p-3 md:col-span-1"
       >
         <div class="text-xs text-muted-foreground">
           Error %

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -173,7 +173,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-2 md:p-3 min-w-0"
+        class="px-3 py-2.5 md:p-3 min-w-0"
       >
         <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           Calls
@@ -185,7 +185,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-2 md:p-3 min-w-0"
+        class="px-3 py-2.5 md:p-3 min-w-0"
       >
         <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           Tokens
@@ -197,7 +197,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-2 md:p-3 min-w-0"
+        class="px-3 py-2.5 md:p-3 min-w-0"
       >
         <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           Cost
@@ -209,7 +209,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-2 md:p-3 min-w-0"
+        class="px-3 py-2.5 md:p-3 min-w-0"
       >
         <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           <span class="md:hidden">Lat.</span>
@@ -222,7 +222,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="p-2 md:p-3 min-w-0"
+        class="px-3 py-2.5 md:p-3 min-w-0"
       >
         <div class="text-[10px] md:text-xs text-muted-foreground truncate">
           <span class="md:hidden">Err%</span>

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -169,11 +169,11 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
 
 <template>
   <div class="space-y-4">
-    <div class="grid gap-3 grid-cols-6 md:grid-cols-5">
+    <div class="grid gap-3 grid-cols-1 md:grid-cols-5">
       <Card
         variant="flat"
         :hover="false"
-        class="col-span-2 p-3 md:col-span-1"
+        class="p-3"
       >
         <div class="text-xs text-muted-foreground">
           Calls
@@ -185,7 +185,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="col-span-2 p-3 md:col-span-1"
+        class="p-3"
       >
         <div class="text-xs text-muted-foreground">
           Tokens
@@ -197,7 +197,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="col-span-2 p-3 md:col-span-1"
+        class="p-3"
       >
         <div class="text-xs text-muted-foreground">
           Cost
@@ -209,7 +209,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="col-span-3 p-3 md:col-span-1"
+        class="p-3"
       >
         <div class="text-xs text-muted-foreground">
           Avg Latency
@@ -221,7 +221,7 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
       <Card
         variant="flat"
         :hover="false"
-        class="col-span-3 p-3 md:col-span-1"
+        class="p-3"
       >
         <div class="text-xs text-muted-foreground">
           Error %

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -13,6 +13,7 @@ interface Props {
   size?: "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "full";
   allowFullscreen?: boolean;
   defaultFullscreen?: boolean;
+  hideFullscreenToggleOnMobile?: boolean;
   closeOnEscape?: boolean;
   closeOnBack?: boolean;
 }
@@ -22,6 +23,7 @@ const props = withDefaults(defineProps<Props>(), {
   size: "lg",
   allowFullscreen: false,
   defaultFullscreen: false,
+  hideFullscreenToggleOnMobile: false,
   closeOnEscape: true,
   closeOnBack: false,
 });
@@ -181,7 +183,10 @@ function toggleFullscreen(): void {
             >
               <button
                 v-if="allowFullscreen"
-                class="dialog-btn flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground transition-all duration-200"
+                :class="[
+                  'dialog-btn items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground transition-all duration-200',
+                  hideFullscreenToggleOnMobile ? 'hidden sm:flex' : 'flex',
+                ]"
                 @click="toggleFullscreen"
               >
                 <Minimize2

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -10,6 +10,7 @@ const hasHeaderActions = computed(() => typeof slots["header-actions"] === "func
 interface Props {
   open: boolean;
   title?: string;
+  titleClass?: string;
   size?: "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "full";
   allowFullscreen?: boolean;
   defaultFullscreen?: boolean;
@@ -20,6 +21,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   title: undefined,
+  titleClass: undefined,
   size: "lg",
   allowFullscreen: false,
   defaultFullscreen: false,
@@ -154,7 +156,10 @@ function toggleFullscreen(): void {
                 <h2
                   v-if="title"
                   :title="title"
-                  class="text-sm sm:text-base md:text-lg font-semibold tracking-tight line-clamp-1"
+                  :class="[
+                    'font-semibold tracking-tight line-clamp-1',
+                    titleClass || 'text-sm sm:text-base md:text-lg',
+                  ]"
                 >
                   {{ title }}
                 </h2>
@@ -168,10 +173,10 @@ function toggleFullscreen(): void {
             </div>
             <div
               v-if="hasHeaderActions"
-              class="col-span-2 sm:col-span-1 min-w-0 flex items-center gap-1.5 sm:gap-2"
+              class="col-span-2 sm:col-span-1 min-w-0 flex items-center justify-center sm:justify-start gap-1.5 sm:gap-2"
             >
               <div class="h-5 w-px bg-border/60 shrink-0 hidden sm:block" />
-              <div class="min-w-0 flex-1 overflow-hidden">
+              <div class="min-w-0 overflow-hidden flex justify-center sm:justify-start sm:flex-1">
                 <slot name="header-actions" />
               </div>
             </div>
@@ -181,6 +186,12 @@ function toggleFullscreen(): void {
                 hasHeaderActions ? 'row-start-1 col-start-2 sm:col-start-3' : '',
               ]"
             >
+              <div
+                v-if="$slots['header-trailing']"
+                class="flex items-center gap-1"
+              >
+                <slot name="header-trailing" />
+              </div>
               <button
                 v-if="allowFullscreen"
                 :class="[
@@ -198,12 +209,6 @@ function toggleFullscreen(): void {
                   class="h-3.5 w-3.5"
                 />
               </button>
-              <div
-                v-if="$slots['header-trailing']"
-                class="flex items-center gap-1"
-              >
-                <slot name="header-trailing" />
-              </div>
               <button
                 class="dialog-btn flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground transition-all duration-200"
                 @click="emit('close')"

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onUnmounted, ref, useSlots, watch } from "vue";
 import { Maximize2, Minimize2, X } from "lucide-vue-next";
 
 import { useDialogBackHistory } from "@/composables/useDialogBackHistory";
+
+const slots = useSlots();
+const hasHeaderActions = computed(() => typeof slots["header-actions"] === "function");
 
 interface Props {
   open: boolean;
@@ -133,8 +136,15 @@ function toggleFullscreen(): void {
           ]"
           @click.stop
         >
-          <div class="dialog-header flex items-center justify-between pb-3 sm:pb-4 mb-3 sm:mb-5 shrink-0 gap-1.5 sm:gap-2">
-            <div class="flex items-center gap-1.5 sm:gap-2 md:gap-4 min-w-0 flex-1 overflow-hidden">
+          <div
+            :class="[
+              'dialog-header shrink-0 pb-3 sm:pb-4 mb-3 sm:mb-5 gap-x-1.5 sm:gap-x-2 gap-y-2',
+              hasHeaderActions
+                ? 'grid grid-cols-[minmax(0,1fr)_auto] sm:grid-cols-[auto_minmax(0,1fr)_auto] items-center'
+                : 'flex items-center justify-between',
+            ]"
+          >
+            <div class="min-w-0 flex items-center gap-1.5 sm:gap-2 md:gap-4 overflow-hidden">
               <div
                 v-if="title || $slots.subtitle"
                 class="min-w-0"
@@ -153,14 +163,22 @@ function toggleFullscreen(): void {
                   <slot name="subtitle" />
                 </div>
               </div>
-              <template v-if="$slots['header-actions']">
-                <div class="h-5 w-px bg-border/60 shrink-0 hidden sm:block" />
-                <div class="min-w-0 flex-1 overflow-hidden">
-                  <slot name="header-actions" />
-                </div>
-              </template>
             </div>
-            <div class="flex items-center gap-1 sm:gap-1.5 flex-shrink-0">
+            <div
+              v-if="hasHeaderActions"
+              class="col-span-2 sm:col-span-1 min-w-0 flex items-center gap-1.5 sm:gap-2"
+            >
+              <div class="h-5 w-px bg-border/60 shrink-0 hidden sm:block" />
+              <div class="min-w-0 flex-1 overflow-hidden">
+                <slot name="header-actions" />
+              </div>
+            </div>
+            <div
+              :class="[
+                'flex items-center gap-1 sm:gap-1.5 flex-shrink-0',
+                hasHeaderActions ? 'row-start-1 col-start-2 sm:col-start-3' : '',
+              ]"
+            >
               <button
                 v-if="allowFullscreen"
                 class="dialog-btn flex items-center justify-center h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground transition-all duration-200"


### PR DESCRIPTION
## Summary
- KPI cards: all five stay in one row on mobile (compact padding/type; Lat./Err% short labels). Desktop unchanged.
- Trace Details: prev/next are compact icon buttons on mobile (no stretched flex-1 pills); Workflow stays inline and sized normally. Header actions still sit on a full-width row under the title on mobile.

## Test plan
- [ ] Traces tab mobile (~390px): five KPI cards side by side, readable values
- [ ] Traces tab desktop: five equal KPI cards
- [ ] Trace Details mobile: small prev/next chevrons, not oversized; Workflow not full-bleed
- [ ] Trace Details desktop: Prev/Next labels + Go to Workflow inline beside title