### PR TITLE
Hide Execution Highlights panel by default on mobile

### DIFF
--- a/frontend/e2e/tab-workflows.spec.ts
+++ b/frontend/e2e/tab-workflows.spec.ts
@@ -616,7 +616,18 @@ test("keeps execution highlights collapsed by default on mobile", async ({ page 
 
   try {
     await page.goto(`/workflows/${workflow.id}`);
-    await page.getByRole("button", { name: "Run Workflow" }).click();
+    await expect(page.getByTestId("workflow-title")).toBeVisible();
+    await expect(page.getByText("Build Highlight")).toBeVisible();
+
+    // On mobile the properties panel starts closed and the Run label is icon-only
+    // below `sm`, so drive the run via the editor shortcut instead.
+    await page.keyboard.press("ControlOrMeta+Enter");
+
+    // The shortcut opens the properties panel; close it so the canvas chip is
+    // unobstructed on a narrow viewport.
+    await expect(page.locator(".properties-panel")).toBeVisible();
+    await page.locator("button.panel-toggle-right").click();
+    await expect(page.locator(".properties-panel")).toBeHidden();
 
     await expect(page.getByTestId("execution-highlights-open")).toBeVisible();
     await expect(page.getByTestId("execution-highlights-panel")).toBeHidden();

--- a/frontend/e2e/tab-workflows.spec.ts
+++ b/frontend/e2e/tab-workflows.spec.ts
@@ -579,6 +579,55 @@ test("shows execution highlights after a workflow run", async ({ page }) => {
   }
 });
 
+test("keeps execution highlights collapsed by default on mobile", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const workflow = await createWorkflow(
+    page,
+    `Mobile Highlights ${Date.now()}`,
+    [
+      {
+        id: "set-highlight",
+        type: "set",
+        position: { x: 120, y: 120 },
+        data: {
+          label: "Build Highlight",
+          mappings: [{ key: "message", value: "Mobile highlight smoke" }],
+          highlight: true,
+        },
+      },
+      {
+        id: "output-final",
+        type: "output",
+        position: { x: 460, y: 120 },
+        data: { label: "Final Output", message: "$input.message" },
+      },
+    ],
+    [
+      {
+        id: "edge-highlight-output",
+        source: "set-highlight",
+        target: "output-final",
+        sourceHandle: "output",
+        targetHandle: "input",
+      },
+    ],
+  );
+
+  try {
+    await page.goto(`/workflows/${workflow.id}`);
+    await page.getByRole("button", { name: "Run Workflow" }).click();
+
+    await expect(page.getByTestId("execution-highlights-open")).toBeVisible();
+    await expect(page.getByTestId("execution-highlights-panel")).toBeHidden();
+
+    await page.getByTestId("execution-highlights-open").click();
+    await expect(page.getByTestId("execution-highlights-panel")).toBeVisible();
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});
+
 test("adds and configures a Linear node", async ({ page }) => {
   const credentialResponse = await page.request.post("/api/credentials", {
     data: {

--- a/frontend/src/components/Canvas/HighlightPopup.vue
+++ b/frontend/src/components/Canvas/HighlightPopup.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useMediaQuery } from "@vueuse/core";
 import {
   Check,
   ChevronDown,
@@ -22,7 +23,14 @@ const emit = defineEmits<{ close: [] }>();
 
 const PREVIEW_LIMIT = 250;
 
-const dismissed = ref(false);
+const isMobile = useMediaQuery("(max-width: 767px)");
+
+/** Collapsed by default on mobile so the canvas stays usable after a run. */
+function defaultDismissed(): boolean {
+  return props.collapsible && isMobile.value;
+}
+
+const dismissed = ref(defaultDismissed());
 const expanded = ref<Set<string>>(new Set());
 const runIndexById = ref<Record<string, number>>({});
 const copiedId = ref<string | null>(null);
@@ -59,7 +67,7 @@ const kindLabel: Record<HighlightRecord["kind"], string> = {
 watch(
   () => props.payload,
   () => {
-    dismissed.value = false;
+    dismissed.value = defaultDismissed();
     expanded.value = new Set();
     runIndexById.value = {};
     copiedId.value = null;

--- a/frontend/src/components/Panels/propertiesPanel/PropertiesPanelRunTab.vue
+++ b/frontend/src/components/Panels/propertiesPanel/PropertiesPanelRunTab.vue
@@ -114,6 +114,7 @@ const {
           :class="isRunbookPlaying && 'runbook-pulse'"
           :loading="isExecuting"
           :disabled="!hasNodes || !!runBodyError"
+          :aria-label="isExecuting ? 'Executing...' : 'Run Workflow'"
           @click="handleExecute"
         >
           <Play class="w-4 h-4 shrink-0" />


### PR DESCRIPTION
## Summary
- On mobile (≤767px), the canvas **Execution Highlights** panel starts collapsed after a run (reopen chip only).
- Desktop behavior is unchanged: the panel still opens by default.
- Added a Playwright coverage case for the mobile default.

## Test plan
- [ ] Mobile viewport: run a workflow with highlights → only the reopen chip shows; opening it works
- [ ] Desktop: run the same workflow → panel still opens by default