### PR TITLE
fix(mcp): make the stdio sandbox usable for npx and uvx servers

### DIFF
--- a/ENVIRONMENT-VARIABLES.md
+++ b/ENVIRONMENT-VARIABLES.md
@@ -128,6 +128,8 @@ A `docker run [flags] IMAGE [args]` command keeps working: Heym starts `IMAGE` i
 
 **No application storage is mounted by default either.** The sandbox sees no Heym files unless you name a volume or directory explicitly, and that mount is read-only unless you also opt into writes. The skill/Codex/OpenCode workspace volumes are never auto-mounted: they hold every tenant's workspaces, so exposing one to a single caller's MCP process would be a cross-tenant read. If a file-oriented MCP server (for example `@modelcontextprotocol/server-filesystem`) needs data, point `HEYM_MCP_STDIO_FILES_VOLUME` at a volume you scope yourself, optionally narrowing it with `HEYM_MCP_STDIO_FILES_SUBPATH`.
 
+Inside the container the root filesystem is read-only and `/tmp` is a throwaway tmpfs, so the sandbox sets `HOME` and the npm/uv cache directories to paths under `/tmp` and mounts that tmpfs with `exec`. Without those, `npx` and `uvx` servers cannot run at all: the sandbox user's passwd home is `/nonexistent`, and Docker applies `noexec` to every `--tmpfs` that does not name `exec` explicitly. Values you set on the connection are applied after these defaults, so you can override them.
+
 Only the env vars set on the connection reach the server. The backend's own environment (`SECRET_KEY`, `ENCRYPTION_KEY`, `DATABASE_URL`, provider API keys) is never forwarded; the MCP SDK supplies a safe default `PATH`/`HOME`/`SHELL`/`TERM`/`USER`/`LOGNAME` set on top.
 
 > **Operator-only escape hatches.** `HEYM_MCP_STDIO_SANDBOX=subprocess` and `HEYM_MCP_STDIO_FILES_HOST_DIR` are never settable by a workflow author, only by whoever runs the deployment. Both can remove the isolation this section describes, so treat them as trusted single-user / single-tenant options and leave them unset on anything multi-user.
