### PR TITLE
Keep the task prompt out of coding-agent pull requests

### DIFF
--- a/backend/app/services/codex_runner_service.py
+++ b/backend/app/services/codex_runner_service.py
@@ -578,6 +578,7 @@ class CodexRunnerService:
         result.branch_name = request.branch_name
         result.diff = self._git_output(["git", "diff", "--binary"], workspace)
         result.changed_files = self._changed_files(workspace)
+        self._redact_publishable_text(result, request.task_prompt)
         if result.status == "completed" and request.publish_mode in _CODEX_REMOTE_PUBLISH_MODES:
             self._publish(workspace, request, result)
         return result
@@ -899,7 +900,10 @@ class CodexRunnerService:
             "and return `status: completed` with a summary and validation notes. Always set "
             "`pull_request_title` to a concise, complete one-line change description "
             "(imperative mood, ideally <=72 characters) suitable as a commit/PR subject. "
-            "Never use placeholder titles such as Done, Fixed, or Update.\n\n"
+            "Never use placeholder titles such as Done, Fixed, or Update. Set "
+            "`pull_request_body` to a `## Change Summary` section (plus `## Screenshots` when "
+            "you captured any).\n"
+            f"{pr_publish.PR_CONTENT_POLICY}\n\n"
             f"Task:\n{task_prompt}"
         )
 
@@ -908,8 +912,22 @@ class CodexRunnerService:
         return (
             "The user answered your previous follow-up question. Continue the same task.\n"
             f"{_CODEX_LOCAL_ONLY_RULES}\n"
-            "Return `needs_input` only if one more user decision is truly essential.\n\n"
+            "Return `needs_input` only if one more user decision is truly essential.\n"
+            f"{pr_publish.PR_CONTENT_POLICY}\n\n"
             f"Answer:\n{answer_text}"
+        )
+
+    @staticmethod
+    def _redact_publishable_text(result: CodexRunResult, task_prompt: str) -> None:
+        """Strip task-prompt echoes from every field that can reach GitHub.
+
+        Enforcement backstop for ``pr_publish.PR_CONTENT_POLICY``: the summary feeds the commit
+        body, and both it and ``pull_request_body`` feed the PR description.
+        """
+        result.summary = pr_publish.redact_task_prompt(result.summary, task_prompt)
+        result.validation = pr_publish.redact_task_prompt(result.validation, task_prompt)
+        result.pull_request_body = pr_publish.redact_task_prompt(
+            result.pull_request_body, task_prompt
         )
 
     @staticmethod

--- a/backend/app/services/coding_agent/pr_publish.py
+++ b/backend/app/services/coding_agent/pr_publish.py
@@ -30,6 +30,42 @@ PR_SCREENSHOT_CONTENT_TYPES: dict[str, str] = {
     ".gif": "image/gif",
 }
 
+# Prompt clause shared by every coding-agent runner: the task prompt is private input, so it must
+# never be echoed into anything Heym publishes to GitHub (PR title, PR body, commit message).
+PR_CONTENT_POLICY = (
+    "Critical pull request policy: the task prompt is PRIVATE. Never quote, paraphrase, summarize, "
+    "transform, or reference the task instructions, your reasoning, logs, or tool output in the "
+    "pull request title, the pull request description, or the commit message. Only two things may "
+    "be published to GitHub: a `## Change Summary` section describing what the code change does, "
+    "and a `## Screenshots` section when applicable. Derive the title from the change summary "
+    "alone. Never add sections such as `## Task`, `## Prompt`, `## Instructions`, or "
+    "`## Original Request`."
+)
+
+# Section headings that restate the private task prompt instead of describing the change.
+_PROMPT_ECHO_HEADINGS: frozenset[str] = frozenset(
+    {
+        "task",
+        "tasks",
+        "task prompt",
+        "task description",
+        "task details",
+        "original task",
+        "original request",
+        "original prompt",
+        "prompt",
+        "instructions",
+        "instruction",
+        "request",
+        "user request",
+        "user prompt",
+        "user instructions",
+    }
+)
+_HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$")
+# Below this length a paragraph is too generic for a verbatim prompt match to mean anything.
+_MIN_PROMPT_ECHO_CHARS = 24
+
 
 def clone_url_with_token(repository_url: str, github_config: dict) -> str:
     """Embed a GitHub token into an https clone URL (as ``x-access-token``)."""
