### PR TITLE
Add haptic vibration feedback when mic activates in voice mode

### DIFF
--- a/frontend/src/composables/useInteractiveVoice.ts
+++ b/frontend/src/composables/useInteractiveVoice.ts
@@ -1,6 +1,7 @@
 import { ref, type Ref } from "vue";
 
 import { voiceApi } from "@/services/api";
+import { vibrate } from "@/utils/audio";
 
 export type VoiceState = "idle" | "listening" | "transcribing" | "thinking" | "speaking";
 
@@ -158,6 +159,7 @@ export function useInteractiveVoice(onUtterance: (text: string) => void): UseInt
   function listen(): void {
     if (muted.value) return;
     setState("listening");
+    vibrate(50);
     beginRecording();
     monitor();
   }

--- a/frontend/src/utils/audio.ts
+++ b/frontend/src/utils/audio.ts
@@ -1,3 +1,9 @@
+export function vibrate(pattern: number | number[] = 50): void {
+  if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
+    navigator.vibrate(pattern);
+  }
+}
+
 export function playSuccessSound(): void {
   const audioContext = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
 


### PR DESCRIPTION
## Change Summary

Added `vibrate()` utility to `frontend/src/utils/audio.ts` wrapping `navigator.vibrate()` with a feature guard. Called `vibrate(50)` inside `listen()` in `useInteractiveVoice.ts` — the single entry point for all listening-mode transitions (start, barge-in, unmute, transcription retry) — so users get a short 50ms haptic pulse on every microphone activation during live voice streaming.