### PR TITLE
fix/coding-agent-pr-content-and-stale-save

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1270,6 +1270,30 @@ async def get_workflow(
     return response
 
 
+def _as_utc(value: datetime) -> datetime:
+    """Treat a naive timestamp as UTC so stored and client-supplied values are comparable."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _reject_stale_update(workflow: Workflow, base_updated_at: datetime | None) -> None:
+    """Refuse an update whose base revision is older than the stored one.
+
+    Optimistic concurrency, like the analysis note's ``base_revision``: the check happens in the
+    same request that writes, so there is no window between checking and saving. Clients that omit
+    ``base_updated_at`` are explicitly overriding and are never rejected.
+    """
+    if base_updated_at is None or workflow.updated_at is None:
+        return
+    if _as_utc(workflow.updated_at) > _as_utc(base_updated_at):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Workflow was updated by someone else",
+                "updated_at": _as_utc(workflow.updated_at).isoformat(),
+            },
+        )
+
+
 @router.put("/{workflow_id}", response_model=WorkflowResponse)
 async def update_workflow(
     workflow_id: uuid.UUID,
@@ -1284,6 +1308,8 @@ async def update_workflow(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow not found",
         )
+
+    _reject_stale_update(workflow, workflow_data.base_updated_at)
 
     should_create_version = False
     old_nodes = workflow.nodes

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -219,6 +219,10 @@ class WorkflowUpdate(BaseModel):
     error_workflow_id: uuid.UUID | None = None
     minutes_saved_per_run: float | None = None
     workflow_timeout_seconds: int | None = None
+    # Optimistic concurrency: the `updated_at` the client's edit is based on. When supplied and the
+    # stored row is newer, the update is rejected with 409 instead of overwriting someone else's
+    # work. Omitted means "save unconditionally" (the explicit override path).
+    base_updated_at: datetime | None = None
 
 
 class WorkflowShareRequest(BaseModel):

--- a/backend/app/services/codex_runner_service.py
+++ b/backend/app/services/codex_runner_service.py
@@ -118,6 +118,10 @@ class CodexRunResult:
     summary: str = ""
     question: str = ""
     validation: str = ""
+    # ``summary`` narrowed to what may be published to GitHub (see
+    # ``pr_publish.publishable_summary``). Deliberately absent from ``to_output()``: it exists
+    # for the commit/PR seam, not the node output.
+    publish_summary: str = ""
     pull_request_title: str = ""
     pull_request_body: str = ""
     diff: str = ""
@@ -578,7 +582,7 @@ class CodexRunnerService:
         result.branch_name = request.branch_name
         result.diff = self._git_output(["git", "diff", "--binary"], workspace)
         result.changed_files = self._changed_files(workspace)
-        self._redact_publishable_text(result, request.task_prompt)
+        self._prepare_publishable_text(result, request.task_prompt)
         if result.status == "completed" and request.publish_mode in _CODEX_REMOTE_PUBLISH_MODES:
             self._publish(workspace, request, result)
         return result
@@ -710,7 +714,12 @@ class CodexRunnerService:
         draft: bool,
     ) -> str | None:
         owner, repo = self._parse_github_owner_repo(request.repository_url)
-        pr_body = str(result.pull_request_body or "").strip() or result.summary or None
+        pr_body = (
+            str(result.pull_request_body or "").strip()
+            or result.publish_summary
+            or pr_publish.changed_files_body(result.changed_files, agent="Codex")
+            or None
+        )
         gh = GitHubService(request.github_config)
         try:
             pr = gh.create_pull_request(
@@ -761,11 +770,7 @@ class CodexRunnerService:
             owner, repo = self._parse_github_owner_repo(request.repository_url)
             gh = GitHubService(request.github_config)
             try:
-                base_body = (
-                    str(result.pull_request_body or "").strip()
-                    or str(result.summary or "").strip()
-                    or ""
-                )
+                base_body = str(result.pull_request_body or "").strip() or result.publish_summary
                 updated_body = pr_publish.upload_and_inject_screenshots(
                     gh,
                     screenshots=screenshots,
@@ -918,27 +923,30 @@ class CodexRunnerService:
         )
 
     @staticmethod
-    def _redact_publishable_text(result: CodexRunResult, task_prompt: str) -> None:
-        """Strip task-prompt echoes from every field that can reach GitHub.
+    def _prepare_publishable_text(result: CodexRunResult, task_prompt: str) -> None:
+        """Narrow every field that can reach GitHub down to publishable content.
 
-        Enforcement backstop for ``pr_publish.PR_CONTENT_POLICY``: the summary feeds the commit
-        body, and both it and ``pull_request_body`` feed the PR description.
+        Enforcement backstop for ``pr_publish.PR_CONTENT_POLICY``, shared with the OpenCode
+        runner: strip task-prompt echoes, then drop a summary that only narrates the agent's own
+        process. The summary feeds the commit body, and both it and ``pull_request_body`` feed
+        the PR description.
         """
         result.summary = pr_publish.redact_task_prompt(result.summary, task_prompt)
         result.validation = pr_publish.redact_task_prompt(result.validation, task_prompt)
         result.pull_request_body = pr_publish.redact_task_prompt(
             result.pull_request_body, task_prompt
         )
+        result.publish_summary = pr_publish.publishable_summary(result.summary)
 
     @staticmethod
     def _commit_title(result: CodexRunResult) -> str:
         return pr_publish.commit_title(
-            result.pull_request_title, result.summary, fallback="Apply Codex changes"
+            result.pull_request_title, result.publish_summary, fallback="Apply Codex changes"
         )
 
     @staticmethod
     def _commit_body(result: CodexRunResult) -> str:
-        return pr_publish.commit_body(result.summary, result.validation)
+        return pr_publish.commit_body(result.publish_summary, result.validation)
 
     @staticmethod
     def _clone_url_with_token(repository_url: str, github_config: dict) -> str:

--- a/backend/app/services/coding_agent/pr_publish.py
+++ b/backend/app/services/coding_agent/pr_publish.py
@@ -119,6 +119,26 @@ _MEANINGLESS_TITLE_RE = re.compile(
 )
 _PR_TITLE_LINE_RE = re.compile(r"(?im)^\s*PR_TITLE:\s*(.+?)\s*$")
 
+# Running commentary an agent emits *between* steps ("Both pass. Let me do a final review:").
+# It reads like prose but describes the agent's own process, not the change, so publishing it
+# leaks reasoning. Matched as a prefix, since narration announces itself in the opening clause.
+_INTERJECTIONS = r"ok(?:ay)?|perfect|great|excellent|good|alright|nice|awesome|cool|now"
+_NARRATION_PREFIX_RE = re.compile(
+    rf"^(?:(?:{_INTERJECTIONS})[,!.]?\s+)*"
+    r"(?:"
+    r"let(?:'|’)?s\b|let me\b|"
+    r"i(?:'|’)?(?:ll|m|ve)\b|i (?:will|am|have|need|should|can)\b|"
+    r"next[,:]?\s+i\b|first[,:]\s|"
+    r"(?:both|all|everything|they|it|the|tests?|checks?|specs?)\s+"
+    r"(?:(?:tests?|checks?|specs?|suites?|builds?)\s+)?(?:now\s+)?"
+    r"(?:pass(?:es|ed)?|look|looks|works?|worked|is correct|are correct|is right)\b"
+    r")",
+    re.IGNORECASE,
+)
+# "Good, …" / "Perfect! …" — an interjection about the agent's own progress, not a change.
+_INTERJECTION_OPENER_RE = re.compile(rf"^(?:{_INTERJECTIONS})\s*[,!.]", re.IGNORECASE)
+_CHANGE_SUMMARY_HEADING = "change summary"
+
 
 def normalize_title_candidate(text: str) -> str:
     """Collapse whitespace and strip a leading ``PR_TITLE:`` label if present."""
@@ -127,12 +147,54 @@ def normalize_title_candidate(text: str) -> str:
     return cleaned.strip("\"'`")
 
 
+def is_agent_narration(text: str) -> bool:
+    """True when the text is the agent narrating its own process rather than the change.
+
+    Three signals, all observed on real agent pull requests: a step announcement
+    ("Let me…", "I'll…"), an interjection about its own progress ("Good, …"), and a trailing
+    colon, which introduces the next step and never ends a change description.
+    """
+    collapsed = _collapse(text)
+    if not collapsed:
+        return False
+    if collapsed.endswith(":"):
+        return True
+    if _INTERJECTION_OPENER_RE.match(collapsed) is not None:
+        return True
+    return _NARRATION_PREFIX_RE.match(collapsed) is not None
+
+
 def is_meaningful_commit_title(title: str) -> bool:
-    """Return False for empty/short/placeholder titles such as ``Done.``."""
+    """Return False for empty/short/placeholder/narration titles such as ``Done.``."""
     normalized = normalize_title_candidate(title)
     if len(normalized) < 8:
         return False
-    return _MEANINGLESS_TITLE_RE.match(normalized) is None
+    if _MEANINGLESS_TITLE_RE.match(normalized) is not None:
+        return False
+    return not is_agent_narration(normalized)
+
+
+def extract_change_summary_section(text: str) -> str:
+    """Return the body of the last ``## Change Summary`` section, or ``""`` when absent.
+
+    The runner prompts ask agents to put the publishable description under this heading, so
+    honouring it keeps step-by-step narration around it out of the pull request.
+    """
+    kept: list[str] = []
+    section_level = 0
+    for line in str(text or "").splitlines():
+        match = _HEADING_RE.match(line)
+        if match is not None:
+            level = len(match.group(1))
+            if _normalize_heading(match.group(2)) == _CHANGE_SUMMARY_HEADING:
+                section_level = level
+                kept = []
+                continue
+            if section_level and level <= section_level:
+                section_level = 0
+        if section_level:
+            kept.append(line)
+    return "\n".join(kept).strip()
 
 
 def extract_pr_title_line(summary: str) -> tuple[str, str]:
@@ -220,6 +282,35 @@ def strip_prompt_echo_blocks(body: str, task_prompt: str) -> str:
         if block.strip():
             kept.append(block.strip())
     return "\n\n".join(kept).strip()
+
+
+def publishable_summary(summary: str, *, placeholder: str = "") -> str:
+    """The agent's description of the change, or ``""`` when it only narrated its own process.
+
+    Runners keep the raw ``summary`` on the node output so a run stays debuggable in Heym; this
+    narrower value is the only one allowed into a commit message or pull request.
+    """
+    text = str(summary or "").strip()
+    if not text or (placeholder and text == placeholder):
+        return ""
+    return "" if is_agent_narration(text) else text
+
+
+def changed_files_body(changed_files: list[str], *, agent: str, limit: int = 20) -> str:
+    """Last-resort PR body: the diff's own file list, which is always safe to publish."""
+    if not changed_files:
+        return ""
+    shown = changed_files[:limit]
+    lines = [f"- `{path}`" for path in shown]
+    remaining = len(changed_files) - len(shown)
+    if remaining > 0:
+        lines.append(f"- …and {remaining} more file(s)")
+    listing = "\n".join(lines)
+    return (
+        "## Change Summary\n\n"
+        f"{agent} did not return a change summary. Files changed in this pull request:\n\n"
+        f"{listing}"
+    )
 
 
 def redact_task_prompt(body: str, task_prompt: str) -> str:

--- a/backend/app/services/opencode_runner_service.py
+++ b/backend/app/services/opencode_runner_service.py
@@ -50,9 +50,11 @@ _LOCAL_ONLY_RULES = (
     "`PR_TITLE: Add case-insensitive screenshot discovery for OpenCode PRs`. "
     "Bad titles are generic or incomplete, e.g. `PR_TITLE: Fix issue`, `PR_TITLE: Update code`, "
     "`PR_TITLE: Done`, or `PR_TITLE: Apply changes`. "
-    "After the PR_TITLE line, provide a concise PR description that explains what changed and "
-    "why, using a `## Change Summary` section. If you saved screenshots, mention their file paths "
-    "so they can be attached automatically. "
+    "Your final assistant message MUST also contain a `## Change Summary` section describing "
+    "what changed and why — Heym publishes that section and nothing else, so a message that only "
+    "narrates your process (for example `Both pass. Let me do a final review:`) leaves the pull "
+    "request with no description. If you saved screenshots, mention their file paths so they can "
+    "be attached automatically. "
     f"{pr_publish.PR_CONTENT_POLICY}"
 )
 _MAX_ERROR_DETAIL_CHARS = 4000
@@ -85,6 +87,9 @@ class OpenCodeRunResult:
     status: str = "completed"
     summary: str = ""
     validation: str = ""
+    # ``summary`` narrowed to what may be published to GitHub — see ``_publishable_summary``.
+    # Deliberately absent from ``to_output()``: it exists for the commit/PR seam, not the UI.
+    publish_summary: str = ""
     pull_request_title: str = ""
     pull_request_body: str = ""
     diff: str = ""
@@ -167,8 +172,16 @@ class OpenCodeRunnerService:
 
     # --- output parsing ---
     def parse_events(self, stdout: str) -> OpenCodeRunResult:
+        """Collect the run's events, preferring the agent's declared change summary.
+
+        OpenCode streams an assistant message per step, so the *last* one is often mid-run
+        narration rather than the final report. Scanning every message for the agreed
+        ``## Change Summary`` / ``PR_TITLE:`` markers keeps commentary out of the pull request.
+        """
         events: list[dict] = []
-        summary = ""
+        last_message = ""
+        change_summary = ""
+        pull_request_title = ""
         for raw in (stdout or "").splitlines():
             line = raw.strip()
             if not line:
@@ -181,14 +194,18 @@ class OpenCodeRunnerService:
                 continue
             events.append(event)
             text = self._event_assistant_text(event)
-            if text:
-                summary = text
-        if not summary:
-            summary = _NO_FINAL_MESSAGE_SUMMARY
-        pull_request_title, cleaned_summary = pr_publish.extract_pr_title_line(summary)
+            if not text:
+                continue
+            title, cleaned = pr_publish.extract_pr_title_line(text)
+            if title:
+                pull_request_title = title
+            section = pr_publish.extract_change_summary_section(cleaned)
+            if section:
+                change_summary = section
+            last_message = cleaned
         return OpenCodeRunResult(
             status="completed",
-            summary=cleaned_summary,
+            summary=change_summary or last_message or _NO_FINAL_MESSAGE_SUMMARY,
             pull_request_title=pull_request_title,
             raw_events=events,
         )
@@ -203,18 +220,17 @@ class OpenCodeRunnerService:
         result.pull_request_body = pr_publish.redact_task_prompt(
             result.pull_request_body, task_prompt
         )
+        result.publish_summary = self._publishable_summary(result)
         result.pull_request_title = self._ensure_meaningful_pr_title(result)
         result.pull_request_body = self._ensure_pr_body(result)
 
+    @staticmethod
+    def _publishable_summary(result: OpenCodeRunResult) -> str:
+        return pr_publish.publishable_summary(result.summary, placeholder=_NO_FINAL_MESSAGE_SUMMARY)
+
     def _ensure_meaningful_pr_title(self, result: OpenCodeRunResult) -> str:
         """Return a meaningful PR title, derived only from what the agent said it changed."""
-        candidates = [
-            result.pull_request_title,
-            result.summary,
-        ]
-        for candidate in candidates:
-            if str(candidate or "").strip() == _NO_FINAL_MESSAGE_SUMMARY:
-                continue
+        for candidate in (result.pull_request_title, result.publish_summary):
             title = pr_publish.normalize_title_candidate(candidate)
             if pr_publish.is_meaningful_commit_title(title):
                 return title
@@ -225,9 +241,9 @@ class OpenCodeRunnerService:
         body = str(result.pull_request_body or "").strip()
         if body:
             return body
-        summary = str(result.summary or "").strip()
+        summary = result.publish_summary
         if not summary:
-            return ""
+            return pr_publish.changed_files_body(result.changed_files, agent="OpenCode")
         if summary.lstrip().startswith("#"):
             return summary
         return f"## Change Summary\n\n{summary}"
@@ -340,11 +356,13 @@ class OpenCodeRunnerService:
         )
         stdout = self._exec_opencode(workspace, home, request, model)
         result = self.parse_events(stdout)