@@ -135,6 +171,64 @@ def commit_title(pull_request_title: str, summary: str, *, fallback: str) -> str
         if is_meaningful_commit_title(candidate):
             return normalize_title_candidate(candidate)
     return fallback
+
+
+def _collapse(text: str) -> str:
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+def _normalize_heading(text: str) -> str:
+    """Lowercase a markdown heading and drop emphasis/punctuation so it can be matched."""
+    cleaned = _collapse(text).strip("*_`").strip()
+    return cleaned.rstrip(":.").strip().lower()
+
+
+def strip_prompt_echo_sections(body: str) -> str:
+    """Drop markdown sections whose heading restates the private task prompt.
+
+    A prompt-echo heading removes everything until the next heading of the same or a
+    higher level, so nested subsections of the echoed block go with it.
+    """
+    kept: list[str] = []
+    skip_level = 0
+    for line in str(body or "").splitlines():
+        match = _HEADING_RE.match(line)
+        if match is not None:
+            level = len(match.group(1))
+            if skip_level and level <= skip_level:
+                skip_level = 0
+            if _normalize_heading(match.group(2)) in _PROMPT_ECHO_HEADINGS:
+                skip_level = level
+                continue
+        if skip_level:
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def strip_prompt_echo_blocks(body: str, task_prompt: str) -> str:
+    """Drop paragraphs that are verbatim copies of (part of) the task prompt."""
+    prompt = _collapse(task_prompt).lower()
+    text = str(body or "").strip()
+    if len(prompt) < _MIN_PROMPT_ECHO_CHARS or not text:
+        return text
+    kept: list[str] = []
+    for block in re.split(r"\n\s*\n", text):
+        normalized = _collapse(block).lower()
+        if len(normalized) >= _MIN_PROMPT_ECHO_CHARS and normalized in prompt:
+            continue
+        if block.strip():
+            kept.append(block.strip())
+    return "\n\n".join(kept).strip()
+
+
+def redact_task_prompt(body: str, task_prompt: str) -> str:
+    """Remove task-prompt echoes from text that is about to be published to GitHub.
+
+    Backstop for ``PR_CONTENT_POLICY``: prompts are guidance, this is enforcement. Only the
+    agent's own description of the change (and screenshots) survives.
+    """
+    return strip_prompt_echo_blocks(strip_prompt_echo_sections(body), task_prompt)
 
 
 def commit_body(summary: str, validation: str) -> str:

--- a/backend/app/services/opencode_runner_service.py
+++ b/backend/app/services/opencode_runner_service.py
@@ -51,10 +51,14 @@ _LOCAL_ONLY_RULES = (
     "Bad titles are generic or incomplete, e.g. `PR_TITLE: Fix issue`, `PR_TITLE: Update code`, "
     "`PR_TITLE: Done`, or `PR_TITLE: Apply changes`. "
     "After the PR_TITLE line, provide a concise PR description that explains what changed and "
-    "why, using a `## Summary` section. If you saved screenshots, mention their file paths so "
-    "they can be attached automatically."
+    "why, using a `## Change Summary` section. If you saved screenshots, mention their file paths "
+    "so they can be attached automatically. "
+    f"{pr_publish.PR_CONTENT_POLICY}"
 )
 _MAX_ERROR_DETAIL_CHARS = 4000
+# Used when OpenCode produces no final assistant message. It never describes the change, so it
+# must not become a PR/commit subject — and it deliberately does not restate the task prompt.
+_NO_FINAL_MESSAGE_SUMMARY = "OpenCode completed without a final assistant message."
 
 
 @dataclass(frozen=True)
