### PR TITLE
Hide JSON tree/plain toggle buttons in console output when node is running

### DIFF
--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -2812,7 +2812,7 @@ function renderContent(content: string): string {
                 </span>
               </span>
               <div class="flex items-center gap-1 shrink-0">
-                <template v-if="!result.error && isValidJson(result.output)">
+                <template v-if="!result.error && result.status !== 'running' && isValidJson(result.output)">
                   <Button
                     :variant="getResultViewMode(result.displayKey, 'tree') === 'tree' ? 'secondary' : 'ghost'"
                     size="sm"


### PR DESCRIPTION
The change is complete. Here's a summary:

**What was done:** Added `result.status !== 'running'` condition to the Tree/Plain toggle button visibility in `DebugPanel.vue:2815`. When a node is currently executing (running), the JSON tree/plain toggle buttons are now hidden since there's no final data to display yet.

**What was the issue:** The Tree/Plain toggle buttons were appearing in the console output area for nodes that were still running, despite having no completed output to display.

**Existing rules preserved:** Error nodes continue to hide buttons (`!result.error`), and success/pending nodes with valid JSON continue to show buttons.

**Screenshot:** `frontend/.e2e-artifacts/running-node-toggle-hidden.png`

## Summary
- **Changed file:** `frontend/src/components/Panels/DebugPanel.vue` (line 2815)
- **Change:** Added `result.status !== 'running'` to the existing `v-if` condition that controls visibility of the Tree/Plain toggle buttons in the DebugPanel console output
- **Behavior:** When a node's execution status is `'running'`, the JSON tree/plain toggle buttons are hidden. They remain visible for completed (success), pending, and other non-error non-running states. Error node hiding behavior is preserved via the existing `!result.error` check.
- **Screenshot:** `frontend/.e2e-artifacts/running-node-toggle-hidden.png`


## Screenshots

![pr-393-running-node-toggle-hidden.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/pr-393-running-node-toggle-hidden.png)