-        self._normalize_pr_metadata(result, request.task_prompt)
         result.workspace_path = str(workspace)
         result.branch_name = request.branch_name
         result.diff = self._git_output(["git", "diff", "--binary"], workspace)
         result.changed_files = self._changed_files(workspace)
+        # After ``changed_files``: the PR body falls back to the file list when the agent
+        # never produced a publishable change summary.
+        self._normalize_pr_metadata(result, request.task_prompt)
         if result.status == "completed" and request.publish_mode in _REMOTE_PUBLISH_MODES:
             self._publish(workspace, request, result)
         return result
@@ -548,7 +566,7 @@ class OpenCodeRunnerService:
             self._run_command(["git", "checkout", "-B", branch], cwd=workspace)
         self._run_command(["git", "add", "-A"], cwd=workspace)
         title = pr_publish.commit_title(
-            result.pull_request_title, result.summary, fallback="Apply OpenCode changes"
+            result.pull_request_title, result.publish_summary, fallback="Apply OpenCode changes"
         )
         commit_cmd = [
             "git",
@@ -559,7 +577,7 @@ class OpenCodeRunnerService:
             "-m",
             title,
         ]
-        body = pr_publish.commit_body(result.summary, result.validation)
+        body = pr_publish.commit_body(result.publish_summary, result.validation)
         if body and body != title:
             commit_cmd.extend(["-m", body])
         self._run_command(commit_cmd, cwd=workspace)