@@ -162,7 +166,7 @@ class OpenCodeRunnerService:
         config_path.chmod(0o600)
 
     # --- output parsing ---
-    def parse_events(self, stdout: str, task_prompt: str = "") -> OpenCodeRunResult:
+    def parse_events(self, stdout: str) -> OpenCodeRunResult:
         events: list[dict] = []
         summary = ""
         for raw in (stdout or "").splitlines():
@@ -180,7 +184,7 @@ class OpenCodeRunnerService:
             if text:
                 summary = text
         if not summary:
-            summary = self._fallback_summary(task_prompt)
+            summary = _NO_FINAL_MESSAGE_SUMMARY
         pull_request_title, cleaned_summary = pr_publish.extract_pr_title_line(summary)
         return OpenCodeRunResult(
             status="completed",
@@ -189,56 +193,44 @@ class OpenCodeRunnerService:
             raw_events=events,
         )
 
-    @staticmethod
-    def _fallback_summary(task_prompt: str) -> str:
-        """Build a useful fallback summary from the task prompt when the agent is silent."""
-        prompt = str(task_prompt or "").strip()
-        if not prompt:
-            return "OpenCode completed without a final assistant message."
-        first_line = prompt.splitlines()[0].strip()
-        # Take a reasonable fragment so the summary is readable but not the whole prompt.
-        snippet = first_line[:200].strip()
-        if len(snippet) < 8:
-            return "OpenCode completed without a final assistant message."
-        return f"OpenCode completed the requested task: {snippet}"
-
     def _normalize_pr_metadata(self, result: OpenCodeRunResult, task_prompt: str) -> None:
-        """Ensure PR title and body are meaningful and informative before publishing."""
-        result.pull_request_title = self._ensure_meaningful_pr_title(result, task_prompt)
-        result.pull_request_body = self._ensure_pr_body(result, task_prompt)
+        """Shape the PR title/body for publishing, keeping the task prompt out of both.
 
-    def _ensure_meaningful_pr_title(self, result: OpenCodeRunResult, task_prompt: str) -> str:
-        """Return a meaningful PR title, deriving one from context if the agent's title is weak."""
+        ``task_prompt`` is used only to *remove* echoes of itself — never as a source of
+        published text (see ``pr_publish.PR_CONTENT_POLICY``).
+        """
+        result.summary = pr_publish.redact_task_prompt(result.summary, task_prompt)
+        result.pull_request_body = pr_publish.redact_task_prompt(
+            result.pull_request_body, task_prompt
+        )
+        result.pull_request_title = self._ensure_meaningful_pr_title(result)
+        result.pull_request_body = self._ensure_pr_body(result)
+
+    def _ensure_meaningful_pr_title(self, result: OpenCodeRunResult) -> str:
+        """Return a meaningful PR title, derived only from what the agent said it changed."""
         candidates = [
             result.pull_request_title,
             result.summary,
         ]
         for candidate in candidates:
+            if str(candidate or "").strip() == _NO_FINAL_MESSAGE_SUMMARY:
+                continue
             title = pr_publish.normalize_title_candidate(candidate)
             if pr_publish.is_meaningful_commit_title(title):
                 return title
-        prompt = str(task_prompt or "").strip()
-        if prompt:
-            first_line = prompt.splitlines()[0].strip()
-            if len(first_line) >= 8:
-                return pr_publish.normalize_title_candidate(first_line)
         return "Apply OpenCode changes"
 
-    def _ensure_pr_body(self, result: OpenCodeRunResult, task_prompt: str) -> str:
-        """Return a PR body with adequate context; enhance a short or missing body."""
+    def _ensure_pr_body(self, result: OpenCodeRunResult) -> str:
+        """Return a PR body built only from the agent's description of the change."""
         body = str(result.pull_request_body or "").strip()