@@ -141,6 +143,7 @@ Only the env vars set on the connection reach the server. The backend's own envi
 | `HEYM_MCP_STDIO_FILES_SUBPATH` | Mount only this subpath of the volume, so a shared volume can be scoped per tenant or per purpose. | — |
 | `HEYM_MCP_STDIO_FILES_HOST_DIR` | Absolute host path to expose instead of a volume. No fallback to `FILE_STORAGE_DIR`. ⚠️ This bind-mounts a backend host path into the sandbox, so a wide path (or one holding several tenants' data) weakens the boundary: scope it deliberately, and prefer a volume with `HEYM_MCP_STDIO_FILES_SUBPATH` on shared deployments. | — |
 | `HEYM_MCP_STDIO_FILES_WRITABLE` | Mount the file mount read-write. Read-only otherwise. | `false` |
+| `HEYM_MCP_STDIO_TMPFS_SIZE` | Size of the writable `/tmp` tmpfs, which holds the npm/uv caches and anything the server installs at startup. Raise it for large packages. | `512m` |
 | `HEYM_MCP_STDIO_MEMORY` | Memory limit for MCP stdio containers. | `512m` |
 | `HEYM_MCP_STDIO_CPUS` | CPU limit for MCP stdio containers. | `2` |
 | `HEYM_MCP_STDIO_PIDS` | PID limit for MCP stdio containers. | `256` |

--- a/backend/app/services/mcp_stdio_sandbox.py
+++ b/backend/app/services/mcp_stdio_sandbox.py
@@ -348,7 +348,6 @@ def _sandbox_user() -> str:
         return _DEFAULT_SANDBOX_USER
     # Re-render from the parsed integers so what was validated is what Docker gets.
     return f"{uid}:{gid}"
-    return value
 
 
 def _hardening_flags(name: str, network: str = "bridge") -> list[str]:
@@ -357,6 +356,23 @@ def _hardening_flags(name: str, network: str = "bridge") -> list[str]:
     ``-i`` is mandatory: the MCP protocol is a bidirectional stream over the
     child's stdin/stdout. No Docker socket is mounted, which is the difference
     between this and a host-side ``docker run``.
+
+    The root filesystem is read-only, so the tmpfs at ``/tmp`` is the only place
+    the server can write. Three details make that usable for ``npx`` / ``uvx``
+    servers, all of which were missing at first and broke them outright:
+
+    * ``exec`` on the tmpfs. Docker applies ``noexec`` to every ``--tmpfs`` unless
+      it is named explicitly, so a package manager could install a server and
+      then fail to run its binary. This does not weaken the boundary in practice:
+      the caller already chooses the entrypoint, so running code inside the
+      container is the premise, not the escalation. The boundary is the missing
+      socket, the dropped capabilities and the non-root user.
+    * ``HOME``. The container runs as uid 65534, whose passwd entry points at
+      ``/nonexistent``, so npm's first action is ``mkdir /nonexistent`` and it
+      dies with ENOENT before it ever reaches the registry.
+    * cache directories. npm and uv both want to write under ``HOME`` or
+      ``XDG_CACHE_HOME``; pointing them at the tmpfs keeps them off the
+      read-only rootfs.
     """
     return [
         "--rm",
@@ -367,7 +383,19 @@ def _hardening_flags(name: str, network: str = "bridge") -> list[str]:
         network,
         "--read-only",
         "--tmpfs",
-        "/tmp:rw,nosuid,size=256m",
+        f"/tmp:rw,exec,nosuid,size={_tunable('HEYM_MCP_STDIO_TMPFS_SIZE', '512m')}",
+        "--env",
+        "HOME=/tmp",
+        "--env",
+        "NPM_CONFIG_CACHE=/tmp/.npm",
+        "--env",
+        "NPM_CONFIG_UPDATE_NOTIFIER=false",
+        "--env",
+        "XDG_CACHE_HOME=/tmp/.cache",
+        "--env",
+        "XDG_DATA_HOME=/tmp/.local/share",
+        "--env",
+        "UV_CACHE_DIR=/tmp/.uv",
         "--user",
         _sandbox_user(),
         "--cap-drop",

--- a/backend/tests/test_mcp_stdio_sandbox.py
+++ b/backend/tests/test_mcp_stdio_sandbox.py
@@ -499,6 +499,100 @@ class SandboxImageResolutionTests(unittest.TestCase):
         self.assertEqual(result.argv[-1], "mcp/fetch")
 
 
+class ContainerRuntimeUsabilityTests(unittest.TestCase):
+    """The hardened container must still be able to run a real MCP server.
+
+    The first version of the sandbox was airtight and unusable: `npx` died with
+    `mkdir /nonexistent` because uid 65534's passwd home does not exist, and once
+    that was fixed the installed binary would not start because Docker silently
+    applies `noexec` to every --tmpfs. The existing tests all asserted argv
+    contents that looked correct, so none of them caught it. These pin the
+    runtime preconditions instead.
+    """
+
+    def setUp(self) -> None:
+        reset_docker_available_cache()
+        self.addCleanup(reset_docker_available_cache)
+        self._patches = [
+            patch.dict(
+                os.environ,
+                {
+                    "HEYM_MCP_STDIO_SANDBOX": "docker",
+                    "HEYM_MCP_STDIO_IMAGE": "heym-backend:local",
+                },
+            ),
+            patch("app.services.mcp_stdio_sandbox.docker_available", return_value=True),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _tmpfs_spec(self, argv: list[str]) -> str:
+        return _flag_value(argv, "--tmpfs") or ""
+
+    def _envs(self, argv: list[str]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        for index, token in enumerate(argv):
+            if token == "--env" and index + 1 < len(argv) and "=" in argv[index + 1]:
+                key, _, value = argv[index + 1].partition("=")
+                out[key] = value
+        return out
+
+    def test_tmpfs_allows_exec(self) -> None:
+        """Docker adds noexec unless exec is named, which blocks npx-installed bins."""
+        spec = self._tmpfs_spec(build_sandboxed_command("npx", [], None).argv)
+        self.assertIn("exec", spec.split(":")[-1].split(","))
+        self.assertNotIn("noexec", spec)
+
+    def test_tmpfs_still_drops_suid(self) -> None:
+        spec = self._tmpfs_spec(build_sandboxed_command("npx", [], None).argv)
+        self.assertIn("nosuid", spec)
+
+    def test_home_points_at_a_writable_path(self) -> None:
+        """uid 65534's passwd home is /nonexistent, so npm cannot even start."""
+        envs = self._envs(build_sandboxed_command("npx", [], None).argv)
+        self.assertEqual(envs.get("HOME"), "/tmp")
+
+    def test_package_manager_caches_point_at_the_tmpfs(self) -> None:
+        envs = self._envs(build_sandboxed_command("npx", [], None).argv)
+        for key in ("NPM_CONFIG_CACHE", "XDG_CACHE_HOME", "UV_CACHE_DIR"):
+            with self.subTest(key=key):
+                self.assertTrue(
+                    (envs.get(key) or "").startswith("/tmp"),
+                    f"{key} must be writable, got {envs.get(key)!r}",
+                )
+
+    def test_rootfs_stays_read_only(self) -> None:
+        """Making /tmp usable must not have loosened the rootfs."""
+        argv = build_sandboxed_command("npx", [], None).argv
+        self.assertIn("--read-only", argv)
+
+    def test_hardening_is_unchanged_by_the_usability_fix(self) -> None:
+        argv = build_sandboxed_command("npx", [], None).argv
+        self.assertEqual(_flag_value(argv, "--cap-drop"), "ALL")
+        self.assertEqual(_flag_value(argv, "--security-opt"), "no-new-privileges")
+        self.assertEqual(_flag_value(argv, "--user"), "65534:65534")
+        self.assertNotIn("docker.sock", " ".join(argv))
+
+    def test_caller_env_can_override_our_defaults(self) -> None:
+        """Caller vars come after ours, so docker resolves them last."""
+        argv = build_sandboxed_command("npx", [], {"HOME": "/tmp/custom"}).argv
+        positions = [i for i, t in enumerate(argv) if t == "--env"]
+        values = [argv[i + 1] for i in positions]
+        self.assertLess(values.index("HOME=/tmp"), values.index("HOME=/tmp/custom"))
+
+    def test_docker_run_form_gets_the_same_runtime_env(self) -> None:
+        argv = build_sandboxed_command("docker", ["run", "mcp/fetch"], None).argv
+        envs = self._envs(argv)
+        self.assertEqual(envs.get("HOME"), "/tmp")
+        self.assertIn("exec", self._tmpfs_spec(argv).split(":")[-1].split(","))
+
+    def test_tmpfs_size_is_tunable(self) -> None:
+        with patch.dict(os.environ, {"HEYM_MCP_STDIO_TMPFS_SIZE": "1g"}):
+            spec = self._tmpfs_spec(build_sandboxed_command("npx", [], None).argv)
+        self.assertIn("size=1g", spec)
+
+
 class DockerRunRewriteTests(unittest.TestCase):
     """`docker run` keeps working, but we start the image instead of the child."""
 


### PR DESCRIPTION
## Problem

The hardened MCP stdio container shipped in `0.0.75` is airtight and unusable for the most common server form. On a `deploy.sh` instance, `npx -y @modelcontextprotocol/server-...` fails before it reaches the registry:

```
npm ERR! enoent ENOENT: no such file or directory, mkdir '/nonexistent'
```

Three things stacked up, and each had to be fixed to get a server running:

1. **HOME.** The container runs as uid 65534, whose passwd entry points at `/nonexistent`, so npm's first act is `mkdir $HOME/.npm` and it dies.
2. **Cache directories.** The rootfs is read-only, so npm and uv have nowhere to write even once `HOME` is set.
3. **noexec.** Docker applies `noexec` to every `--tmpfs` unless `exec` is named explicitly, so `/tmp:rw,nosuid,size=256m` silently became noexec. With 1 and 2 fixed, npx installed the package and then could not run its binary:

```
sh: 1: mcp-server-sequential-thinking: Permission denied
```

## Fix

Set `HOME`, `NPM_CONFIG_CACHE`, `XDG_CACHE_HOME`, `XDG_DATA_HOME` and `UV_CACHE_DIR` under `/tmp`, and mount that tmpfs with `exec` at a tunable size (`HEYM_MCP_STDIO_TMPFS_SIZE`, default `512m`, up from `256m` since packages land there). Connection env vars are still applied after these, so a caller can override them.

Also removes an unreachable `return value` left in `_sandbox_user()` by an earlier revision.

## Security

Allowing `exec` on `/tmp` does not weaken the boundary in any practical sense: the caller already chooses the container's entrypoint, so executing code inside the sandbox is the premise rather than an escalation. Anyone who can pick the entrypoint could already do `sh -c 'curl ... | sh'`, which never needed exec permission on a file.

Everything that makes it a boundary is unchanged, and re-verified against real Docker on this branch:

```
[PASS] advisory PoC cannot write to the host   (marker present=False)
[PASS] payload executes inside the container   (uid=65534 rc=0)
[PASS] container runs as non-root              (uid=65534)
[PASS] docker socket not reachable inside sandbox (NO_SOCKET)
[PASS] backend secrets absent from child env   (leaked=none)
[PASS] caller's own env var still delivered
[PASS] `docker run IMAGE` form still runs      (rc=0 out=MCPOK)
[PASS] image + image args preserved
[PASS] user -e carried into the rewritten command
9/9 checks passed
```

The original GHSA-378x-q589-34mv PoC still returns 422 with no host side effect, and the mount, root-user and cross-tenant volume regression tests all still pass.

## Verification

End to end against real Docker with a full JSON-RPC `initialize` handshake, on all three command shapes:

| form | result |
|------|--------|
| `npx -y @modelcontextprotocol/server-sequential-thinking` | `serverInfo` returned |
| `uvx mcp-server-time` | `serverInfo` returned |
| `docker run -i --rm mcp/sequentialthinking` | `serverInfo` returned |

Cold npx runs measured at 3.4-4.5s, inside the 15s fetch-tools deadline.

- `./check.sh` green (2361 passed)
- `./run_e2e.sh --workers=8 --fully-parallel` green (123 passed)
- Deployment regression 23/23 across Compose, GHCR, `deploy.sh` and `run.sh`, covering stdio, sse and streamable_http

## Tests

The existing tests all asserted argv contents that looked correct, which is exactly why none of them caught this: the flags were right and the container still could not run anything. The new tests pin the runtime preconditions instead (tmpfs carries `exec` and not `noexec`, `HOME` and the caches are writable, the rootfs stays read-only, the hardening flags are unchanged, and caller env still wins), so a future tightening that breaks execution fails the suite.