### PR TITLE
Show settings gear icon on mobile in top navigation bar

### DIFF
--- a/frontend/src/components/Layout/AppHeader.vue
+++ b/frontend/src/components/Layout/AppHeader.vue
@@ -113,14 +113,14 @@ async function handleLogout(): Promise<void> {
         <button
           v-if="authStore.user"
           type="button"
-          class="user-badge hidden md:flex items-center gap-2.5 text-sm mr-2 px-3 py-2 rounded-xl cursor-pointer hover:opacity-80 transition-opacity text-left"
+          class="user-badge flex items-center gap-2.5 text-sm mr-2 px-3 py-2 rounded-xl cursor-pointer hover:opacity-80 transition-opacity text-left"
           title="Settings"
           @click="settingsInitialTab = 'profile'; showSettingsDialog = true; pushOverlayState()"
         >
           <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/15 text-primary shrink-0">
             <Settings class="w-4 h-4" />
           </div>
-          <span class="font-medium text-foreground">{{ authStore.user.name }}</span>
+          <span class="font-medium text-foreground hidden md:inline">{{ authStore.user.name }}</span>
         </button>
 
         <slot name="actions" />

--- a/frontend/src/components/Layout/AppHeader.vue
+++ b/frontend/src/components/Layout/AppHeader.vue
@@ -113,11 +113,12 @@ async function handleLogout(): Promise<void> {
         <button
           v-if="authStore.user"
           type="button"
-          class="user-badge flex items-center gap-2.5 text-sm mr-2 px-3 py-2 rounded-xl cursor-pointer hover:opacity-80 transition-opacity text-left"
+          class="user-badge flex items-center justify-center md:justify-start gap-2.5 text-sm text-foreground h-11 w-11 min-h-[44px] min-w-[44px] rounded-xl cursor-pointer hover:bg-muted/50 transition-colors md:mr-2 md:h-auto md:w-auto md:min-h-0 md:min-w-0 md:px-3 md:py-2 md:hover:bg-transparent md:hover:opacity-80 md:transition-opacity text-left"
           title="Settings"
           @click="settingsInitialTab = 'profile'; showSettingsDialog = true; pushOverlayState()"
         >
-          <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/15 text-primary shrink-0">
+          <Settings class="w-4 h-4 md:hidden" />
+          <div class="hidden md:flex items-center justify-center w-7 h-7 rounded-lg bg-primary/15 text-primary shrink-0">
             <Settings class="w-4 h-4" />
           </div>
           <span class="font-medium text-foreground hidden md:inline">{{ authStore.user.name }}</span>


### PR DESCRIPTION
Both lint and typecheck pass cleanly.

## Summary

Fixed a responsive design issue where the user account settings button (gear icon) was completely hidden on mobile devices (viewport < 768px).

**Root cause:** The user badge `<button>` had `hidden md:flex` Tailwind classes, making it `display: none` on all screen sizes below the `md` breakpoint (768px). Unlike other nav buttons (search, theme toggle, logout) which remained visible on mobile, the settings button was the only element completely unavailable.

**Changes in `frontend/src/components/Layout/AppHeader.vue`:**

1. Changed `hidden md:flex` → `flex` on the settings button so it's always visible
2. Added `hidden md:inline` to the username `<span>` so it's hidden on mobile (icon-only), matching the pattern used by the Documentation link

**Behavior:**
- **Mobile (< 768px):** Gear icon visible, username hidden — matching the Documentation link pattern
- **Desktop (≥ 768px):** Unchanged — gear icon + username both visible

**Screenshot:** `frontend/.e2e-artifacts/mobile-header-with-gear-icon.png`

## Task

Fix responsive design issue: Make the user account settings button (gear icon only) visible on mobile devices in the top navigation bar.

Current Issue:
- The gear icon button for user account settings is currently hidden on mobile responsive views
- It works correctly on desktop but is not visible on mobile
- The button should be displayed alongside other navigation buttons on mobile

Requirements:
1. Make the gear icon visible on mobile devices in the top navigation
2. Display only the gear icon (no username text) on mobile
3. Ensure it appears alongside other navigation buttons
4. Maintain existing desktop behavior (no changes needed)
5. Follow existing responsive design patterns in the codebase
6. Respect the @agents.md file guidelines

Technical Context:
- This is a Vue.js frontend project
- The navigation component is likely in frontend/src/components/
- Look for responsive CSS classes or media queries that might be hiding the gear icon on mobile
- Check for display: none, visibility: hidden, or similar CSS rules applied to the settings button on mobile breakpoints

## Screenshots

![pr-385-mobile-header-with-gear-icon.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-385-mobile-header-with-gear-icon.png)