-        summary = str(result.summary or "").strip()
-        prompt = str(task_prompt or "").strip()
-        if len(body) >= 60 and body != summary:
+        if body:
             return body
-        parts: list[str] = []
-        if summary and summary != body:
-            parts.append(summary)
-        if prompt:
-            parts.append(f"## Task\n\n{prompt}")
-        if not parts:
+        summary = str(result.summary or "").strip()
+        if not summary:
             return ""
-        return "\n\n".join(parts)
+        if summary.lstrip().startswith("#"):
+            return summary
+        return f"## Change Summary\n\n{summary}"
 
     @staticmethod
     def _event_assistant_text(event: dict) -> str:
@@ -347,7 +339,7 @@ class OpenCodeRunnerService:
             home, api_key=request.api_key, base_url=request.base_url, model=model
         )
         stdout = self._exec_opencode(workspace, home, request, model)
-        result = self.parse_events(stdout, task_prompt=request.task_prompt)
+        result = self.parse_events(stdout)
         self._normalize_pr_metadata(result, request.task_prompt)
         result.workspace_path = str(workspace)
         result.branch_name = request.branch_name

--- a/backend/tests/test_codex_publish_modes.py
+++ b/backend/tests/test_codex_publish_modes.py
@@ -70,6 +70,37 @@ class TestPublishModeConstants(unittest.TestCase):
         self.assertIn("Do NOT run git", prompt)
         self.assertIn("use port 1234", prompt)
 
+    def test_build_prompt_states_pull_request_content_policy(self) -> None:
+        prompt = CodexRunnerService._build_prompt("translate the readme")
+        self.assertIn("the task prompt is PRIVATE", prompt)
+        self.assertIn("## Change Summary", prompt)
+        self.assertIn("## Screenshots", prompt)
+
+    def test_resume_prompt_states_pull_request_content_policy(self) -> None:
+        self.assertIn(
+            pr_publish.PR_CONTENT_POLICY, CodexRunnerService._build_resume_prompt("use port 1234")
+        )
+
+
+class TestCodexPublishedTextRedaction(unittest.TestCase):
+    def test_finalize_strips_task_prompt_echo_from_published_fields(self) -> None:
+        prompt = "Add a retry to the webhook trigger and do not touch the scheduler."
+        result = CodexRunResult(
+            status="completed",
+            summary=f"Added the retry loop.\n\n{prompt}",
+            validation="Ran the backend suite.",
+            pull_request_title="Add webhook trigger retry",
+            pull_request_body=f"## Change Summary\n\nAdded the retry loop.\n\n## Task\n\n{prompt}",
+        )
+
+        CodexRunnerService._redact_publishable_text(result, prompt)
+
+        self.assertEqual(result.summary, "Added the retry loop.")
+        self.assertEqual(result.validation, "Ran the backend suite.")
+        self.assertNotIn("## Task", result.pull_request_body)
+        self.assertNotIn("do not touch the scheduler", result.pull_request_body)
+        self.assertIn("Added the retry loop.", result.pull_request_body)
+
 
 class TestCommitMessage(unittest.TestCase):
     def test_commit_title_keeps_full_single_sentence(self) -> None:

--- a/backend/tests/test_coding_agent_pr_publish.py
+++ b/backend/tests/test_coding_agent_pr_publish.py
@@ -174,3 +174,45 @@ class TestPrPublishHelpers(unittest.TestCase):
         )
         gh.get_release_by_tag.assert_called_once_with("acme", "app", "opencode-pr-assets")
         self.assertIn("![pr-1-ui.png](http://x/pr-1-ui.png)", body)