@@ -660,11 +678,7 @@ class OpenCodeRunnerService:
             owner, repo = pr_publish.parse_github_owner_repo(request.repository_url)
             gh = GitHubService(request.github_config)
             try:
-                base_body = (
-                    str(result.pull_request_body or "").strip()
-                    or str(result.summary or "").strip()
-                    or ""
-                )
+                base_body = str(result.pull_request_body or "").strip() or result.publish_summary
                 updated_body = pr_publish.upload_and_inject_screenshots(
                     gh,
                     screenshots=screenshots,

--- a/backend/tests/test_codex_publish_modes.py
+++ b/backend/tests/test_codex_publish_modes.py
@@ -1,6 +1,6 @@
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from app.config import settings
 from app.services.codex_runner_service import (
@@ -93,7 +93,7 @@ class TestCodexPublishedTextRedaction(unittest.TestCase):
             pull_request_body=f"## Change Summary\n\nAdded the retry loop.\n\n## Task\n\n{prompt}",
         )
 
-        CodexRunnerService._redact_publishable_text(result, prompt)
+        CodexRunnerService._prepare_publishable_text(result, prompt)
 
         self.assertEqual(result.summary, "Added the retry loop.")
         self.assertEqual(result.validation, "Ran the backend suite.")
@@ -103,19 +103,25 @@ class TestCodexPublishedTextRedaction(unittest.TestCase):
 
 
 class TestCommitMessage(unittest.TestCase):
+    @staticmethod
+    def _result(**kwargs) -> CodexRunResult:
+        """Build a result the way the runner does, so `publish_summary` is populated."""
+        result = CodexRunResult(status="completed", **kwargs)
+        CodexRunnerService._prepare_publishable_text(result, "")
+        return result
+
     def test_commit_title_keeps_full_single_sentence(self) -> None:
         # A long run-on summary (no early period) is kept whole, not cut at ~72 chars.
         summary = "Added n8n10 to docker-compose.yml using host port 2245, internal port 3032"
-        result = CodexRunResult(status="completed", summary=summary)
+        result = self._result(summary=summary)
         self.assertEqual(CodexRunnerService._commit_title(result), summary)
 
     def test_commit_title_keeps_short_summary(self) -> None:
-        result = CodexRunResult(status="completed", summary="Fix typo")
+        result = self._result(summary="Fix typo")
         self.assertEqual(CodexRunnerService._commit_title(result), "Fix typo")
 
     def test_commit_title_prefers_pull_request_title(self) -> None:
-        result = CodexRunResult(
-            status="completed",
+        result = self._result(
             summary="A long detailed summary sentence describing everything that changed in depth.",
             pull_request_title="Add n8n10 service to compose and Traefik",
         )
@@ -124,15 +130,13 @@ class TestCommitMessage(unittest.TestCase):
         )
 
     def test_commit_title_uses_first_sentence(self) -> None:
-        result = CodexRunResult(
-            status="completed",
+        result = self._result(
             summary="README.md translated. Headings, tables, notes localized; commands preserved.",
         )
         self.assertEqual(CodexRunnerService._commit_title(result), "README.md translated.")
 
     def test_commit_title_skips_placeholder_done(self) -> None:
-        result = CodexRunResult(
-            status="completed",
+        result = self._result(
             summary="Done. Reorder the mobile chat header actions.",
             pull_request_title="Done.",
         )
@@ -142,9 +146,7 @@ class TestCommitMessage(unittest.TestCase):
         )
 
     def test_commit_body_has_full_summary_and_validation(self) -> None:
-        result = CodexRunResult(
-            status="completed", summary="X" * 100, validation="ran docker compose config"
-        )
+        result = self._result(summary="X" * 100, validation="ran docker compose config")
         body = CodexRunnerService._commit_body(result)
         self.assertIn("X" * 100, body)
         self.assertIn("ran docker compose config", body)
@@ -280,3 +282,46 @@ class TestPublishDispatch(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCodexNarrationIsNotPublished(unittest.TestCase):
+    """The narration guard is shared with OpenCode; Codex must get the same treatment."""
+
+    NARRATION = "Both pass. Let me do a final review of the complete changes:"
+
+    def _prepared(self, **kwargs) -> CodexRunResult:
+        result = CodexRunResult(status="completed", **kwargs)
+        CodexRunnerService._prepare_publishable_text(result, "")
+        return result
+
+    def test_narration_summary_is_not_a_commit_title_or_body(self) -> None:
+        result = self._prepared(summary=self.NARRATION, changed_files=["a.py"])
+
+        self.assertEqual(result.publish_summary, "")
+        self.assertEqual(CodexRunnerService._commit_title(result), "Apply Codex changes")
+        self.assertNotIn("Let me do a final review", CodexRunnerService._commit_body(result))
+        # The raw message stays on the node output so the run is still debuggable in Heym.
+        self.assertIn("Let me do a final review", result.summary)
+
+    def test_a_real_summary_still_reaches_the_commit(self) -> None:
+        result = self._prepared(summary="Add a retry to the webhook trigger.")
+
+        self.assertEqual(
+            CodexRunnerService._commit_title(result), "Add a retry to the webhook trigger."
+        )
+
+    def test_pr_body_falls_back_to_the_changed_file_list(self) -> None:
+        result = self._prepared(summary=self.NARRATION, changed_files=["app/main.py", "app/api.py"])
+        gh = MagicMock()
+        gh.create_pull_request.return_value = {"number": 7, "html_url": "https://x/pull/7"}
+        runner = CodexRunnerService(workspace_root="/tmp/heym-codex-ws")
+        runner._attach_pr_screenshots = MagicMock()  # type: ignore[method-assign]
+
+        with patch("app.services.codex_runner_service.GitHubService", return_value=gh):
+            runner._create_pr(
+                Path("/tmp/ws"), _request("open_pr"), result, "codex/run", draft=False
+            )
+
+        body = gh.create_pull_request.call_args.kwargs["body"]
+        self.assertNotIn("Let me do a final review", body)
+        self.assertIn("`app/main.py`", body)

--- a/backend/tests/test_coding_agent_pr_publish.py
+++ b/backend/tests/test_coding_agent_pr_publish.py
@@ -216,3 +216,94 @@ class TestTaskPromptRedaction(unittest.TestCase):
 
     def test_empty_input_is_safe(self):
         self.assertEqual(pr_publish.redact_task_prompt("", self.PROMPT), "")
+
+
+class TestAgentNarrationDetection(unittest.TestCase):
+    NARRATION = (
+        "Both pass. Let me do a final review of the complete changes:",
+        "Let me do a final review of the complete changes:",
+        "Now let me verify the store wiring.",
+        "I'll run the e2e suite next.",
+        "Perfect! Now I will check the remaining callers.",
+        "All tests pass, moving on.",
+        "It works. Next, I check the docs.",
+        "Good, the swap is correct.",
+        "Perfect! The build is clean.",
+        "First, check dependencies and start a preview server:",
+        "Applying the remaining changes now:",
+    )
+    # Real titles from merged agent pull requests — the guard must leave every one of them alone.
+    DESCRIPTIONS = (
+        "Hide Execution Highlights panel by default on mobile",
+        "Auto-scroll console to selected node's most recent execution log",
+        "Swap Traces and Templates tab positions in dashboard nav bar",
+        "Hide JSON tree/plain toggle buttons in console output when node is running",
+        "Update trace detail json tree view",
+        "Add a stale-save override dialog for concurrent workflow edits",
+        "Fix OpenCode fallback summary when no assistant message is returned",
+        "Let the workflow store detect a newer server revision before saving",
+        "Passing the loaded revision through to the save call",
+        # "Good" only opens narration when it is an interjection ("Good, …").
+        "Good defaults for the retry policy",
+    )
+
+    def test_narration_is_detected(self):
+        for text in self.NARRATION:
+            with self.subTest(text=text):
+                self.assertTrue(pr_publish.is_agent_narration(text))
+
+    def test_change_descriptions_are_not_narration(self):
+        for text in self.DESCRIPTIONS:
+            with self.subTest(text=text):
+                self.assertFalse(pr_publish.is_agent_narration(text))
+
+    def test_narration_is_rejected_as_a_commit_title(self):
+        # Regression: PR #397 shipped with this exact string as its title.
+        self.assertFalse(
+            pr_publish.is_meaningful_commit_title(
+                "Both pass. Let me do a final review of the complete changes:"
+            )
+        )
+
+    def test_every_sentence_of_a_narrated_summary_is_rejected(self):
+        # Regression: PR #389 shipped with this exact string as its title and commit subject.
+        # `commit_title` walks sentence by sentence, so each one has to be caught.
+        summary = (
+            "Good, the swap is correct. Now let me take a screenshot. "
+            "First, check dependencies and start a preview server:"
+        )
+        self.assertEqual(pr_publish.commit_title("", summary, fallback="Fallback"), "Fallback")
+
+    def test_commit_title_falls_back_when_the_summary_only_narrates(self):
+        title = pr_publish.commit_title(
+            "", "Both pass. Let me do a final review of the complete changes:", fallback="Fallback"
+        )
+        self.assertEqual(title, "Fallback")
+
+
+class TestChangeSummaryExtraction(unittest.TestCase):
+    def test_extracts_section_and_drops_surrounding_narration(self):
+        text = (
+            "Let me do a final review of the complete changes:\n\n"
+            "## Change Summary\n\n"
+            "Added a stale-save override dialog.\n\n"
+            "## Screenshots\n\n"
+            "![ui](frontend/.e2e-artifacts/ui.png)\n"
+        )
+        self.assertEqual(
+            pr_publish.extract_change_summary_section(text), "Added a stale-save override dialog."
+        )
+
+    def test_keeps_nested_subsections(self):
+        text = "## Change Summary\n\nTop level.\n\n### Store\n\nStore detail.\n\n## Task\n\nsecret"
+        section = pr_publish.extract_change_summary_section(text)
+        self.assertIn("### Store", section)
+        self.assertIn("Store detail.", section)
+        self.assertNotIn("secret", section)
+
+    def test_last_section_wins(self):
+        text = "## Change Summary\n\nFirst draft.\n\n# Redo\n\n## Change Summary\n\nFinal wording."
+        self.assertEqual(pr_publish.extract_change_summary_section(text), "Final wording.")
+
+    def test_absent_section_returns_empty(self):
+        self.assertEqual(pr_publish.extract_change_summary_section("Just prose."), "")

--- a/backend/tests/test_opencode_runner_service.py
+++ b/backend/tests/test_opencode_runner_service.py
@@ -183,6 +183,7 @@ class TestOpenCodePrMetadataNormalization(unittest.TestCase):
         result = OpenCodeRunResult(
             summary="Implemented the mobile drawer fix.", pull_request_title=""
         )
+        result.publish_summary = self.svc._publishable_summary(result)
         title = self.svc._ensure_meaningful_pr_title(result)
         self.assertEqual(title, "Implemented the mobile drawer fix.")
 
@@ -200,6 +201,7 @@ class TestOpenCodePrMetadataNormalization(unittest.TestCase):
 
     def test_ensure_pr_body_wraps_summary_in_change_summary_section(self):
         result = OpenCodeRunResult(summary="Reordered the mobile header actions.")
+        result.publish_summary = self.svc._publishable_summary(result)
         body = self.svc._ensure_pr_body(result)
         self.assertEqual(body, "## Change Summary\n\nReordered the mobile header actions.")
 
@@ -344,3 +346,58 @@ class TestOpenCodePushBranch(unittest.TestCase):
             ],
         )
         self.assertEqual(commands[2], ["git", "push", "-u", "origin", "opencode/run"])
+
+
+class TestOpenCodeNarrationIsNotPublished(unittest.TestCase):
+    """Regression for PR #397: mid-run narration became the PR title and description."""
+
+    def setUp(self):
+        self.svc = OpenCodeRunnerService(workspace_root="/tmp/heym-oc-ws")
+
+    @staticmethod
+    def _stream(*texts: str) -> str:
+        return "\n".join(json.dumps({"role": "assistant", "text": text}) for text in texts)
+
+    def test_change_summary_section_wins_over_later_narration(self):
+        stdout = self._stream(
+            "Reading the workflow store.",
+            "## Change Summary\n\nAdd a stale-save override dialog.\n\nPR_TITLE: Add stale-save"
+            " override dialog",
+            "Both pass. Let me do a final review of the complete changes:",
+        )
+        result = self.svc.parse_events(stdout)
+        self.assertEqual(result.summary, "Add a stale-save override dialog.")
+        self.assertEqual(result.pull_request_title, "Add stale-save override dialog")
+
+    def test_narration_only_run_falls_back_to_the_changed_file_list(self):
+        stdout = self._stream("Both pass. Let me do a final review of the complete changes:")
+        result = self.svc.parse_events(stdout)
+        result.changed_files = ["frontend/src/stores/workflow.ts", "frontend/src/views/Editor.vue"]
+
+        self.svc._normalize_pr_metadata(result, "add an override dialog for stale saves")
+
+        self.assertEqual(result.pull_request_title, "Apply OpenCode changes")
+        self.assertNotIn("Let me do a final review", result.pull_request_body)
+        self.assertIn("`frontend/src/stores/workflow.ts`", result.pull_request_body)
+        # The raw message stays on the node output so the run is still debuggable in Heym.
+        self.assertIn("Let me do a final review", result.summary)
+        self.assertEqual(result.publish_summary, "")
+
+    def test_narration_never_reaches_the_commit_message(self):
+        result = OpenCodeRunResult(
+            summary="Both pass. Let me do a final review of the complete changes:",
+            changed_files=["a.ts"],
+        )
+        self.svc._normalize_pr_metadata(result, "")
+        self.svc._run_command = MagicMock()  # type: ignore[method-assign]
+
+        self.svc._commit_changes(Path("/tmp/ws"), "opencode/run", result, new_branch=True)
+
+        commit_cmd = self.svc._run_command.call_args_list[-1].args[0]
+        self.assertIn("Apply OpenCode changes", commit_cmd)
+        self.assertNotIn("Both pass. Let me do a final review of the complete changes:", commit_cmd)
+
+    def test_changed_file_list_is_capped(self):
+        result = OpenCodeRunResult(summary="", changed_files=[f"file{i}.ts" for i in range(25)])
+        self.svc._normalize_pr_metadata(result, "")
+        self.assertIn("…and 5 more file(s)", result.pull_request_body)

--- a/backend/tests/test_workflow_stale_update_conflict.py
+++ b/backend/tests/test_workflow_stale_update_conflict.py
@@ -1,0 +1,64 @@
+"""Optimistic concurrency on workflow updates (`base_updated_at` -> 409)."""
+
+import unittest
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from fastapi import HTTPException
+
+from app.api.workflows import _reject_stale_update
+
+
+def _workflow(updated_at: datetime | None) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), updated_at=updated_at)
+
+
+class RejectStaleUpdateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stored_at = datetime(2026, 7, 22, 8, 30, tzinfo=timezone.utc)
+
+    def test_no_base_revision_is_an_explicit_override(self) -> None:
+        # The "Override" button omits the base so the write always lands.
+        _reject_stale_update(_workflow(self.stored_at), None)
+
+    def test_same_revision_is_accepted(self) -> None:
+        _reject_stale_update(_workflow(self.stored_at), self.stored_at)
+
+    def test_newer_base_revision_is_accepted(self) -> None:
+        # This tab wrote after it loaded, so its base is ahead of nothing stored newer.
+        _reject_stale_update(_workflow(self.stored_at), self.stored_at + timedelta(seconds=5))
+
+    def test_stale_base_revision_is_rejected_with_the_server_revision(self) -> None:
+        with self.assertRaises(HTTPException) as ctx:
+            _reject_stale_update(_workflow(self.stored_at), self.stored_at - timedelta(seconds=1))
+
+        self.assertEqual(ctx.exception.status_code, 409)
+        self.assertEqual(ctx.exception.detail["updated_at"], self.stored_at.isoformat())
+
+    def test_naive_stored_timestamp_is_compared_as_utc(self) -> None:
+        # SQLite/older rows can hand back naive datetimes; comparing them must not raise.
+        naive = self.stored_at.replace(tzinfo=None)
+        with self.assertRaises(HTTPException):
+            _reject_stale_update(_workflow(naive), self.stored_at - timedelta(seconds=1))
+        _reject_stale_update(_workflow(naive), self.stored_at)
+
+    def test_missing_stored_timestamp_is_not_a_conflict(self) -> None:
+        _reject_stale_update(_workflow(None), self.stored_at)
+
+
+class WorkflowUpdateSchemaTests(unittest.TestCase):
+    def test_base_updated_at_defaults_to_none(self) -> None:
+        from app.models.schemas import WorkflowUpdate
+
+        self.assertIsNone(WorkflowUpdate().base_updated_at)
+
+    def test_base_updated_at_parses_an_iso_string(self) -> None:
+        from app.models.schemas import WorkflowUpdate
+
+        payload = WorkflowUpdate(base_updated_at="2026-07-22T08:30:00+00:00")
+        self.assertEqual(payload.base_updated_at, datetime(2026, 7, 22, 8, 30, tzinfo=timezone.utc))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/e2e/execution-deep-link.spec.ts
+++ b/frontend/e2e/execution-deep-link.spec.ts
@@ -167,7 +167,8 @@ test("opens one running execution live from both history dialogs", async ({ page
       }),
       workflowNode("wait_live", "wait", 340, 160, {
         label: "waitLive",
-        duration: 6_000,
+        // Long enough for both history dialogs under CI (3 Playwright workers share the runner).
+        duration: 18_000,
       }),
       workflowNode("set_live", "set", 600, 160, {
         label: "setLive",
@@ -193,7 +194,9 @@ test("opens one running execution live from both history dialogs", async ({ page
   let executionId = "";
   const allHistoryPage = await page.context().newPage();
   try {
-    await page.goto(`/workflows/${workflow.id}`);
+    // Warm the second page before the run starts so opening All History does not burn the
+    // wait window (CI with parallel workers can make a cold dashboard load exceed 6s).
+    await Promise.all([page.goto(`/workflows/${workflow.id}`), allHistoryPage.goto("/")]);
     await expect(page.locator(".vue-flow__node")).toHaveCount(5);
     await page.evaluate((workflowId) => {
       void fetch(`/api/workflows/${workflowId}/execute?trigger_source=E2E`, {
@@ -229,7 +232,6 @@ test("opens one running execution live from both history dialogs", async ({ page
     await expect(page.getByPlaceholder("Enter text...")).toHaveValue("live input payload");
     await expect(page.getByTestId("debug-node-result-input_live")).toContainText("inputLive");
 
-    await allHistoryPage.goto("/");
     await allHistoryPage.getByRole("button", { name: "History", exact: true }).click();
     await expect(
       allHistoryPage.getByRole("heading", { name: "All Execution History" }),
@@ -245,7 +247,7 @@ test("opens one running execution live from both history dialogs", async ({ page
 
     await expect(page.locator('[data-id="wait_live_two"] .node-base')).toHaveClass(
       /animate-heartbeat/,
-      { timeout: 10_000 },
+      { timeout: 25_000 },
     );
     await expect(page.getByTestId("debug-node-result-wait_live_two")).toContainText(
       "waitLiveTwo",

--- a/frontend/e2e/workflow-stale-save.spec.ts
+++ b/frontend/e2e/workflow-stale-save.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+import { createWorkflow, deleteWorkflow } from "./support";
+
+/** Simulate a second tab / another user saving the workflow. */
+async function saveFromElsewhere(page: import("@playwright/test").Page, id: string): Promise<void> {
+  const response = await page.request.put(`/api/workflows/${id}`, {
+    data: {
+      nodes: [
+        {
+          id: "other-tab-node",
+          type: "consoleLog",
+          position: { x: 500, y: 300 },
+          data: { label: "fromOtherTab", message: "hello" },
+        },
+      ],
+      edges: [],
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+}
+
+test("clean tab: Run on a workflow changed elsewhere asks to reload", async ({ page }) => {
+  const workflow = await createWorkflow(page, `Stale Clean ${Date.now()}`);
+  try {
+    await page.goto(`/workflows/${workflow.id}`);
+    await page.getByTestId("node-palette-consoleLog").dblclick();
+    await expect(page.locator(".vue-flow__node")).toHaveCount(1);
+    await page.getByTestId("save-workflow-button").click();
+    await expect(page.getByTestId("save-workflow-button")).toBeDisabled();
+
+    // Tab A is now clean and in sync. Another tab saves.
+    await saveFromElsewhere(page, workflow.id);
+
+    await page.getByRole("button", { name: "Run Workflow" }).click();
+
+    await expect(page.getByText("Workflow Changed Elsewhere")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Reload and Run" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Reload and Run" }).click();
+    // The canvas now shows the other tab's node, and the run proceeds.
+    await expect(page.getByText("Last Executed Node")).toBeVisible();
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});
+
+test("dirty tab: Run on a workflow changed elsewhere asks before overwriting", async ({ page }) => {
+  const workflow = await createWorkflow(page, `Stale Dirty ${Date.now()}`);
+  try {
+    await page.goto(`/workflows/${workflow.id}`);
+    await page.getByTestId("node-palette-consoleLog").dblclick();
+    await expect(page.locator(".vue-flow__node")).toHaveCount(1);
+
+    // Unsaved local edits here, and another tab saves in the meantime.
+    await saveFromElsewhere(page, workflow.id);
+
+    await page.getByRole("button", { name: "Run Workflow" }).click();
+
+    await expect(page.getByText("Stale Workflow Detected")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Override and Run" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Cancel Run" }).click();
+    // Cancelling keeps the local edits and starts no run.
+    await expect(page.locator(".vue-flow__node")).toHaveCount(1);
+    await expect(page.getByTestId("save-workflow-button")).toBeEnabled();
+    await expect(page.getByText("Last Executed Node")).toBeHidden();
+
+    // Overriding saves this tab's version and runs it.
+    await page.getByRole("button", { name: "Run Workflow" }).click();
+    await page.getByRole("button", { name: "Override and Run" }).click();
+    await expect(page.getByText("Last Executed Node")).toBeVisible();
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});
+
+test("normal Save on a workflow changed elsewhere warns", async ({ page }) => {
+  const workflow = await createWorkflow(page, `Stale Save ${Date.now()}`);
+  try {
+    await page.goto(`/workflows/${workflow.id}`);
+    await page.getByTestId("node-palette-consoleLog").dblclick();
+    await expect(page.locator(".vue-flow__node")).toHaveCount(1);
+
+    await saveFromElsewhere(page, workflow.id);
+
+    await page.getByTestId("save-workflow-button").click();
+    await expect(page.getByText("Stale Workflow Detected")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Override", exact: true })).toBeVisible();
+  } finally {
+    await deleteWorkflow(page, workflow.id);
+  }
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -23,10 +23,14 @@ if (!process.env.DATABASE_URL) {
 
 export default defineConfig({
   testDir: "./e2e",
+  // Parallelise across spec files but keep the tests inside a file sequential: several specs
+  // build up state across their own tests, while the shared E2E user makes cross-file ordering
+  // irrelevant. GitHub's public `ubuntu-latest` runner has 4 vCPUs; 3 browser workers leave room
+  // for the backend and Vite dev servers that run alongside them.
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 3 : "50%",
   outputDir: testResultsDir,
   reporter: process.env.CI
     ? [["line"], ["html", { open: "never", outputFolder: reportDir }]]

--- a/frontend/src/docs/content/nodes/codex-node.md
+++ b/frontend/src/docs/content/nodes/codex-node.md
@@ -85,7 +85,7 @@ For UI/frontend tasks, Codex should save PNG screenshots under a gitignored path
 
 Your **Task Prompt** is private input, not PR content. Only two things are published: a `## Change Summary` describing what the code change does, and a `## Screenshots` section when screenshots were captured. The PR title is derived from the change summary alone.
 
-The runner prompt states this policy, and Heym also enforces it after the run: before anything is committed or opened as a pull request, it strips prompt-echo sections (`## Task`, `## Prompt`, `## Instructions`, `## Original Request`, …) and any paragraph copied verbatim from the task prompt out of the summary, the PR body, and the commit message.
+The runner prompt states this policy, and Heym also enforces it after the run: before anything is committed or opened as a pull request, it strips prompt-echo sections (`## Task`, `## Prompt`, `## Instructions`, `## Original Request`, …) and any paragraph copied verbatim from the task prompt out of the summary, the PR body, and the commit message. Step narration such as `Both pass. Let me do a final review:` is also rejected as a PR title or commit subject.
 
 ## Follow-up Questions
 

--- a/frontend/src/docs/content/nodes/opencode-go-node.md
+++ b/frontend/src/docs/content/nodes/opencode-go-node.md
@@ -85,6 +85,8 @@ Your **Task Prompt** is private input, not PR content. Only two things are publi
 
 The runner prompt states this policy, and Heym also enforces it after the run: before anything is committed or opened as a pull request, it strips prompt-echo sections (`## Task`, `## Prompt`, `## Instructions`, `## Original Request`, …) and any paragraph copied verbatim from the task prompt out of the summary, the PR body, and the commit message.
 
+Heym reads the `## Change Summary` section out of the agent's messages rather than taking whatever it said last, because OpenCode emits a message per step and the final one is often mid-run commentary. Step narration (`Both pass. Let me do a final review:`) is also rejected as a PR title or commit subject. If the run produces no usable change summary, the pull request falls back to listing the changed files instead of publishing commentary.
+
 ## As an agent tool
 
 The OpenCode Go node can be attached to an **AI Agent** node's tool handle so the agent can delegate coding tasks. Configure the credential, GitHub credential, and repository on the node, then mark **Task Prompt** (and optionally **Repository URL**) with the agent-provided toggle so the agent supplies them at call time.

--- a/frontend/src/docs/content/tabs/workflows-tab.md
+++ b/frontend/src/docs/content/tabs/workflows-tab.md
@@ -48,6 +48,17 @@ Open a workflow in the editor and click **Share** to invite users by email or sh
 - **Edit** – Change workflow name and description from the card menu
 - **Delete** – Workflows are [scheduled for deletion](../reference/workflow-organization.md); they move to a trash area before permanent removal
 
+## Concurrent Edits
+
+Saving sends the revision your edits are based on, and the server rejects the write if the workflow changed in the meantime — for example because a teammate saved it, or you left the same workflow open in a second tab. Heym then shows a **Stale Workflow Detected** dialog with two choices:
+
+- **Cancel** – Keeps your unsaved changes in the editor so you can reload in another tab and reconcile them
+- **Override** – Saves anyway, replacing the other person's version
+
+**Running** a workflow saves it first, so it goes through the same check. If the workflow changed underneath you, the run pauses on the dialog rather than overwriting silently: **Override and Run** saves your version and starts the run, **Cancel Run** abandons both and leaves your edits untouched.
+
+The check is part of the save request itself, so it costs no extra round trip and there is no window in which a save could slip past it. Your own changes from elsewhere in the app — a rename, a settings change, a properties-panel toggle — never count as a conflict.
+
 ## Command Palette
 
 Press **Ctrl+K** (or **Cmd+K**) to open the command palette. You can:

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -379,6 +379,23 @@ export const versionApi = {
   },
 };
 
+// Newest `updated_at` this tab has itself written, per workflow id. The stale-save check compares
+// against it so a workflow the user edited from a settings dialog, the properties panel, or the
+// dashboard is not mistaken for a concurrent edit by someone else. Recorded here rather than at
+// each call site so new writers are covered without having to remember to opt in.
+const lastWrittenWorkflowRevisions = new Map<string, string>();
+
+export function lastWrittenWorkflowRevision(id: string): string | null {
+  return lastWrittenWorkflowRevisions.get(id) ?? null;
+}
+
+function noteWorkflowRevision(workflow: Workflow): Workflow {
+  if (workflow.id && workflow.updated_at) {
+    lastWrittenWorkflowRevisions.set(workflow.id, workflow.updated_at);
+  }
+  return workflow;
+}
+
 export const workflowApi = {
   list: async (): Promise<WorkflowListItem[]> => {
     const response = await api.get<WorkflowListItem[]>("/workflows");
@@ -512,7 +529,7 @@ export const workflowApi = {
     description?: string;
   }): Promise<Workflow> => {
     const response = await api.post<Workflow>("/workflows", data);
-    return response.data;
+    return noteWorkflowRevision(response.data);
   },
 
   update: async (
@@ -538,10 +555,14 @@ export const workflowApi = {
         | "minutes_saved_per_run"
         | "workflow_timeout_seconds"
       >
-    >,
+    > & {
+      // Optimistic concurrency: the revision this edit is based on. The server answers 409 when
+      // the stored workflow is newer. Omit to save unconditionally.
+      base_updated_at?: string;
+    },
   ): Promise<Workflow> => {
     const response = await api.put<Workflow>(`/workflows/${id}`, data);
-    return response.data;
+    return noteWorkflowRevision(response.data);
   },
 
   clearResponseCache: async (id: string): Promise<void> => {

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -1,12 +1,13 @@
 import { computed, ref, shallowRef } from "vue";
 import { defineStore } from "pinia";
+import axios from "axios";
 
 import { buildLegacyWebhookBody, getHistoryWebhookBody, parseWebhookJson, stringifyWebhookJson } from "@/lib/webhookBody";
 import { getLatestNodeResultForNode } from "@/lib/executionLog";
 import { getSentryOperationMetadata } from "@/lib/sentryExpressionFields";
 import { replaceNodeLabelRefs } from "@/lib/utils";
 import { normalizeWorkflowEdges } from "@/lib/workflowEdges";
-import { workflowApi } from "@/services/api";
+import { lastWrittenWorkflowRevision, workflowApi } from "@/services/api";
 import { useToast } from "@/composables/useToast";
 import type {
   AgentProgressEntry,
@@ -70,6 +71,16 @@ export const useWorkflowStore = defineStore("workflow", () => {
   const isObservingExecution = ref(false);
   const isSaving = ref(false);
   const hasUnsavedChanges = ref(false);
+  const workflowLoadedAt = ref<string | null>(null);
+  const staleSaveDialogOpen = ref(false);
+  const staleSaveServerUpdatedAt = ref<string | null>(null);
+  // A run that hit a stale-save conflict and is waiting on the dialog. Wrapped in an object so a
+  // legitimately undefined body is still distinguishable from "no run pending".
+  const pendingStaleSaveRun = ref<{ body: unknown } | null>(null);
+  const staleSaveBlockedARun = computed(() => pendingStaleSaveRun.value !== null);
+  // "overwrite": this tab has edits that would replace the newer server version.
+  // "reload": this tab has no edits, so it is simply showing an outdated workflow.
+  const staleSaveMode = ref<"overwrite" | "reload">("overwrite");
   const runningNodeId = ref<string | null>(null);
   const propertiesPanelOpen = ref(false);
   const propertiesPanelVisible = ref(false);
@@ -584,6 +595,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     currentWorkflow.value = { ...workflow, nodes: loadedNodes, edges: loadedEdges };
     nodes.value = loadedNodes;
     edges.value = loadedEdges;
+    workflowLoadedAt.value = workflow.updated_at;
     void refreshAnalysisNoteEmpty();
     hasUnsavedChanges.value = false;
     timelinePickedNodeResultIndex.value = null;
@@ -619,18 +631,115 @@ export const useWorkflowStore = defineStore("workflow", () => {
     historyIndex.value = 0;
   }
 
-  async function saveWorkflow(): Promise<void> {
-    if (!currentWorkflow.value) return;
+  function revisionTime(value: string | null): number {
+    if (!value) return 0;
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  /**
+   * Newest revision this tab knows it produced: the loaded one, or any later write of its own
+   * (a rename, a settings change, the properties panel — see `lastWrittenWorkflowRevision`).
+   */
+  function knownWorkflowRevision(id: string): string | null {
+    const loaded = workflowLoadedAt.value;
+    const written = lastWrittenWorkflowRevision(id);
+    if (!loaded) return written;
+    if (!written) return loaded;
+    return revisionTime(written) >= revisionTime(loaded) ? written : loaded;
+  }
+
+  /** Returns false when a concurrent edit blocked the save and the dialog was opened. */
+  async function saveWorkflow(): Promise<boolean> {
+    const wf = currentWorkflow.value;
+    if (!wf) return false;
+    return _executeSave(knownWorkflowRevision(wf.id));
+  }
+
+  /**
+   * Send the save. Passing `baseUpdatedAt` asks the server to reject the write when someone else
+   * has changed the workflow since; the check rides along with the write so a save is never lost
+   * to an extra round trip, and there is no window between checking and saving.
+   */
+  async function _executeSave(baseUpdatedAt: string | null = null): Promise<boolean> {
+    const wf = currentWorkflow.value;
+    if (!wf) return false;
 
     isSaving.value = true;
     try {
-      await workflowApi.update(currentWorkflow.value.id, {
+      const updated = await workflowApi.update(wf.id, {
         nodes: nodes.value,
         edges: edges.value,
+        ...(baseUpdatedAt ? { base_updated_at: baseUpdatedAt } : {}),
       });
+      workflowLoadedAt.value = updated.updated_at;
       hasUnsavedChanges.value = false;
+      return true;
+    } catch (error: unknown) {
+      if (!isStaleSaveConflict(error)) throw error;
+      // Keep hasUnsavedChanges true: the edits are still only in this tab.
+      staleSaveMode.value = "overwrite";
+      staleSaveServerUpdatedAt.value = conflictUpdatedAt(error);
+      staleSaveDialogOpen.value = true;
+      return false;
     } finally {
       isSaving.value = false;
+    }
+  }
+
+  function isStaleSaveConflict(error: unknown): boolean {
+    return axios.isAxiosError(error) && error.response?.status === 409;
+  }
+
+  function conflictUpdatedAt(error: unknown): string | null {
+    if (!axios.isAxiosError(error)) return null;
+    const detail = error.response?.data?.detail as { updated_at?: string } | undefined;
+    return detail?.updated_at ?? null;
+  }
+
+  /** Save regardless of the conflict, then resume the run that was waiting on it, if any. */
+  async function forceSaveWorkflow(): Promise<void> {
+    staleSaveDialogOpen.value = false;
+    staleSaveServerUpdatedAt.value = null;
+    const pendingRun = pendingStaleSaveRun.value;
+    pendingStaleSaveRun.value = null;
+    const saved = await _executeSave();
+    if (saved && pendingRun) await executeWorkflow(pendingRun.body);
+  }
+
+  /** Dismiss the conflict, keeping the local edits — and abandon any run that was waiting. */
+  function cancelStaleSave(): void {
+    staleSaveDialogOpen.value = false;
+    staleSaveServerUpdatedAt.value = null;
+    pendingStaleSaveRun.value = null;
+  }
+
+  /** Pull the newer server version into this tab, then resume the run that was waiting. */
+  async function reloadStaleWorkflowAndRun(): Promise<void> {
+    staleSaveDialogOpen.value = false;
+    staleSaveServerUpdatedAt.value = null;
+    const pendingRun = pendingStaleSaveRun.value;
+    pendingStaleSaveRun.value = null;
+    const wf = currentWorkflow.value;
+    if (!wf) return;
+    await loadWorkflow(wf.id);
+    if (pendingRun) await executeWorkflow(pendingRun.body);
+  }
+
+  /**
+   * Server `updated_at` when another tab or user has saved since this tab last loaded or wrote,
+   * else null. Only used on the run path when there is nothing to save — with no write to race,
+   * the extra request cannot cost anyone their work.
+   */
+  async function outOfDateServerRevision(id: string): Promise<string | null> {
+    try {
+      const fresh = await workflowApi.get(id);
+      const known = knownWorkflowRevision(id);
+      if (!known) return null;
+      return revisionTime(fresh.updated_at) > revisionTime(known) ? fresh.updated_at : null;
+    } catch {
+      // A failed check must never block a run.
+      return null;
     }
   }
 
@@ -1210,6 +1319,30 @@ export const useWorkflowStore = defineStore("workflow", () => {
     const wf = currentWorkflow.value;
     if (!wf) return;
 
+    // Check freshness before touching any execution state, so cancelling leaves the editor
+    // exactly as it was. The dialog resumes the run through `forceSaveWorkflow` /
+    // `reloadStaleWorkflowAndRun`, or drops it through `cancelStaleSave`.
+    //
+    // The two stale cases need different remedies. With local edits, the run would save over the
+    // newer version, so the user is asked to confirm the overwrite. Without them there is nothing
+    // to overwrite, but the execution request carries only inputs — the backend runs the *stored*
+    // workflow — so the run would silently execute a definition this tab is not showing.
+    if (hasUnsavedChanges.value) {
+      if (!(await saveWorkflow())) {
+        pendingStaleSaveRun.value = { body };
+        return;
+      }
+    } else {
+      const serverUpdatedAt = await outOfDateServerRevision(wf.id);
+      if (serverUpdatedAt) {
+        staleSaveMode.value = "reload";
+        staleSaveServerUpdatedAt.value = serverUpdatedAt;
+        staleSaveDialogOpen.value = true;
+        pendingStaleSaveRun.value = { body };
+        return;
+      }
+    }
+
     isExecuting.value = true;
     currentExecutionWorkflowId.value = wf.id;
     executionResult.value = null;
@@ -1225,10 +1358,6 @@ export const useWorkflowStore = defineStore("workflow", () => {
     currentExecutionId.value = null;
 
     try {
-      if (hasUnsavedChanges.value) {
-        await saveWorkflow();
-      }
-
       nodes.value.forEach((node) => {
         setNodeStatus(node.id, "pending");
       });
@@ -1658,6 +1787,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
       currentExecutionWorkflowId.value = null;
     }
     hasUnsavedChanges.value = false;
+    workflowLoadedAt.value = null;
+    staleSaveDialogOpen.value = false;
+    staleSaveServerUpdatedAt.value = null;
+    pendingStaleSaveRun.value = null;
   }
 
   function clearExecution(): void {
@@ -3206,6 +3339,14 @@ export const useWorkflowStore = defineStore("workflow", () => {
     canRedo,
     loadWorkflow,
     saveWorkflow,
+    forceSaveWorkflow,
+    cancelStaleSave,
+    workflowLoadedAt,
+    staleSaveDialogOpen,
+    staleSaveServerUpdatedAt,
+    staleSaveBlockedARun,
+    staleSaveMode,
+    reloadStaleWorkflowAndRun,
     updateMetadata,
     addNode,
     updateNode,

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -270,6 +270,38 @@ function toggleRightPanel(): void {
 }
 
 const { analysisPanelOpen } = storeToRefs(workflowStore);
+const { staleSaveDialogOpen, staleSaveBlockedARun, staleSaveMode } =
+  storeToRefs(workflowStore);
+
+// Two conflicts, two remedies: this tab's edits would replace a newer version ("overwrite"), or
+// this tab has no edits and is simply showing an outdated workflow ("reload").
+const staleSaveDialogTitle = computed(() =>
+  staleSaveMode.value === "reload"
+    ? "Workflow Changed Elsewhere"
+    : "Stale Workflow Detected",
+);
+
+const staleSaveDialogMessage = computed(() => {
+  if (staleSaveMode.value === "reload") {
+    return "This workflow was saved elsewhere, so this tab is showing an older version. Running it now would execute the newer saved version instead of what you see here.";
+  }
+  return staleSaveBlockedARun.value
+    ? "A newer version of this workflow has been saved since you opened it. Running will overwrite it with your version. Continue?"
+    : "A newer version of this workflow has been saved since you opened it. Do you want to overwrite it?";
+});
+
+const staleSaveConfirmLabel = computed(() => {
+  if (staleSaveMode.value === "reload") return "Reload and Run";
+  return staleSaveBlockedARun.value ? "Override and Run" : "Override";
+});
+
+async function onConfirmStaleSave(): Promise<void> {
+  if (staleSaveMode.value === "reload") {
+    await workflowStore.reloadStaleWorkflowAndRun();
+    return;
+  }
+  await workflowStore.forceSaveWorkflow();
+}
 
 const analysisWorkflowId = computed(() => workflowStore.currentWorkflow?.id ?? "");
 const analysisWorkflowPayload = computed(() => ({
@@ -2309,6 +2341,44 @@ function onDocSelectFromPalette(categoryId: string, slug: string, event?: MouseE
               >
                 Close
               </Button>
+            </div>
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <Teleport to="body">
+      <Transition name="fade">
+        <div
+          v-if="staleSaveDialogOpen"
+          class="fixed inset-0 z-50 flex items-center justify-center"
+        >
+          <div
+            class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            @click="workflowStore.cancelStaleSave()"
+          />
+          <div class="relative bg-card border rounded-lg shadow-xl w-[90vw] max-w-[440px]">
+            <div class="p-6">
+              <h3 class="font-semibold text-base mb-2">
+                {{ staleSaveDialogTitle }}
+              </h3>
+              <p class="text-sm text-muted-foreground mb-6">
+                {{ staleSaveDialogMessage }}
+              </p>
+              <div class="flex justify-end gap-3">
+                <Button
+                  variant="outline"
+                  @click="workflowStore.cancelStaleSave()"
+                >
+                  {{ staleSaveBlockedARun ? "Cancel Run" : "Cancel" }}
+                </Button>
+                <Button
+                  variant="gradient"
+                  @click="onConfirmStaleSave()"
+                >
+                  {{ staleSaveConfirmLabel }}
+                </Button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
* Implement optimistic concurrency control for workflow updates

Added a mechanism to reject updates to workflows if the base revision is older than the stored version, preventing potential data loss from concurrent edits. Introduced a new `base_updated_at` field in the `WorkflowUpdate` schema to facilitate this check. Updated the `update_workflow` endpoint to utilize this new logic, ensuring that clients are informed of conflicts with a 409 status code when necessary. Additionally, refactored related functions to handle UTC timestamps for accurate comparisons.