+
+
+class TestTaskPromptRedaction(unittest.TestCase):
+    PROMPT = "Rework the mobile chat header so History sits last, then run the e2e suite."
+
+    def test_removes_task_section(self):
+        body = f"## Change Summary\n\nMoved History last.\n\n## Task\n\n{self.PROMPT}\n"
+        self.assertEqual(
+            pr_publish.redact_task_prompt(body, self.PROMPT),
+            "## Change Summary\n\nMoved History last.",
+        )
+
+    def test_section_removal_is_case_and_label_tolerant(self):
+        for heading in ("### Original Request", "## Instructions:", "## **User Prompt**"):
+            body = f"## Change Summary\n\nMoved History last.\n\n{heading}\n\nsecret guidance\n"
+            with self.subTest(heading=heading):
+                self.assertNotIn("secret guidance", pr_publish.redact_task_prompt(body, ""))
+
+    def test_prompt_section_removal_stops_at_next_same_level_heading(self):
+        body = (
+            "## Task\n\nprivate guidance here\n\n"
+            "### Details\n\nmore private guidance\n\n"
+            "## Screenshots\n\n![ui](http://x/ui.png)\n"
+        )
+        cleaned = pr_publish.redact_task_prompt(body, "")
+        self.assertNotIn("private guidance", cleaned)
+        self.assertIn("![ui](http://x/ui.png)", cleaned)
+
+    def test_removes_verbatim_prompt_paragraph_without_a_heading(self):
+        body = f"{self.PROMPT}\n\nMoved History last."
+        self.assertEqual(pr_publish.redact_task_prompt(body, self.PROMPT), "Moved History last.")
+
+    def test_keeps_wording_that_merely_overlaps_the_prompt(self):
+        body = "## Change Summary\n\nMoved History last in the mobile chat header."
+        self.assertEqual(pr_publish.redact_task_prompt(body, self.PROMPT), body)
+
+    def test_short_prompts_do_not_trigger_paragraph_removal(self):
+        body = "Fix the tests"
+        self.assertEqual(pr_publish.redact_task_prompt(body, "Fix the tests"), body)
+
+    def test_empty_input_is_safe(self):
+        self.assertEqual(pr_publish.redact_task_prompt("", self.PROMPT), "")

--- a/backend/tests/test_opencode_runner_service.py
+++ b/backend/tests/test_opencode_runner_service.py
@@ -53,13 +53,18 @@ class TestOpenCodeRunCommand(unittest.TestCase):
         self.assertNotIn("./check.sh", cmd[-1])
         self.assertNotIn("Do NOT install package managers", cmd[-1])
 
+    def test_run_command_states_pull_request_content_policy(self):
+        prompt = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)[-1]
+        self.assertIn(pr_publish.PR_CONTENT_POLICY, prompt)
+        self.assertIn("## Change Summary", prompt)
+
     def test_run_command_emphasizes_mandatory_pr_title(self):
         cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
         prompt = cmd[-1]
         self.assertIn("PR metadata is MANDATORY", prompt)
         self.assertIn("good PR title is specific", prompt)
         self.assertIn("Bad titles are generic", prompt)
-        self.assertIn("## Summary", prompt)
+        self.assertIn("## Change Summary", prompt)
 
     def test_run_command_includes_screenshot_instructions(self):
         cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
@@ -157,18 +162,8 @@ class TestOpenCodeParser(unittest.TestCase):
         self.assertEqual(result.status, "completed")
         self.assertTrue(result.summary)
 
-    def test_parse_uses_task_prompt_for_fallback_summary(self):
-        result = self.svc.parse_events("", task_prompt="Fix the OpenCode fallback summary logic")
-        self.assertIn("OpenCode completed the requested task", result.summary)
-        self.assertIn("Fix the OpenCode fallback summary logic", result.summary)
-
-    def test_parse_fallback_summary_avoids_generic_message_when_prompt_present(self):
-        result = self.svc.parse_events("", task_prompt="Add case-insensitive screenshot discovery")
-        self.assertNotEqual(result.summary, "OpenCode completed without a final assistant message.")
-        self.assertIn("Add case-insensitive screenshot discovery", result.summary)
-
-    def test_parse_empty_task_prompt_falls_back_to_generic_message(self):
-        result = self.svc.parse_events("", task_prompt="")
+    def test_parse_fallback_summary_never_echoes_the_task_prompt(self):
+        result = self.svc.parse_events("")
         self.assertEqual(result.summary, "OpenCode completed without a final assistant message.")
 
 
@@ -181,46 +176,65 @@ class TestOpenCodePrMetadataNormalization(unittest.TestCase):
             summary="Did some work.",
             pull_request_title="Fix OpenCode fallback summary logic",
         )
-        title = self.svc._ensure_meaningful_pr_title(result, "some task")
-        self.assertEqual(title, "Fix OpenCode fallback summary logic")
-
-    def test_ensure_meaningful_pr_title_skips_placeholder(self):
-        result = OpenCodeRunResult(summary="Done.", pull_request_title="Done")
-        title = self.svc._ensure_meaningful_pr_title(result, "Fix OpenCode fallback summary logic")
+        title = self.svc._ensure_meaningful_pr_title(result)
         self.assertEqual(title, "Fix OpenCode fallback summary logic")
 
     def test_ensure_meaningful_pr_title_derives_from_summary(self):
         result = OpenCodeRunResult(
             summary="Implemented the mobile drawer fix.", pull_request_title=""
         )
-        title = self.svc._ensure_meaningful_pr_title(result, "fix ui")
+        title = self.svc._ensure_meaningful_pr_title(result)
         self.assertEqual(title, "Implemented the mobile drawer fix.")
 
     def test_ensure_meaningful_pr_title_last_resort_fallback(self):
         result = OpenCodeRunResult(summary="Done.", pull_request_title="")
-        title = self.svc._ensure_meaningful_pr_title(result, "")
+        title = self.svc._ensure_meaningful_pr_title(result)
         self.assertEqual(title, "Apply OpenCode changes")
 
-    def test_ensure_pr_body_enhances_short_body_with_task(self):
-        result = OpenCodeRunResult(summary="Done.", pull_request_body="")
-        body = self.svc._ensure_pr_body(result, "Fix OpenCode fallback summary logic")
-        self.assertIn("## Task", body)
-        self.assertIn("Fix OpenCode fallback summary logic", body)
-
-    def test_ensure_pr_body_keeps_existing_long_body(self):
-        long_body = "This is a sufficiently long PR body with enough context to remain unchanged."
+    def test_ensure_meaningful_pr_title_skips_missing_message_sentinel(self):
         result = OpenCodeRunResult(
-            summary="Summary text.",
-            pull_request_body=long_body,
+            summary="OpenCode completed without a final assistant message.",
+            pull_request_title="",
         )
-        body = self.svc._ensure_pr_body(result, "task prompt")
-        self.assertEqual(body, long_body)
+        self.assertEqual(self.svc._ensure_meaningful_pr_title(result), "Apply OpenCode changes")
 
-    def test_normalize_pr_metadata_mutates_result(self):
+    def test_ensure_pr_body_wraps_summary_in_change_summary_section(self):
+        result = OpenCodeRunResult(summary="Reordered the mobile header actions.")
+        body = self.svc._ensure_pr_body(result)
+        self.assertEqual(body, "## Change Summary\n\nReordered the mobile header actions.")
+
+    def test_ensure_pr_body_keeps_existing_body(self):
+        long_body = "This is a sufficiently long PR body with enough context to remain unchanged."
+        result = OpenCodeRunResult(summary="Summary text.", pull_request_body=long_body)
+        self.assertEqual(self.svc._ensure_pr_body(result), long_body)
+
+    def test_normalize_pr_metadata_never_publishes_the_task_prompt(self):
         result = OpenCodeRunResult(summary="Done.", pull_request_title="Update")
         self.svc._normalize_pr_metadata(result, "Fix OpenCode fallback summary logic")
-        self.assertEqual(result.pull_request_title, "Fix OpenCode fallback summary logic")
-        self.assertIn("## Task", result.pull_request_body)
+        self.assertEqual(result.pull_request_title, "Apply OpenCode changes")
+        self.assertNotIn("## Task", result.pull_request_body)
+        self.assertNotIn("Fix OpenCode fallback summary logic", result.pull_request_body)
+
+    def test_normalize_pr_metadata_strips_task_section_from_agent_body(self):
+        prompt = "Move the chat list toggle before History on mobile, then run the e2e suite."
+        result = OpenCodeRunResult(
+            summary="Reordered the mobile chat header actions.",
+            pull_request_title="Reorder mobile chat header actions",
+            pull_request_body=(
+                "## Change Summary\n\nReordered the mobile chat header actions.\n\n"
+                f"## Task\n\n{prompt}\n"
+            ),
+        )
+        self.svc._normalize_pr_metadata(result, prompt)
+        self.assertNotIn("## Task", result.pull_request_body)
+        self.assertNotIn("run the e2e suite", result.pull_request_body)
+        self.assertIn("Reordered the mobile chat header actions.", result.pull_request_body)
+
+    def test_normalize_pr_metadata_strips_prompt_echo_from_summary(self):
+        prompt = "Move the chat list toggle before History on mobile, then run the e2e suite."
+        result = OpenCodeRunResult(summary=f"{prompt}\n\nReordered the header actions.")
+        self.svc._normalize_pr_metadata(result, prompt)
+        self.assertEqual(result.summary, "Reordered the header actions.")
 
 
 class TestOpenCodeExecFailureFormatting(unittest.TestCase):
@@ -264,15 +278,20 @@ class TestOpenCodeCreatePr(unittest.TestCase):
         self.workspace = Path("/tmp/ws")
         self.request = _request(publish_mode="open_pr", branch_name="opencode/run")
 
-    def test_create_pr_enhances_weak_title_and_body(self):
+    def test_create_pr_publishes_change_summary_without_the_task_prompt(self):
+        request = _request(
+            publish_mode="open_pr",
+            branch_name="opencode/run",
+            task_prompt="Fix the flaky mobile execution-highlight e2e spec before Friday.",
+        )
         result = OpenCodeRunResult(
             status="completed",
-            summary="Done.",
+            summary="Ran the highlights spec through the keyboard shortcut instead of the menu.",
             pull_request_title="Update",
             pull_request_body="",
             changed_files=["a.vue"],
         )
-        self.runner._normalize_pr_metadata(result, self.request.task_prompt)
+        self.runner._normalize_pr_metadata(result, request.task_prompt)
         gh = MagicMock()
         gh.create_pull_request.return_value = {
             "number": 1,
@@ -281,7 +300,7 @@ class TestOpenCodeCreatePr(unittest.TestCase):
 
         with patch("app.services.opencode_runner_service.GitHubService", return_value=gh) as gh_cls:
             url = self.runner._create_pr(
-                self.workspace, self.request, result, "opencode/run", draft=False
+                self.workspace, request, result, "opencode/run", draft=False
             )
 
         self.assertEqual(url, "https://github.com/acme/app/pull/1")
@@ -289,9 +308,10 @@ class TestOpenCodeCreatePr(unittest.TestCase):
         title = gh.create_pull_request.call_args.args[2]
         body = gh.create_pull_request.call_args.kwargs["body"]
         self.assertNotEqual(title, "Update")
-        self.assertIn("fix the tests", title.lower())
-        self.assertIn("## Task", body)
-        self.assertIn("fix the tests", body.lower())
+        self.assertIn("keyboard shortcut", title.lower())
+        self.assertIn("## Change Summary", body)
+        self.assertNotIn("## Task", body)
+        self.assertNotIn("before friday", body.lower())
 
 
 class TestOpenCodePushBranch(unittest.TestCase):

--- a/frontend/src/docs/content/nodes/codex-node.md
+++ b/frontend/src/docs/content/nodes/codex-node.md
@@ -81,6 +81,12 @@ OpenAI references:
 
 For UI/frontend tasks, Codex should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, Codex may run `bun install` (or npm/pnpm install) and start a short-lived preview/`bun run dev` solely to capture the UI. After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`codex-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description. Codex must also set a meaningful `pull_request_title` (never placeholders such as `Done.`). 
 
+## What gets published to GitHub
+
+Your **Task Prompt** is private input, not PR content. Only two things are published: a `## Change Summary` describing what the code change does, and a `## Screenshots` section when screenshots were captured. The PR title is derived from the change summary alone.
+
+The runner prompt states this policy, and Heym also enforces it after the run: before anything is committed or opened as a pull request, it strips prompt-echo sections (`## Task`, `## Prompt`, `## Instructions`, `## Original Request`, …) and any paragraph copied verbatim from the task prompt out of the summary, the PR body, and the commit message.
+
 ## Follow-up Questions
 
 If Codex needs missing requirements or a product decision, it returns `needs_input`. Heym pauses the execution and exposes a `question` output handle. Connect that handle to a notification branch, for example Slack or Send Email, to send the reviewer the public follow-up link.

--- a/frontend/src/docs/content/nodes/opencode-go-node.md
+++ b/frontend/src/docs/content/nodes/opencode-go-node.md
@@ -79,6 +79,12 @@ For UI/frontend tasks, OpenCode should save PNG screenshots under a gitignored p
 
 OpenCode is also instructed to end with a `PR_TITLE: …` line so Heym can open the pull request with a meaningful subject instead of placeholders such as `Done.`
 
+## What gets published to GitHub
+
+Your **Task Prompt** is private input, not PR content. Only two things are published: a `## Change Summary` describing what the code change does, and a `## Screenshots` section when screenshots were captured. The PR title is derived from the change summary alone.
+
+The runner prompt states this policy, and Heym also enforces it after the run: before anything is committed or opened as a pull request, it strips prompt-echo sections (`## Task`, `## Prompt`, `## Instructions`, `## Original Request`, …) and any paragraph copied verbatim from the task prompt out of the summary, the PR body, and the commit message.
+
 ## As an agent tool
 
 The OpenCode Go node can be attached to an **AI Agent** node's tool handle so the agent can delegate coding tasks. Configure the credential, GitHub credential, and repository on the node, then mark **Task Prompt** (and optionally **Repository URL**) with the agent-provided toggle so the agent supplies them at call time.


### PR DESCRIPTION
## Change Summary

The Codex and OpenCode Go nodes could publish the user's task prompt to GitHub. OpenCode did it structurally, not just occasionally:

- a missing PR body was filled with a `## Task` section containing the raw prompt,
- a weak PR title fell back to the prompt's first line,
- a run with no final assistant message produced a summary quoting a 200-character prompt snippet, which then became the commit body.

**Policy.** Both runner prompts now carry a shared `PR_CONTENT_POLICY`: the task prompt is private, and only a `## Change Summary` (plus `## Screenshots` when captured) may reach GitHub. The PR title is derived from the change summary alone.

**Enforcement.** A prompt is guidance, so `pr_publish.redact_task_prompt` backstops it on the way out. It strips prompt-echo sections (`## Task`, `## Prompt`, `## Instructions`, `## Original Request`, …) and any paragraph copied verbatim from the task prompt out of the summary, the PR body, and the commit message — for both runners.

**Removed prompt-derived generation.** `_ensure_pr_body` no longer appends the task; `_ensure_meaningful_pr_title` no longer falls back to the prompt's first line; the silent-run summary is now a fixed sentinel that is also barred from becoming a PR subject. `parse_events` no longer takes `task_prompt` at all, so the leak cannot come back by accident — `task_prompt` now flows into the publish path only as input to redaction.

Docs: both node pages gain a "What gets published to GitHub" section.

## Validation

`./check.sh` — frontend lint + typecheck clean, 2372 backend tests pass, including new coverage for the redaction helpers, the two runner policies, and the removed prompt-derived fallbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)