### PR TITLE
Fix coding-agent PR screenshots + reliable open/update PR

### DIFF
--- a/backend/app/services/codex_runner_service.py
+++ b/backend/app/services/codex_runner_service.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import subprocess
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -47,12 +47,24 @@ CODEX_PUBLISH_MODES: frozenset[str] = frozenset(
         "commit_push",
         "direct_commit",
         "update_existing_pr",
+        "open_or_update_pr",
         "patch_artifact",
     }
 )
 _CODEX_REMOTE_PUBLISH_MODES: frozenset[str] = frozenset(
-    {"draft_pr", "open_pr", "commit_push", "direct_commit", "update_existing_pr"}
+    {
+        "draft_pr",
+        "open_pr",
+        "commit_push",
+        "direct_commit",
+        "update_existing_pr",
+        "open_or_update_pr",
+    }
 )
+# Modes that update the agent's existing open PR when one exists, else open a new one.
+# ``open_or_update_pr`` is the intuitive single mode for re-runs; ``update_existing_pr`` is kept
+# for back-compat and behaves identically.
+_CODEX_OPEN_OR_UPDATE_MODES: frozenset[str] = frozenset({"update_existing_pr", "open_or_update_pr"})
 
 # Codex must only edit files on disk; Heym owns all git/GitHub operations. Codex's own GitHub
 # tools/API are network calls that the sandbox blocks, which otherwise makes Codex loop on
@@ -68,7 +80,10 @@ _CODEX_LOCAL_ONLY_RULES = (
     "dependencies are missing, you MAY run a package install (for example `bun install`, "
     "`npm install`, or `pnpm install`) and start a short-lived preview/dev server solely to "
     "capture the screenshot, then stop the server. Heym uploads those images onto the pull "
-    "request after you finish (do not commit screenshot binaries into source)."
+    "request after you finish (do not commit screenshot binaries into source). Capture "
+    "screenshots BEFORE you return your final result — never end a turn by announcing a pending "
+    "step such as 'Now let me take a screenshot'; perform that step first, then return "
+    "`status: completed`."
 )
 
 _PR_SCREENSHOT_RELEASE_TAG = "codex-pr-assets"
@@ -299,6 +314,9 @@ class CodexRunnerService:
         self.parser = CodexJsonlParser()
 
     def run_task(self, request: CodexRunRequest) -> CodexRunResult:
+        # Resolve the real head branch of the agent's open PR for update_existing_pr, so a
+        # per-run/LLM-generated branch name still updates that PR instead of opening a new one.
+        request = self._resolve_update_existing_pr_request(request)
         workspace = self._prepare_workspace(request)
         self._authenticate(
             workspace, request.codex_auth, request.codex_access_token, request.timeout_seconds
@@ -350,12 +368,30 @@ class CodexRunnerService:
         )
         return self._finalize_result(result, workspace, run_request)
 
+    def _resolve_update_existing_pr_request(self, request: CodexRunRequest) -> CodexRunRequest:
+        """For update/open-or-update modes, swap in the head branch of the agent's open PR."""
+        if request.publish_mode not in _CODEX_OPEN_OR_UPDATE_MODES:
+            return request
+        owner, repo = self._parse_github_owner_repo(request.repository_url)
+        gh = GitHubService(request.github_config)
+        try:
+            branch = pr_publish.resolve_update_existing_pr_branch(
+                gh,
+                owner,
+                repo,
+                base_branch=request.base_branch,
+                configured_branch=request.branch_name,
+            )
+        finally:
+            gh.close()
+        return request if branch == request.branch_name else replace(request, branch_name=branch)
+
     def _prepare_workspace(self, request: CodexRunRequest) -> Path:
         self.workspace_root.mkdir(parents=True, exist_ok=True)
         workspace = (self.workspace_root / str(uuid.uuid4())).resolve()
-        # ``update_existing_pr`` clones the existing PR branch so Codex works on top of it; if that
-        # branch does not exist yet it falls back to the base branch and creates it.
-        if request.publish_mode == "update_existing_pr":
+        # update/open-or-update modes clone the existing PR branch so Codex works on top of it; if
+        # that branch does not exist yet it falls back to the base branch and creates it.
+        if request.publish_mode in _CODEX_OPEN_OR_UPDATE_MODES:
             try:
                 self._clone_branch(workspace, request, request.branch_name)
                 self._exclude_runner_files(workspace)
@@ -584,8 +620,62 @@ class CodexRunnerService:
         result.changed_files = self._changed_files(workspace)
         self._prepare_publishable_text(result, request.task_prompt)
         if result.status == "completed" and request.publish_mode in _CODEX_REMOTE_PUBLISH_MODES:
+            # Finish a run that stopped mid-task (e.g. announced a screenshot but never took it)
+            # before publishing, so the screenshot and a real summary reach the pull request.
+            self._finish_incomplete_run(workspace, request, result)
             self._publish(workspace, request, result)
         return result
+
+    def _finish_incomplete_run(
+        self,
+        workspace: Path,
+        request: CodexRunRequest,
+        result: CodexRunResult,
+    ) -> None:
+        """Run one more Codex exec when the first ended before finishing the task.
+
+        The follow-up resumes in the same workspace (in-progress edits are already on disk); it
+        only captures any promised screenshot and returns a real report. Best-effort: a failure
+        never breaks the primary run. When a UI change still lacks a screenshot afterwards, a
+        visible note is added so the gap is never silent.
+        """
+        try:
+            has_screenshots = bool(self._discover_pr_screenshots(workspace))
+            if pr_publish.needs_finishing_pass(
+                will_publish=True,
+                changed_files=result.changed_files,
+                publish_summary=result.publish_summary,
+                ui_change=pr_publish.changed_files_touch_ui(result.changed_files),
+                has_screenshots=has_screenshots,
+            ):
+                finished = self._run_codex_exec(
+                    workspace=workspace,
+                    prompt=self._build_finishing_prompt(),
+                    timeout_seconds=request.timeout_seconds,
+                    resume_thread_id=result.thread_id,
+                    codex_access_token=self._exec_token(
+                        request.codex_auth, request.codex_access_token
+                    ),
+                    model=request.model,
+                    reasoning_effort=request.reasoning_effort,
+                )
+                if finished.summary:
+                    result.summary = finished.summary
+                if finished.pull_request_title:
+                    result.pull_request_title = finished.pull_request_title
+                if finished.pull_request_body:
+                    result.pull_request_body = finished.pull_request_body
+                result.diff = self._git_output(["git", "diff", "--binary"], workspace)
+                result.changed_files = self._changed_files(workspace)
+                self._prepare_publishable_text(result, request.task_prompt)
+        except Exception:  # noqa: BLE001 - a finishing pass must never fail the primary run
+            pass
+        if pr_publish.changed_files_touch_ui(
+            result.changed_files
+        ) and not self._discover_pr_screenshots(workspace):
+            result.pull_request_body = pr_publish.note_missing_ui_screenshot(
+                result.pull_request_body
+            )
 
     def _publish(
         self,
@@ -603,7 +693,7 @@ class CodexRunnerService:
             self._push_branch(workspace, request, request.base_branch)
             result.pushed_branch = request.base_branch
             return
-        if mode == "update_existing_pr":
+        if mode in _CODEX_OPEN_OR_UPDATE_MODES:
             on_existing = self._current_branch(workspace) == request.branch_name
             self._commit_changes(workspace, request.branch_name, result, new_branch=not on_existing)
             self._push_branch(workspace, request, request.branch_name)
@@ -611,9 +701,9 @@ class CodexRunnerService:
             existing_url = self._open_pr_url_for_head(request, request.branch_name)
             if existing_url:
                 result.pull_request_url = existing_url
-                pr_number = self._pr_number_from_url(existing_url)
-                if pr_number is not None:
-                    self._attach_pr_screenshots(workspace, request, result, pr_number)
+                self._update_pr_body_with_screenshots(
+                    workspace, request, result, request.branch_name, existing_url
+                )
             else:
                 result.pull_request_url = self._create_pr(
                     workspace, request, result, request.branch_name, draft=False
@@ -714,12 +804,8 @@ class CodexRunnerService:
         draft: bool,
     ) -> str | None:
         owner, repo = self._parse_github_owner_repo(request.repository_url)
-        pr_body = (
-            str(result.pull_request_body or "").strip()
-            or result.publish_summary
-            or pr_publish.changed_files_body(result.changed_files, agent="Codex")
-            or None
-        )
+        # Embed screenshots BEFORE creating the PR so it opens already containing them.
+        pr_body = self._screenshot_body(workspace, request, result, head) or None
         gh = GitHubService(request.github_config)
         try:
             pr = gh.create_pull_request(
@@ -733,11 +819,7 @@ class CodexRunnerService:
             )
         finally:
             gh.close()
-        url = str(pr.get("html_url") or "").strip() or None
-        pr_number = pr.get("number")
-        if url and isinstance(pr_number, int):
-            self._attach_pr_screenshots(workspace, request, result, pr_number)
-        return url
+        return str(pr.get("html_url") or "").strip() or None
 
     def _open_pr_url_for_head(self, request: CodexRunRequest, head: str) -> str | None:
         owner, repo = self._parse_github_owner_repo(request.repository_url)
@@ -755,45 +837,77 @@ class CodexRunnerService:
         """Find local UI screenshots that Codex left on disk (gitignored / untracked only)."""
         return pr_publish.discover_pr_screenshots(workspace, self._git_output)
 
-    def _attach_pr_screenshots(
+    def _screenshot_body(
         self,
         workspace: Path,
         request: CodexRunRequest,
         result: CodexRunResult,
-        pr_number: int,
-    ) -> None:
-        """Upload discovered screenshots as a GitHub release asset set and embed them in the PR."""
+        head: str,
+    ) -> str:
+        """Return the PR body with any UI screenshots uploaded and embedded.
+
+        Uploads discovered screenshots as release assets (keyed on the branch, so this can run
+        before the PR exists) and injects a ``## Screenshots`` section. Best-effort: on any failure
+        the plain body is returned. Also updates ``result.pull_request_body``.
+        """
+        base_body = (
+            str(result.pull_request_body or "").strip()
+            or result.publish_summary
+            or pr_publish.changed_files_body(result.changed_files, agent="Codex")
+        )
         try:
             screenshots = self._discover_pr_screenshots(workspace)
-            if not screenshots:
-                return
+            if screenshots:
+                owner, repo = self._parse_github_owner_repo(request.repository_url)
+                gh = GitHubService(request.github_config)
+                try:
+                    injected = pr_publish.upload_and_inject_screenshots(
+                        gh,
+                        screenshots=screenshots,
+                        owner=owner,
+                        repo=repo,
+                        base_branch=request.base_branch,
+                        asset_slug=head,
+                        base_body=base_body,
+                        release_tag=_PR_SCREENSHOT_RELEASE_TAG,
+                        release_name="Codex PR screenshots",
+                        release_body=(
+                            "Shared bucket for Heym Codex UI screenshots attached to pull "
+                            "requests. Assets are named <branch>-… and are not part of source."
+                        ),
+                    )
+                finally:
+                    gh.close()
+                if injected:
+                    base_body = injected
+        except Exception:  # noqa: BLE001 - screenshot embedding is best-effort
+            pass
+        result.pull_request_body = base_body
+        return base_body
+
+    def _update_pr_body_with_screenshots(
+        self,
+        workspace: Path,
+        request: CodexRunRequest,
+        result: CodexRunResult,
+        head: str,
+        pr_url: str,
+    ) -> None:
+        """Embed screenshots and push the updated body onto an already-open PR."""
+        pr_number = self._pr_number_from_url(pr_url)
+        if pr_number is None:
+            return
+        body = self._screenshot_body(workspace, request, result, head)
+        if not body:
+            return
+        try:
             owner, repo = self._parse_github_owner_repo(request.repository_url)
             gh = GitHubService(request.github_config)
             try:
-                base_body = str(result.pull_request_body or "").strip() or result.publish_summary
-                updated_body = pr_publish.upload_and_inject_screenshots(
-                    gh,
-                    screenshots=screenshots,
-                    owner=owner,
-                    repo=repo,
-                    base_branch=request.base_branch,
-                    pr_number=pr_number,
-                    base_body=base_body,
-                    release_tag=_PR_SCREENSHOT_RELEASE_TAG,
-                    release_name="Codex PR screenshots",
-                    release_body=(
-                        "Shared bucket for Heym Codex UI screenshots attached to pull requests. "
-                        "Assets are named pr-<number>-… and are not part of source."
-                    ),
-                )
-                if not updated_body:
-                    return
-                gh.update_issue(owner, repo, pr_number, body=updated_body)
-                result.pull_request_body = updated_body
+                gh.update_issue(owner, repo, pr_number, body=body)
             finally:
                 gh.close()
-        except Exception:
-            # Screenshot attach is best-effort; never fail the Codex publish path for it.
+        except Exception:  # noqa: BLE001 - updating the body is best-effort
             return
 
     @staticmethod
@@ -801,8 +915,8 @@ class CodexRunnerService:
         return pr_publish.pr_number_from_url(url)
 
     @staticmethod
-    def _release_asset_name(path: Path, pr_number: int, index: int) -> str:
-        return pr_publish.release_asset_name(path, pr_number, index)
+    def _release_asset_name(path: Path, slug: str, index: int) -> str:
+        return pr_publish.release_asset_name(path, slug, index)
 
     @staticmethod
     def _inject_screenshot_markdown(body: str, images: list[tuple[str, str]]) -> str:
@@ -910,6 +1024,18 @@ class CodexRunnerService:
             "you captured any).\n"
             f"{pr_publish.PR_CONTENT_POLICY}\n\n"
             f"Task:\n{task_prompt}"
+        )
+
+    @staticmethod
+    def _build_finishing_prompt() -> str:
+        return (
+            "You are running as the Heym Codex node inside a local cloned git repository.\n"
+            f"{_CODEX_LOCAL_ONLY_RULES}\n"
+            f"{pr_publish.FINISHING_PASS_PREAMBLE}\n"
+            "Return `status: completed` with `summary`, `validation`, a concise imperative "
+            "`pull_request_title`, and `pull_request_body` set to a `## Change Summary` section "
+            "(plus `## Screenshots` when you captured any).\n"
+            f"{pr_publish.PR_CONTENT_POLICY}"
         )
 
     @staticmethod

--- a/backend/app/services/coding_agent/pr_publish.py
+++ b/backend/app/services/coding_agent/pr_publish.py
@@ -341,12 +341,167 @@ def pr_number_from_url(url: str) -> int | None:
     return int(match.group(1))
 
 
-def release_asset_name(path: Path, pr_number: int, index: int) -> str:
+def resolve_update_existing_pr_branch(
+    gh: GitHubService,
+    owner: str,
+    repo: str,
+    *,
+    base_branch: str,
+    configured_branch: str,
+) -> str:
+    """Head branch to reuse for ``update_existing_pr`` so a re-run updates the agent's existing
+    open pull request instead of opening a new one.
+
+    ``update_existing_pr`` used to trust ``configured_branch`` to already equal an open PR's head.
+    In agentic/board flows the branch name is generated per run (e.g. by an LLM planner), so it
+    never matches and every "update the open PR" run opened a *new* PR. This resolves the real
+    target:
+
+    * an open PR whose head already equals ``configured_branch`` wins (explicit targeting);
+    * otherwise the token account's most-recently-updated open PR into ``base_branch`` is adopted;
+    * otherwise ``configured_branch`` is returned unchanged (a fresh PR is created downstream).
+
+    Best-effort: any GitHub error falls back to ``configured_branch`` (never raises).
+    """
+    try:
+        pulls = gh.list_pull_requests(owner, repo, state="open", per_page=100)
+    except Exception:  # noqa: BLE001 - discovery is best-effort; fall back to the configured branch
+        return configured_branch
+
+    to_base = [pr for pr in pulls if _pr_base_ref(pr) == base_branch]
+    for pull in to_base:
+        if _pr_head_ref(pull) == configured_branch:
+            return configured_branch
+
+    author = _authenticated_login(gh)
+    if author:
+        candidates = [pull for pull in to_base if _pr_author_login(pull) == author]
+    else:
+        # Without a known author, only adopt when there is exactly one open PR into the base,
+        # so a re-run never hijacks an unrelated contributor's pull request.
+        candidates = to_base if len(to_base) == 1 else []
+    if not candidates:
+        return configured_branch
+    target = max(candidates, key=lambda pull: str(pull.get("updated_at") or ""))
+    return _pr_head_ref(target) or configured_branch
+
+
+def _pr_head_ref(pull: dict) -> str:
+    return str((pull.get("head") or {}).get("ref") or "")
+
+
+def _pr_base_ref(pull: dict) -> str:
+    return str((pull.get("base") or {}).get("ref") or "")
+
+
+def _pr_author_login(pull: dict) -> str:
+    return str((pull.get("user") or {}).get("login") or "")
+
+
+def _authenticated_login(gh: GitHubService) -> str:
+    try:
+        user = gh.get_authenticated_user()
+    except Exception:  # noqa: BLE001 - some tokens can't read /user; fall back to count-based scope
+        return ""
+    return str((user or {}).get("login") or "").strip()
+
+
+# --- finishing pass / screenshot completeness (shared) ---
+# A coding agent sometimes ends its turn mid-task (e.g. "…Now let me take a screenshot"), so the
+# run finalizes before the screenshot is captured and with only narration for a summary. When that
+# happens the runner does ONE more pass with this preamble, in the same workspace, to finish.
+FINISHING_PASS_PREAMBLE = (
+    "You ended your previous turn before finishing. The repository already contains your "
+    "in-progress changes on disk — do NOT redo or re-plan that work, and make no further code "
+    "changes except what is strictly required to capture a screenshot. Complete any step you "
+    "announced but did not perform: for a UI/frontend change, capture at least one PNG screenshot "
+    "of the result under a gitignored path such as `frontend/.e2e-artifacts/` (Heym attaches it to "
+    "the pull request; do not commit the image). Then return your final report describing what "
+    "changed. Never end by announcing a further step (for example 'Now let me take a screenshot')."
+)
+
+# Frontend/visual files a reviewer would expect a screenshot for.
+_UI_VISUAL_SUFFIXES: frozenset[str] = frozenset(
+    {".vue", ".tsx", ".jsx", ".svelte", ".css", ".scss", ".sass", ".less", ".html"}
+)
+_UI_SCRIPT_SUFFIXES: frozenset[str] = frozenset({".ts", ".js"})
+_UI_PATH_HINTS: tuple[str, ...] = (
+    "frontend/",
+    "/components/",
+    "/views/",
+    "/pages/",
+    "src/components/",
+    "src/views/",
+)
+_MISSING_SCREENSHOT_NOTE = (
+    "> ⚠️ This pull request changes UI/frontend files, but the coding agent did not "
+    "capture a screenshot. Add one manually if a visual review is needed."
+)
+
+
+def changed_files_touch_ui(changed_files: list[str]) -> bool:
+    """True when the diff touches frontend/visual files a reviewer would expect a screenshot for."""
+    for raw in changed_files or []:
+        path = str(raw or "").strip().replace("\\", "/").lower()
+        name = path.rsplit("/", 1)[-1]
+        suffix = path[path.rfind(".") :] if "." in name else ""
+        if suffix in _UI_VISUAL_SUFFIXES:
+            return True
+        if suffix in _UI_SCRIPT_SUFFIXES and any(hint in path for hint in _UI_PATH_HINTS):
+            return True
+    return False
+
+
+def needs_finishing_pass(
+    *,
+    will_publish: bool,
+    changed_files: list[str],
+    publish_summary: str,
+    ui_change: bool,
+    has_screenshots: bool,
+) -> bool:
+    """Whether to run one more agent pass before publishing.
+
+    Trigger when there is work to publish but the agent left no publishable summary (it stopped
+    mid-report), or a UI change shipped without a screenshot (it stopped before capturing one).
+    """
+    if not will_publish or not changed_files:
+        return False
+    if not str(publish_summary or "").strip():
+        return True
+    return bool(ui_change) and not bool(has_screenshots)
+
+
+def note_missing_ui_screenshot(body: str) -> str:
+    """Append a visible ``## Screenshots`` note when a UI change shipped without a screenshot.
+
+    No-op when the body already has a Screenshots section (screenshots were attached).
+    """
+    text = (body or "").strip()
+    if re.search(r"(?im)^\s*##\s+screenshots?\b", text):
+        return text + ("\n" if text else "")
+    section = f"## Screenshots\n\n{_MISSING_SCREENSHOT_NOTE}"
+    return (f"{text}\n\n{section}" if text else section) + "\n"
+
+
+def sanitize_asset_slug(head: str) -> str:
+    """Sanitize a branch/head ref into a stable release-asset prefix.
+
+    Keyed on the branch (not the PR number) so screenshots can be uploaded and embedded *before*
+    the pull request exists — the PR then opens already containing them — and so re-runs on the
+    same branch replace the same-named asset instead of piling up duplicates.
+    """
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", str(head or "")).strip("-._")
+    return slug or "pr"
+
+
+def release_asset_name(path: Path, slug: str, index: int) -> str:
     stem = re.sub(r"[^A-Za-z0-9._-]+", "-", path.stem).strip("-._") or "screenshot"
     suffix = path.suffix.lower() if path.suffix.lower() in PR_SCREENSHOT_SUFFIXES else ".png"
+    clean_slug = sanitize_asset_slug(slug)
     if index == 0:
-        return f"pr-{pr_number}-{stem}{suffix}"
-    return f"pr-{pr_number}-{stem}-{index}{suffix}"
+        return f"{clean_slug}-{stem}{suffix}"
+    return f"{clean_slug}-{stem}-{index}{suffix}"
 
 
 def inject_screenshot_markdown(body: str, images: list[tuple[str, str]]) -> str:
@@ -468,7 +623,7 @@ def upload_and_inject_screenshots(
     owner: str,
     repo: str,
     base_branch: str,
-    pr_number: int,
+    asset_slug: str,
     base_body: str,
     release_tag: str,
     release_name: str,
@@ -495,7 +650,7 @@ def upload_and_inject_screenshots(
     }
     uploaded: list[tuple[str, str]] = []
     for index, shot in enumerate(screenshots):
-        asset_name = release_asset_name(shot, pr_number, index)
+        asset_name = release_asset_name(shot, asset_slug, index)
         existing_id = existing_assets.get(asset_name)
         if existing_id is not None:
             gh.delete_release_asset(owner, repo, existing_id)

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -923,6 +923,15 @@ class GitHubService:
         response = self._request_json("GET", "/issues", params=params)
         return response if isinstance(response, list) else []
 
+    def get_authenticated_user(self) -> dict[str, Any]:
+        """Fetch the account behind the token (``GET /user``).
+
+        Used to scope ``update_existing_pr`` PR discovery to the coding agent's own open pull
+        requests so a re-run never adopts an unrelated contributor's PR.
+        """
+        response = self._request_json("GET", "/user")
+        return response if isinstance(response, dict) else {}
+
     def invite_user(self, organization: str, email: str) -> dict[str, Any]:
         """Invite a user to an organization by email."""
         response = self._request_json(

--- a/backend/app/services/node_execution/nodes/opencode_go_node.py
+++ b/backend/app/services/node_execution/nodes/opencode_go_node.py
@@ -17,6 +17,7 @@ OPENCODE_PUBLISH_MODES: frozenset[str] = frozenset(
         "commit_push",
         "direct_commit",
         "update_existing_pr",
+        "open_or_update_pr",
         "patch_artifact",
     }
 )

--- a/backend/app/services/opencode_runner_service.py
+++ b/backend/app/services/opencode_runner_service.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import subprocess
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from app.config import settings
@@ -27,8 +27,19 @@ from app.services.opencode_catalog import OPENCODE_DEFAULT_MODEL, OPENCODE_ZEN_B
 logger = logging.getLogger(__name__)
 
 _REMOTE_PUBLISH_MODES: frozenset[str] = frozenset(
-    {"draft_pr", "open_pr", "commit_push", "direct_commit", "update_existing_pr"}
+    {
+        "draft_pr",
+        "open_pr",
+        "commit_push",
+        "direct_commit",
+        "update_existing_pr",
+        "open_or_update_pr",
+    }
 )
+# Modes that update the agent's existing open PR when one exists, else open a new one.
+# ``open_or_update_pr`` is the intuitive single mode for re-runs; ``update_existing_pr`` is kept
+# for back-compat and behaves identically.
+_OPEN_OR_UPDATE_MODES: frozenset[str] = frozenset({"update_existing_pr", "open_or_update_pr"})
 _PR_SCREENSHOT_RELEASE_TAG = "opencode-pr-assets"
 
 _LOCAL_ONLY_RULES = (
@@ -42,6 +53,10 @@ _LOCAL_ONLY_RULES = (
     "and start a short-lived preview/dev server solely to capture the UI, then stop the server. "
     "Do not commit screenshot binaries into source; Heym uploads those images onto the pull "
     "request afterward. "
+    "Capture screenshots BEFORE you write your final message. Your final assistant message MUST "
+    "be the `## Change Summary` (with the `PR_TITLE:` line) — never an announcement of a pending "
+    "step such as 'Now let me take a screenshot'. If you are about to announce a next step, "
+    "perform that step first, then report. "
     "PR metadata is MANDATORY. End your final assistant message with a dedicated line "
     "`PR_TITLE: <imperative one-line change description, ideally <=72 chars>` — never use "
     "placeholders such as Done, Fixed, Update, or Completed. "
@@ -339,9 +354,12 @@ class OpenCodeRunnerService:
         home = Path(f"{workspace}.oc-home")
         home.mkdir(parents=True, exist_ok=True)
 
-        # ``update_existing_pr`` clones the existing PR branch so OpenCode works on top of it; if
-        # that branch does not exist yet it falls back to the base branch (same as Codex).
-        if request.publish_mode == "update_existing_pr":
+        # update/open-or-update modes clone the existing PR branch so OpenCode works on top of it;
+        # if that branch does not exist yet it falls back to the base branch (same as Codex).
+        if request.publish_mode in _OPEN_OR_UPDATE_MODES:
+            # Resolve the real head branch of the agent's open PR: the configured branch name is
+            # often generated per run and would otherwise never match, opening a new PR instead.
+            request = replace(request, branch_name=self._resolve_existing_pr_branch(request))
             try:
                 self._clone_branch(workspace, request, request.branch_name)
             except ValueError:
@@ -363,20 +381,94 @@ class OpenCodeRunnerService:
         # After ``changed_files``: the PR body falls back to the file list when the agent
         # never produced a publishable change summary.
         self._normalize_pr_metadata(result, request.task_prompt)
+        if request.publish_mode in _REMOTE_PUBLISH_MODES:
+            # Finish a run that stopped mid-task (e.g. announced a screenshot but never took it)
+            # so the screenshot and a real summary make it onto the pull request.
+            self._finish_incomplete_run(workspace, home, request, model, result)
         if result.status == "completed" and request.publish_mode in _REMOTE_PUBLISH_MODES:
             self._publish(workspace, request, result)
         return result
 
+    def _resolve_existing_pr_branch(self, request: OpenCodeRunRequest) -> str:
+        """Head branch of the agent's existing open PR to update, or the configured branch."""
+        owner, repo = pr_publish.parse_github_owner_repo(request.repository_url)
+        gh = GitHubService(request.github_config)
+        try:
+            return pr_publish.resolve_update_existing_pr_branch(
+                gh,
+                owner,
+                repo,
+                base_branch=request.base_branch,
+                configured_branch=request.branch_name,
+            )
+        finally:
+            gh.close()
+
+    def _finish_incomplete_run(
+        self,
+        workspace: Path,
+        home: Path,
+        request: OpenCodeRunRequest,
+        model: str,
+        result: OpenCodeRunResult,
+    ) -> None:
+        """Run one more OpenCode pass when the first ended before finishing the task.
+
+        The follow-up runs in the same workspace, so the in-progress edits are already on disk; it
+        only captures any promised screenshot and returns a real summary. Best-effort: a failure
+        never breaks the primary run. When a UI change still has no screenshot afterwards, a
+        visible note is added so the gap is never silent.
+        """
+        try:
+            has_screenshots = bool(pr_publish.discover_pr_screenshots(workspace, self._git_output))
+            if pr_publish.needs_finishing_pass(
+                will_publish=True,
+                changed_files=result.changed_files,
+                publish_summary=result.publish_summary,
+                ui_change=pr_publish.changed_files_touch_ui(result.changed_files),
+                has_screenshots=has_screenshots,
+            ):
+                prompt = f"{_LOCAL_ONLY_RULES}\n\n{pr_publish.FINISHING_PASS_PREAMBLE}"
+                stdout = self._exec_opencode(
+                    workspace, home, request, model, prompt_override=prompt
+                )
+                finished = self.parse_events(stdout)
+                if finished.summary and finished.summary != _NO_FINAL_MESSAGE_SUMMARY:
+                    result.summary = finished.summary
+                if finished.pull_request_title:
+                    result.pull_request_title = finished.pull_request_title
+                result.pull_request_body = ""  # rebuilt from the fresh summary below
+                result.diff = self._git_output(["git", "diff", "--binary"], workspace)
+                result.changed_files = self._changed_files(workspace)
+                self._normalize_pr_metadata(result, request.task_prompt)
+        except Exception:  # noqa: BLE001 - a finishing pass must never fail the primary run
+            pass
+        if pr_publish.changed_files_touch_ui(
+            result.changed_files
+        ) and not pr_publish.discover_pr_screenshots(workspace, self._git_output):
+            result.pull_request_body = pr_publish.note_missing_ui_screenshot(
+                result.pull_request_body
+            )
+
     def build_run_command(
-        self, model: str, request: OpenCodeRunRequest, workspace: Path
+        self,
+        model: str,
+        request: OpenCodeRunRequest,
+        workspace: Path,
+        *,
+        prompt: str | None = None,
     ) -> list[str]:
         """The ``<cli_command> run …`` argv (host binary locally, docker wrapper in deployments).
 
         ``--dir`` pins OpenCode to the cloned workspace. Without it OpenCode resolves its project by
         walking up from the process cwd and can edit files in an enclosing repository (e.g. Heym's
         own checkout) instead of the clone — the run then reports success with an empty diff.
+
+        ``prompt`` overrides the default task prompt (used by the finishing pass).
         """
-        prompt = f"{_LOCAL_ONLY_RULES}\n\nTask:\n{request.task_prompt}"
+        prompt = (
+            prompt if prompt is not None else f"{_LOCAL_ONLY_RULES}\n\nTask:\n{request.task_prompt}"
+        )
         cmd = [
             self.cli_command,
             "run",
@@ -400,6 +492,7 @@ class OpenCodeRunnerService:
         home: Path,
         request: OpenCodeRunRequest,
         model: str,
+        prompt_override: str | None = None,
     ) -> str:
         # HOME/XDG point at the per-run OpenCode home on the workspace volume. The docker wrapper
         # forwards these into the sibling container; locally OpenCode reads them directly.
@@ -407,7 +500,7 @@ class OpenCodeRunnerService:
         env["HOME"] = str(home)
         env["XDG_CONFIG_HOME"] = str(home / ".config")
         env["XDG_DATA_HOME"] = str(home / ".local" / "share")
-        cmd = self.build_run_command(model, request, workspace)
+        cmd = self.build_run_command(model, request, workspace, prompt=prompt_override)
         try:
             completed = subprocess.run(
                 cmd,
@@ -525,7 +618,7 @@ class OpenCodeRunnerService:
             self._push_branch(workspace, request, request.base_branch)
             result.pushed_branch = request.base_branch
             return
-        if mode == "update_existing_pr":
+        if mode in _OPEN_OR_UPDATE_MODES:
             on_existing = self._current_branch(workspace) == request.branch_name
             self._commit_changes(workspace, request.branch_name, result, new_branch=not on_existing)
             self._push_branch(workspace, request, request.branch_name)
@@ -533,9 +626,9 @@ class OpenCodeRunnerService:
             existing_url = self._open_pr_url_for_head(request, request.branch_name)
             if existing_url:
                 result.pull_request_url = existing_url
-                pr_number = pr_publish.pr_number_from_url(existing_url)
-                if pr_number is not None:
-                    self._attach_pr_screenshots(workspace, request, result, pr_number)
+                self._update_pr_body_with_screenshots(
+                    workspace, request, result, request.branch_name, existing_url
+                )
             else:
                 result.pull_request_url = self._create_pr(
                     workspace, request, result, request.branch_name, draft=False
@@ -648,7 +741,8 @@ class OpenCodeRunnerService:
             logger.warning(
                 "OpenCode PR title is missing or low quality; creating PR with title: %s", title
             )
-        pr_body = result.pull_request_body or None
+        # Embed screenshots BEFORE creating the PR so it opens already containing them.
+        pr_body = self._screenshot_body(workspace, request, result, head) or None
         if not pr_body:
             logger.warning("OpenCode PR body is empty; creating PR without a description")
         gh = GitHubService(request.github_config)
@@ -658,50 +752,75 @@ class OpenCodeRunnerService:
             )
         finally:
             gh.close()
-        url = str(pr.get("html_url") or "").strip() or None
-        pr_number = pr.get("number")
-        if url and isinstance(pr_number, int):
-            self._attach_pr_screenshots(workspace, request, result, pr_number)
-        return url
+        return str(pr.get("html_url") or "").strip() or None
 
-    def _attach_pr_screenshots(
+    def _screenshot_body(
         self,
         workspace: Path,
         request: OpenCodeRunRequest,
         result: OpenCodeRunResult,
-        pr_number: int,
-    ) -> None:
+        head: str,
+    ) -> str:
+        """Return the PR body with any UI screenshots uploaded and embedded.
+
+        Uploads discovered screenshots as release assets (keyed on the branch, so this can run
+        before the PR exists) and injects a ``## Screenshots`` section. Best-effort: on any failure
+        the plain body is returned. Also updates ``result.pull_request_body``.
+        """
+        base_body = str(result.pull_request_body or "").strip() or result.publish_summary
         try:
             screenshots = pr_publish.discover_pr_screenshots(workspace, self._git_output)
-            if not screenshots:
-                return
+            if screenshots:
+                owner, repo = pr_publish.parse_github_owner_repo(request.repository_url)
+                gh = GitHubService(request.github_config)
+                try:
+                    injected = pr_publish.upload_and_inject_screenshots(
+                        gh,
+                        screenshots=screenshots,
+                        owner=owner,
+                        repo=repo,
+                        base_branch=request.base_branch,
+                        asset_slug=head,
+                        base_body=base_body,
+                        release_tag=_PR_SCREENSHOT_RELEASE_TAG,
+                        release_name="OpenCode PR screenshots",
+                        release_body=(
+                            "Shared bucket for Heym OpenCode UI screenshots attached to pull "
+                            "requests. Assets are named <branch>-… and are not part of source."
+                        ),
+                    )
+                finally:
+                    gh.close()
+                if injected:
+                    base_body = injected
+        except Exception:  # noqa: BLE001 - screenshot embedding is best-effort
+            pass
+        result.pull_request_body = base_body
+        return base_body
+
+    def _update_pr_body_with_screenshots(
+        self,
+        workspace: Path,
+        request: OpenCodeRunRequest,
+        result: OpenCodeRunResult,
+        head: str,
+        pr_url: str,
+    ) -> None:
+        """Embed screenshots and push the updated body onto an already-open PR."""
+        pr_number = pr_publish.pr_number_from_url(pr_url)
+        if pr_number is None:
+            return
+        body = self._screenshot_body(workspace, request, result, head)
+        if not body:
+            return
+        try:
             owner, repo = pr_publish.parse_github_owner_repo(request.repository_url)
             gh = GitHubService(request.github_config)
             try:
-                base_body = str(result.pull_request_body or "").strip() or result.publish_summary
-                updated_body = pr_publish.upload_and_inject_screenshots(
-                    gh,
-                    screenshots=screenshots,
-                    owner=owner,
-                    repo=repo,
-                    base_branch=request.base_branch,
-                    pr_number=pr_number,
-                    base_body=base_body,
-                    release_tag=_PR_SCREENSHOT_RELEASE_TAG,
-                    release_name="OpenCode PR screenshots",
-                    release_body=(
-                        "Shared bucket for Heym OpenCode UI screenshots attached to pull requests. "
-                        "Assets are named pr-<number>-… and are not part of source."
-                    ),
-                )
-                if not updated_body:
-                    return
-                gh.update_issue(owner, repo, pr_number, body=updated_body)
-                result.pull_request_body = updated_body
+                gh.update_issue(owner, repo, pr_number, body=body)
             finally:
                 gh.close()
-        except Exception:
-            # Screenshot attach is best-effort; never fail the publish path for it.
+        except Exception:  # noqa: BLE001 - updating the body is best-effort
             return
 
     def cleanup_workspace(self, workspace_path: str | None) -> None:

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -4224,6 +4224,9 @@ Use ONLY: `str()`, `int()`, `float()`, `bool()`, `list()`, `dict(key=value)`, `l
     - `open_pr`: commit + push `branchName`, open a review-ready (non-draft) pull request
     - `commit_push`: commit + push `branchName`, no pull request
     - `direct_commit`: commit + push straight to `baseBranch` (no separate branch/PR)
+    - `open_or_update_pr`: update the agent's existing open PR when one exists (even if
+      `branchName` differs — the runner finds it), else open a new one. Best for re-runs / "update
+      the open PR" instructions.
     - `update_existing_pr`: add a commit to the existing `branchName`/PR (opens one if none exists)
     - `patch_artifact`: save the diff as a downloadable file, return `patchUrl`; nothing pushed
   - `branchName`: Working branch for PR/commit modes, e.g. `codex/$executionId`
@@ -4311,7 +4314,9 @@ Use ONLY: `str()`, `int()`, `float()`, `bool()`, `list()`, `dict(key=value)`, `l
   - `taskPrompt` (default `$input.text`): the coding task, required
   - `branchName` (default `opencode/$executionId`): working branch for PR/commit modes
   - `publishMode` (default `diff_only`): how OpenCode's changes are delivered — `diff_only`,
-    `draft_pr`, `open_pr`, `commit_push`, `direct_commit`, `update_existing_pr`, `patch_artifact`
+    `draft_pr`, `open_pr`, `commit_push`, `direct_commit`, `open_or_update_pr`,
+    `update_existing_pr`, `patch_artifact` (`open_or_update_pr` updates the agent's existing open
+    PR when one exists, else opens a new one — best for re-runs)
   - `opencodeModel`: OpenCode Go model id, e.g. `opencode/kimi-k3`, `opencode/deepseek-v4-pro`;
     empty uses the runner default (`opencode/kimi-k3`)
   - `opencodeVariant`: optional model reasoning variant passed to `opencode run --variant`

--- a/backend/tests/test_codex_pr_screenshots.py
+++ b/backend/tests/test_codex_pr_screenshots.py
@@ -75,7 +75,9 @@ class TestAttachPrScreenshots(unittest.TestCase):
         self.runner = CodexRunnerService()
         self.workspace = Path("/tmp/ws")
 
-    def test_create_pr_attaches_screenshots_and_updates_body(self) -> None:
+    def test_create_pr_opens_already_containing_screenshots(self) -> None:
+        # Screenshots are uploaded and embedded BEFORE the PR is created, so it opens with them
+        # (no follow-up update_issue on the create path).
         shot = Path("/tmp/ws/frontend/.e2e-artifacts/ui.png")
         result = CodexRunResult(
             status="completed",
@@ -101,9 +103,9 @@ class TestAttachPrScreenshots(unittest.TestCase):
         }
         gh.upload_release_asset.return_value = {
             "browser_download_url": (
-                "https://github.com/acme/app/releases/download/codex-pr-assets/pr-347-ui.png"
+                "https://github.com/acme/app/releases/download/codex-pr-assets/codex-run-ui.png"
             ),
-            "name": "pr-347-ui.png",
+            "name": "codex-run-ui.png",
         }
 
         self.runner._discover_pr_screenshots = MagicMock(return_value=[shot])  # type: ignore[method-assign]
@@ -115,23 +117,20 @@ class TestAttachPrScreenshots(unittest.TestCase):
 
         self.assertEqual(url, "https://github.com/acme/app/pull/347")
         gh_cls.assert_called()
-        gh.get_release_by_tag.assert_called_once_with("acme", "app", "codex-pr-assets")
-        gh.create_release.assert_called_once()
-        self.assertEqual(gh.create_release.call_args.args[2], "codex-pr-assets")
         release_kwargs = gh.create_release.call_args.kwargs
         self.assertTrue(release_kwargs.get("prerelease"))
-        self.assertFalse(release_kwargs.get("draft"))
-        upload_kwargs = gh.upload_release_asset.call_args.kwargs
-        self.assertEqual(upload_kwargs["name"], "pr-347-ui.png")
-        gh.update_issue.assert_called_once()
-        updated_body = gh.update_issue.call_args.kwargs["body"]
+        # Asset name is keyed on the branch (available before the PR exists), not the PR number.
+        self.assertEqual(gh.upload_release_asset.call_args.kwargs["name"], "codex-run-ui.png")
+        # The PR is created with the screenshot already in its body; no post-create body update.
+        gh.update_issue.assert_not_called()
+        created_body = gh.create_pull_request.call_args.kwargs["body"]
         self.assertIn(
-            "https://github.com/acme/app/releases/download/codex-pr-assets/pr-347-ui.png",
-            updated_body,
+            "https://github.com/acme/app/releases/download/codex-pr-assets/codex-run-ui.png",
+            created_body,
         )
-        self.assertIn("![pr-347-ui.png]", updated_body)
-        self.assertNotIn("Attach the generated screenshot", updated_body)
-        self.assertEqual(result.pull_request_body, updated_body)
+        self.assertIn("![codex-run-ui.png]", created_body)
+        self.assertNotIn("Attach the generated screenshot", created_body)
+        self.assertEqual(result.pull_request_body, created_body)
 
     def test_reuses_shared_release_and_replaces_same_named_asset(self) -> None:
         shot = Path("/tmp/ws/frontend/.e2e-artifacts/ui.png")
@@ -145,13 +144,13 @@ class TestAttachPrScreenshots(unittest.TestCase):
             "id": 99,
             "upload_url": "https://uploads.github.com/repos/acme/app/releases/99/assets{?name,label}",
             "tag_name": "codex-pr-assets",
-            "assets": [{"id": 55, "name": "pr-347-ui.png"}],
+            "assets": [{"id": 55, "name": "codex-run-ui.png"}],
         }
         gh.upload_release_asset.return_value = {
             "browser_download_url": (
-                "https://github.com/acme/app/releases/download/codex-pr-assets/pr-347-ui.png"
+                "https://github.com/acme/app/releases/download/codex-pr-assets/codex-run-ui.png"
             ),
-            "name": "pr-347-ui.png",
+            "name": "codex-run-ui.png",
         }
         self.runner._discover_pr_screenshots = MagicMock(return_value=[shot])  # type: ignore[method-assign]
 
@@ -160,7 +159,7 @@ class TestAttachPrScreenshots(unittest.TestCase):
 
         gh.create_release.assert_not_called()
         gh.delete_release_asset.assert_called_once_with("acme", "app", 55)
-        self.assertEqual(gh.upload_release_asset.call_args.kwargs["name"], "pr-347-ui.png")
+        self.assertEqual(gh.upload_release_asset.call_args.kwargs["name"], "codex-run-ui.png")
 
     def test_attach_failure_does_not_raise(self) -> None:
         result = CodexRunResult(
@@ -186,7 +185,7 @@ class TestAttachPrScreenshots(unittest.TestCase):
         self.assertEqual(url, "https://github.com/acme/app/pull/1")
         gh.create_release.assert_not_called()
 
-    def test_update_existing_pr_also_attaches(self) -> None:
+    def test_update_existing_pr_updates_body_with_screenshots(self) -> None:
         result = CodexRunResult(status="completed", summary="done", changed_files=["a.vue"])
         self.runner._commit_changes = MagicMock()  # type: ignore[method-assign]
         self.runner._push_branch = MagicMock()  # type: ignore[method-assign]
@@ -194,17 +193,35 @@ class TestAttachPrScreenshots(unittest.TestCase):
         self.runner._open_pr_url_for_head = MagicMock(  # type: ignore[method-assign]
             return_value="https://github.com/acme/app/pull/42"
         )
-        self.runner._attach_pr_screenshots = MagicMock()  # type: ignore[method-assign]
+        self.runner._update_pr_body_with_screenshots = MagicMock()  # type: ignore[method-assign]
 
         self.runner._publish(self.workspace, _request("update_existing_pr"), result)
 
-        self.runner._attach_pr_screenshots.assert_called_once()
-        args = self.runner._attach_pr_screenshots.call_args
-        self.assertEqual(args.args[3], 42)
-        self.assertEqual(result.pull_request_url, "https://github.com/acme/app/pull/42")
-        self.assertIs(args.args[2], result)
-        # shot path discovery happens inside attach; ensure we passed workspace
+        self.runner._update_pr_body_with_screenshots.assert_called_once()
+        args = self.runner._update_pr_body_with_screenshots.call_args
         self.assertEqual(args.args[0], self.workspace)
+        self.assertIs(args.args[2], result)
+        self.assertEqual(args.args[3], "codex/run")
+        self.assertEqual(args.args[4], "https://github.com/acme/app/pull/42")
+        self.assertEqual(result.pull_request_url, "https://github.com/acme/app/pull/42")
+
+    def test_open_or_update_pr_updates_existing(self) -> None:
+        # The new intuitive mode shares the update-or-open path.
+        result = CodexRunResult(status="completed", summary="done", changed_files=["a.vue"])
+        self.runner._commit_changes = MagicMock()  # type: ignore[method-assign]
+        self.runner._push_branch = MagicMock()  # type: ignore[method-assign]
+        self.runner._current_branch = MagicMock(return_value="codex/run")  # type: ignore[method-assign]
+        self.runner._open_pr_url_for_head = MagicMock(  # type: ignore[method-assign]
+            return_value="https://github.com/acme/app/pull/42"
+        )
+        self.runner._update_pr_body_with_screenshots = MagicMock()  # type: ignore[method-assign]
+        self.runner._create_pr = MagicMock()  # type: ignore[method-assign]
+
+        self.runner._publish(self.workspace, _request("open_or_update_pr"), result)
+
+        self.runner._update_pr_body_with_screenshots.assert_called_once()
+        self.runner._create_pr.assert_not_called()
+        self.assertEqual(result.pull_request_url, "https://github.com/acme/app/pull/42")
 
 
 class TestScreenshotBodyHelpers(unittest.TestCase):
@@ -219,14 +236,14 @@ class TestScreenshotBodyHelpers(unittest.TestCase):
         self.assertNotIn("Attach the generated", updated)
         self.assertIn("## Summary", updated)
 
-    def test_release_asset_name_prefixes_pr_number(self) -> None:
+    def test_release_asset_name_prefixes_sanitized_branch(self) -> None:
         self.assertEqual(
-            CodexRunnerService._release_asset_name(Path("ui.png"), 347, 0),
-            "pr-347-ui.png",
+            CodexRunnerService._release_asset_name(Path("ui.png"), "codex/run", 0),
+            "codex-run-ui.png",
         )
         self.assertEqual(
-            CodexRunnerService._release_asset_name(Path("board.png"), 42, 1),
-            "pr-42-board-1.png",
+            CodexRunnerService._release_asset_name(Path("board.png"), "codex/run", 1),
+            "codex-run-board-1.png",
         )
 
     def test_parse_pr_number_from_url(self) -> None:

--- a/backend/tests/test_codex_publish_modes.py
+++ b/backend/tests/test_codex_publish_modes.py
@@ -47,6 +47,7 @@ class TestPublishModeConstants(unittest.TestCase):
                 "commit_push",
                 "direct_commit",
                 "update_existing_pr",
+                "open_or_update_pr",
                 "patch_artifact",
             },
         )
@@ -80,6 +81,95 @@ class TestPublishModeConstants(unittest.TestCase):
         self.assertIn(
             pr_publish.PR_CONTENT_POLICY, CodexRunnerService._build_resume_prompt("use port 1234")
         )
+
+    def test_build_prompt_forbids_ending_on_a_screenshot_announcement(self) -> None:
+        # Regression for the observed "…Now let me take a screenshot" early stop.
+        prompt = CodexRunnerService._build_prompt("add a badge")
+        self.assertIn("BEFORE you return your final result", prompt)
+        self.assertIn("Now let me take a screenshot", prompt)
+
+    def test_finishing_prompt_states_the_finishing_preamble(self) -> None:
+        prompt = CodexRunnerService._build_finishing_prompt()
+        self.assertIn(pr_publish.FINISHING_PASS_PREAMBLE, prompt)
+        self.assertIn("Do NOT run git", prompt)
+        self.assertIn("## Change Summary", prompt)
+
+
+class TestCodexResolveUpdateExistingPr(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CodexRunnerService()
+
+    def test_non_update_mode_is_unchanged(self) -> None:
+        request = _request("open_pr")
+        self.assertIs(self.runner._resolve_update_existing_pr_request(request), request)
+
+    def test_update_mode_swaps_in_the_existing_pr_branch(self) -> None:
+        request = _request("update_existing_pr")
+        gh = MagicMock()
+        with (
+            patch("app.services.codex_runner_service.GitHubService", return_value=gh),
+            patch.object(
+                pr_publish, "resolve_update_existing_pr_branch", return_value="feat/real-branch"
+            ),
+        ):
+            resolved = self.runner._resolve_update_existing_pr_request(request)
+        self.assertEqual(resolved.branch_name, "feat/real-branch")
+        self.assertEqual(request.branch_name, "codex/run")  # original request untouched
+        gh.close.assert_called_once()
+
+
+class TestCodexFinishIncompleteRun(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CodexRunnerService()
+        self.runner._git_output = MagicMock(return_value="")  # type: ignore[method-assign]
+        self.ws = Path("/tmp/ws")
+
+    def test_reruns_and_updates_summary_when_agent_stopped_mid_task(self) -> None:
+        # Real PR #401 case: the agent stopped right before the screenshot ("Backend code is
+        # clean. Let me now take a screenshot."). A UI change with no screenshot triggers the
+        # finishing pass even though the summary is not empty.
+        result = CodexRunResult(
+            status="completed",
+            summary="Backend code is clean. Let me now take a screenshot.",
+            changed_files=["frontend/src/views/DashboardView.vue"],
+        )
+        CodexRunnerService._prepare_publishable_text(result, "")
+
+        finished = CodexRunResult(
+            status="completed",
+            summary="Add a live running-workflow count badge to the toolbar.",
+            pull_request_title="Add running-workflow count badge",
+            pull_request_body="## Change Summary\n\nAdd a live badge.",
+        )
+        self.runner._run_codex_exec = MagicMock(return_value=finished)  # type: ignore[method-assign]
+        self.runner._discover_pr_screenshots = MagicMock(return_value=[])  # type: ignore[method-assign]
+        self.runner._changed_files = MagicMock(  # type: ignore[method-assign]
+            return_value=["frontend/src/views/DashboardView.vue"]
+        )
+
+        self.runner._finish_incomplete_run(self.ws, _request("open_pr"), result)
+
+        self.runner._run_codex_exec.assert_called_once()
+        self.assertEqual(result.summary, "Add a live running-workflow count badge to the toolbar.")
+        self.assertEqual(result.pull_request_title, "Add running-workflow count badge")
+        # A UI change with no screenshot after the pass gets a visible note.
+        self.assertIn("## Screenshots", result.pull_request_body)
+
+    def test_no_rerun_when_summary_and_screenshot_present(self) -> None:
+        result = CodexRunResult(
+            status="completed",
+            summary="Add a live badge.",
+            changed_files=["frontend/src/views/DashboardView.vue"],
+        )
+        CodexRunnerService._prepare_publishable_text(result, "")
+        self.runner._run_codex_exec = MagicMock()  # type: ignore[method-assign]
+        self.runner._discover_pr_screenshots = MagicMock(  # type: ignore[method-assign]
+            return_value=[Path("/tmp/ws/frontend/.e2e-artifacts/shot.png")]
+        )
+
+        self.runner._finish_incomplete_run(self.ws, _request("open_pr"), result)
+
+        self.runner._run_codex_exec.assert_not_called()
 
 
 class TestCodexPublishedTextRedaction(unittest.TestCase):
@@ -315,7 +405,7 @@ class TestCodexNarrationIsNotPublished(unittest.TestCase):
         gh = MagicMock()
         gh.create_pull_request.return_value = {"number": 7, "html_url": "https://x/pull/7"}
         runner = CodexRunnerService(workspace_root="/tmp/heym-codex-ws")
-        runner._attach_pr_screenshots = MagicMock()  # type: ignore[method-assign]
+        runner._discover_pr_screenshots = MagicMock(return_value=[])  # type: ignore[method-assign]
 
         with patch("app.services.codex_runner_service.GitHubService", return_value=gh):
             runner._create_pr(

--- a/backend/tests/test_coding_agent_pr_publish.py
+++ b/backend/tests/test_coding_agent_pr_publish.py
@@ -157,8 +157,8 @@ class TestPrPublishHelpers(unittest.TestCase):
         gh.get_release_by_tag.side_effect = ValueError("Not Found")
         gh.create_release.return_value = {"id": 9, "upload_url": None, "assets": []}
         gh.upload_release_asset.return_value = {
-            "browser_download_url": "http://x/pr-1-ui.png",
-            "name": "pr-1-ui.png",
+            "browser_download_url": "http://x/opencode-run-ui.png",
+            "name": "opencode-run-ui.png",
         }
         body = pr_publish.upload_and_inject_screenshots(
             gh,
@@ -166,14 +166,16 @@ class TestPrPublishHelpers(unittest.TestCase):
             owner="acme",
             repo="app",
             base_branch="main",
-            pr_number=1,
+            asset_slug="opencode/run",
             base_body="Body",
             release_tag="opencode-pr-assets",
             release_name="OpenCode PR screenshots",
             release_body="bucket",
         )
         gh.get_release_by_tag.assert_called_once_with("acme", "app", "opencode-pr-assets")
-        self.assertIn("![pr-1-ui.png](http://x/pr-1-ui.png)", body)
+        # Asset name is keyed on the (sanitized) branch, not the PR number.
+        self.assertIn("![opencode-run-ui.png](http://x/opencode-run-ui.png)", body)
+        self.assertEqual(gh.upload_release_asset.call_args.kwargs["name"], "opencode-run-ui.png")
 
 
 class TestTaskPromptRedaction(unittest.TestCase):
@@ -307,3 +309,163 @@ class TestChangeSummaryExtraction(unittest.TestCase):
 
     def test_absent_section_returns_empty(self):
         self.assertEqual(pr_publish.extract_change_summary_section("Just prose."), "")
+
+
+def _pr(head: str, base: str = "main", login: str = "heym-coder", updated_at: str = "") -> dict:
+    return {
+        "head": {"ref": head},
+        "base": {"ref": base},
+        "user": {"login": login},
+        "updated_at": updated_at,
+        "html_url": f"https://github.com/acme/app/pull/{head}",
+    }
+
+
+class TestResolveUpdateExistingPrBranch(unittest.TestCase):
+    """update_existing_pr must find the agent's real open PR, not trust the configured branch."""
+
+    def _gh(self, pulls: list[dict], login: str = "heym-coder") -> MagicMock:
+        gh = MagicMock()
+        gh.list_pull_requests.return_value = pulls
+        gh.get_authenticated_user.return_value = {"login": login}
+        return gh
+
+    def test_exact_head_match_wins(self):
+        gh = self._gh([_pr("feature-a"), _pr("configured")])
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="configured"
+        )
+        self.assertEqual(branch, "configured")
+
+    def test_adopts_authors_open_pr_when_branch_does_not_match(self):
+        # The real board bug: the configured branch was LLM-generated and never matched PR #401.
+        gh = self._gh([_pr("feat/running-workflow-count-badge")])
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="reuse-branch-from-pr-401"
+        )
+        self.assertEqual(branch, "feat/running-workflow-count-badge")
+
+    def test_picks_most_recently_updated_of_the_authors_prs(self):
+        gh = self._gh(
+            [
+                _pr("older", updated_at="2026-07-20T10:00:00Z"),
+                _pr("newest", updated_at="2026-07-22T10:00:00Z"),
+            ]
+        )
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+        )
+        self.assertEqual(branch, "newest")
+
+    def test_ignores_other_authors_and_other_base_branches(self):
+        gh = self._gh(
+            [
+                _pr("human-pr", login="someone-else"),
+                _pr("wrong-base", base="develop"),
+            ]
+        )
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+        )
+        self.assertEqual(branch, "unmatched")
+
+    def test_without_author_only_adopts_a_single_open_pr(self):
+        gh = self._gh([_pr("only-one")])
+        gh.get_authenticated_user.side_effect = ValueError("token cannot read /user")
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+        )
+        self.assertEqual(branch, "only-one")
+
+    def test_without_author_does_not_adopt_when_ambiguous(self):
+        gh = self._gh([_pr("one"), _pr("two")])
+        gh.get_authenticated_user.side_effect = ValueError("token cannot read /user")
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+        )
+        self.assertEqual(branch, "unmatched")
+
+    def test_github_error_falls_back_to_configured_branch(self):
+        gh = MagicMock()
+        gh.list_pull_requests.side_effect = ValueError("boom")
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh, "acme", "app", base_branch="main", configured_branch="configured"
+        )
+        self.assertEqual(branch, "configured")
+
+
+class TestFinishingPassHelpers(unittest.TestCase):
+    def test_changed_files_touch_ui_detects_vue_and_frontend_scripts(self):
+        self.assertTrue(pr_publish.changed_files_touch_ui(["frontend/src/views/DashboardView.vue"]))
+        self.assertTrue(pr_publish.changed_files_touch_ui(["frontend/src/views/Editor.ts"]))
+        self.assertTrue(pr_publish.changed_files_touch_ui(["app/styles/theme.css"]))
+
+    def test_changed_files_touch_ui_ignores_backend_only(self):
+        self.assertFalse(
+            pr_publish.changed_files_touch_ui(
+                ["backend/app/api/workflows.py", "backend/tests/test_x.py"]
+            )
+        )
+
+    def test_needs_finishing_pass_when_no_publishable_summary(self):
+        self.assertTrue(
+            pr_publish.needs_finishing_pass(
+                will_publish=True,
+                changed_files=["a.py"],
+                publish_summary="",
+                ui_change=False,
+                has_screenshots=False,
+            )
+        )
+
+    def test_needs_finishing_pass_when_ui_change_lacks_screenshot(self):
+        self.assertTrue(
+            pr_publish.needs_finishing_pass(
+                will_publish=True,
+                changed_files=["frontend/src/App.vue"],
+                publish_summary="Add a badge.",
+                ui_change=True,
+                has_screenshots=False,
+            )
+        )
+
+    def test_no_finishing_pass_when_summary_and_screenshot_present(self):
+        self.assertFalse(
+            pr_publish.needs_finishing_pass(
+                will_publish=True,
+                changed_files=["frontend/src/App.vue"],
+                publish_summary="Add a badge.",
+                ui_change=True,
+                has_screenshots=True,
+            )
+        )
+
+    def test_no_finishing_pass_without_changes_or_publish(self):
+        self.assertFalse(
+            pr_publish.needs_finishing_pass(
+                will_publish=False,
+                changed_files=["a.py"],
+                publish_summary="",
+                ui_change=False,
+                has_screenshots=False,
+            )
+        )
+        self.assertFalse(
+            pr_publish.needs_finishing_pass(
+                will_publish=True,
+                changed_files=[],
+                publish_summary="",
+                ui_change=False,
+                has_screenshots=False,
+            )
+        )
+
+    def test_note_missing_ui_screenshot_appends_section(self):
+        body = pr_publish.note_missing_ui_screenshot("## Change Summary\n\nAdd a badge.")
+        self.assertIn("## Screenshots", body)
+        self.assertIn("did not", body)
+        self.assertIn("capture a screenshot", body)
+
+    def test_note_missing_ui_screenshot_is_noop_when_screenshots_present(self):
+        body = "## Change Summary\n\nx\n\n## Screenshots\n\n![shot](http://x/y.png)"
+        self.assertEqual(pr_publish.note_missing_ui_screenshot(body).strip(), body.strip())

--- a/backend/tests/test_opencode_runner_service.py
+++ b/backend/tests/test_opencode_runner_service.py
@@ -73,6 +73,16 @@ class TestOpenCodeRunCommand(unittest.TestCase):
         self.assertIn("frontend/.e2e-artifacts/", prompt)
         self.assertIn("Do not commit screenshot binaries", prompt)
 
+    def test_run_command_forbids_ending_on_screenshot_announcement(self):
+        # Regression for the observed "…Now let me take a screenshot" early stop.
+        prompt = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)[-1]
+        self.assertIn("Capture screenshots BEFORE you write your final message", prompt)
+        self.assertIn("Now let me take a screenshot", prompt)
+
+    def test_build_run_command_prompt_override(self):
+        cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS, prompt="FINISH NOW")
+        self.assertEqual(cmd[-1], "FINISH NOW")
+
     def test_run_command_pins_workspace_dir(self):
         cmd = self.svc.build_run_command("opencode/kimi-k3", _request(), _WS)
         self.assertEqual(cmd[cmd.index("--dir") + 1], str(_WS))
@@ -294,6 +304,9 @@ class TestOpenCodeCreatePr(unittest.TestCase):
             changed_files=["a.vue"],
         )
         self.runner._normalize_pr_metadata(result, request.task_prompt)
+        self.runner._screenshot_body = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda _ws, _req, res, _head: res.pull_request_body
+        )
         gh = MagicMock()
         gh.create_pull_request.return_value = {
             "number": 1,
@@ -401,3 +414,117 @@ class TestOpenCodeNarrationIsNotPublished(unittest.TestCase):
         result = OpenCodeRunResult(summary="", changed_files=[f"file{i}.ts" for i in range(25)])
         self.svc._normalize_pr_metadata(result, "")
         self.assertIn("…and 5 more file(s)", result.pull_request_body)
+
+
+class TestOpenCodeResolveExistingPrBranch(unittest.TestCase):
+    def setUp(self):
+        self.svc = OpenCodeRunnerService(workspace_root="/tmp/heym-oc-ws")
+
+    def test_resolves_existing_pr_branch(self):
+        request = _request(publish_mode="open_or_update_pr", branch_name="reuse-branch-from-pr-401")
+        gh = MagicMock()
+        with (
+            patch("app.services.opencode_runner_service.GitHubService", return_value=gh),
+            patch.object(
+                pr_publish,
+                "resolve_update_existing_pr_branch",
+                return_value="feat/running-workflow-count-badge",
+            ),
+        ):
+            branch = self.svc._resolve_existing_pr_branch(request)
+        self.assertEqual(branch, "feat/running-workflow-count-badge")
+        gh.close.assert_called_once()
+
+
+class TestOpenCodeFinishIncompleteRun(unittest.TestCase):
+    def setUp(self):
+        self.svc = OpenCodeRunnerService(workspace_root="/tmp/heym-oc-ws")
+        self.svc._git_output = MagicMock(return_value="")  # type: ignore[method-assign]
+        self.ws = Path("/tmp/ws")
+        self.home = Path("/tmp/ws.oc-home")
+
+    @staticmethod
+    def _stream(*texts: str) -> str:
+        return "\n".join(json.dumps({"role": "assistant", "text": text}) for text in texts)
+
+    def test_reruns_and_updates_when_ui_change_has_no_screenshot(self):
+        # Real PR #402 case: agent stopped right before capturing a screenshot of a UI change.
+        result = OpenCodeRunResult(
+            status="completed",
+            summary="All checks pass - 2406 tests, 0 failures. Now let me take a screenshot.",
+            changed_files=["frontend/src/views/DashboardView.vue"],
+        )
+        self.svc._normalize_pr_metadata(result, "")
+        self.svc._changed_files = MagicMock(  # type: ignore[method-assign]
+            return_value=["frontend/src/views/DashboardView.vue"]
+        )
+        finishing_stdout = self._stream(
+            "## Change Summary\n\nAdd a live running-workflow count badge.\n\n"
+            "PR_TITLE: Add running-workflow count badge"
+        )
+        self.svc._exec_opencode = MagicMock(return_value=finishing_stdout)  # type: ignore[method-assign]
+
+        with patch.object(pr_publish, "discover_pr_screenshots", return_value=[]):
+            self.svc._finish_incomplete_run(
+                self.ws, self.home, _request(), "opencode/kimi-k3", result
+            )
+
+        self.svc._exec_opencode.assert_called_once()
+        override = self.svc._exec_opencode.call_args.kwargs["prompt_override"]
+        self.assertIn(pr_publish.FINISHING_PASS_PREAMBLE, override)
+        self.assertEqual(result.pull_request_title, "Add running-workflow count badge")
+        # A UI change with no screenshot after the pass gets a visible note.
+        self.assertIn("## Screenshots", result.pull_request_body)
+
+    def test_no_rerun_when_summary_and_screenshot_present(self):
+        result = OpenCodeRunResult(
+            status="completed",
+            summary="Add a badge.",
+            changed_files=["frontend/src/views/DashboardView.vue"],
+        )
+        self.svc._normalize_pr_metadata(result, "")
+        self.svc._exec_opencode = MagicMock()  # type: ignore[method-assign]
+
+        with patch.object(
+            pr_publish,
+            "discover_pr_screenshots",
+            return_value=[Path("/tmp/ws/frontend/.e2e-artifacts/shot.png")],
+        ):
+            self.svc._finish_incomplete_run(
+                self.ws, self.home, _request(), "opencode/kimi-k3", result
+            )
+
+        self.svc._exec_opencode.assert_not_called()
+
+
+class TestOpenCodeOpenOrUpdatePublish(unittest.TestCase):
+    def setUp(self):
+        self.svc = OpenCodeRunnerService(workspace_root="/tmp/heym-oc-ws")
+        self.svc._commit_changes = MagicMock()  # type: ignore[method-assign]
+        self.svc._push_branch = MagicMock()  # type: ignore[method-assign]
+        self.svc._current_branch = MagicMock(return_value="opencode/run")  # type: ignore[method-assign]
+        self.svc._create_pr = MagicMock()  # type: ignore[method-assign]
+        self.svc._update_pr_body_with_screenshots = MagicMock()  # type: ignore[method-assign]
+        self.ws = Path("/tmp/ws")
+
+    def test_open_or_update_updates_existing_pr(self):
+        self.svc._open_pr_url_for_head = MagicMock(  # type: ignore[method-assign]
+            return_value="https://github.com/acme/app/pull/42"
+        )
+        result = OpenCodeRunResult(status="completed", summary="done", changed_files=["a.vue"])
+
+        self.svc._publish(self.ws, _request(publish_mode="open_or_update_pr"), result)
+
+        self.svc._update_pr_body_with_screenshots.assert_called_once()
+        self.svc._create_pr.assert_not_called()
+        self.assertEqual(result.pull_request_url, "https://github.com/acme/app/pull/42")
+
+    def test_open_or_update_opens_new_pr_when_none_exists(self):
+        self.svc._open_pr_url_for_head = MagicMock(return_value=None)  # type: ignore[method-assign]
+        self.svc._create_pr = MagicMock(return_value="https://github.com/acme/app/pull/99")  # type: ignore[method-assign]
+        result = OpenCodeRunResult(status="completed", summary="done", changed_files=["a.vue"])
+
+        self.svc._publish(self.ws, _request(publish_mode="open_or_update_pr"), result)
+
+        self.svc._create_pr.assert_called_once()
+        self.assertEqual(result.pull_request_url, "https://github.com/acme/app/pull/99")

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -5933,6 +5933,7 @@ export function usePropertiesPanelController() {
     { value: "open_pr", label: "Open PR" },
     { value: "commit_push", label: "Commit & push" },
     { value: "direct_commit", label: "Direct commit" },
+    { value: "open_or_update_pr", label: "Open or update PR" },
     { value: "update_existing_pr", label: "Update existing PR" },
     { value: "patch_artifact", label: "Patch artifact" },
   ];
@@ -5943,6 +5944,8 @@ export function usePropertiesPanelController() {
     open_pr: "Commits to the branch, pushes it, and opens a review-ready (non-draft) pull request.",
     commit_push: "Commits to the branch and pushes it, without opening a pull request.",
     direct_commit: "Commits and pushes straight to the base branch (no separate branch or PR).",
+    open_or_update_pr:
+      "Updates the agent's existing open PR when one exists (even if the branch name differs), otherwise opens a new one. Best for re-runs.",
     update_existing_pr:
       "Adds a commit to the existing branch/PR; opens one if none exists yet.",
     patch_artifact: "Saves the diff as a downloadable file and returns a patchUrl (nothing pushed).",

--- a/frontend/src/docs/content/nodes/codex-node.md
+++ b/frontend/src/docs/content/nodes/codex-node.md
@@ -58,6 +58,7 @@ OpenAI references:
 | `open_pr` | Commits to the branch, pushes it, and opens a review-ready (non-draft) pull request. |
 | `commit_push` | Commits to the branch and pushes it, without opening a pull request. |
 | `direct_commit` | Commits and pushes straight to the base branch (no separate branch or PR). |
+| `open_or_update_pr` | Updates the agent's existing open PR when one exists — even if the branch name differs, the runner finds it by author + base — otherwise opens a new one. Best for re-runs and "update the open PR" instructions. |
 | `update_existing_pr` | Adds a commit to the existing branch/PR; opens one if none exists yet. |
 | `patch_artifact` | Saves the diff as a downloadable file and returns `patchUrl`. Nothing is pushed. |
 
@@ -72,14 +73,16 @@ OpenAI references:
 | `changedFiles` | Changed file paths |
 | `threadId` | Codex thread/session id when available |
 | `branchName` | Working branch name |
-| `pullRequestUrl` | PR URL in `draft_pr`, `open_pr`, and `update_existing_pr` modes |
+| `pullRequestUrl` | PR URL in `draft_pr`, `open_pr`, `open_or_update_pr`, and `update_existing_pr` modes |
 | `pushedBranch` | Branch that was pushed in commit/PR modes |
 | `patchUrl` | Download link for the diff in `patch_artifact` mode |
 | `usage` | Usage metadata reported by Codex CLI when available |
 
 ## UI screenshots on pull requests
 
-For UI/frontend tasks, Codex should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, Codex may run `bun install` (or npm/pnpm install) and start a short-lived preview/`bun run dev` solely to capture the UI. After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`codex-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description. Codex must also set a meaningful `pull_request_title` (never placeholders such as `Done.`). 
+For UI/frontend tasks, Codex should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, Codex may run `bun install` (or npm/pnpm install) and start a short-lived preview/`bun run dev` solely to capture the UI. Heym uploads those images to a single shared GitHub **prerelease** (`codex-pr-assets`) as assets named `<branch>-…`, then embeds them in the PR description **before the pull request is opened**, so a new PR is created already containing its screenshots (existing PRs are updated in place). Codex must also set a meaningful `pull_request_title` (never placeholders such as `Done.`).
+
+Codex sometimes ends a turn mid-task ("…Now let me take a screenshot"), which would finalize the run before the screenshot is captured. To prevent that, the runner prompt requires capturing screenshots **before** the final result, and if the run still finishes with no publishable summary or with a UI change but no screenshot, Heym runs one more Codex pass in the same workspace to finish. If a UI change still has no screenshot afterwards, a visible note is added to the PR body so the gap is never silent.
 
 ## What gets published to GitHub
 

--- a/frontend/src/docs/content/nodes/opencode-go-node.md
+++ b/frontend/src/docs/content/nodes/opencode-go-node.md
@@ -56,6 +56,7 @@ OpenCode Go's model roster changes often, so the **Model** field is populated li
 | `open_pr` | Commits to the branch, pushes it, and opens a review-ready (non-draft) pull request. |
 | `commit_push` | Commits to the branch and pushes it, without opening a pull request. |
 | `direct_commit` | Commits and pushes straight to the base branch (no separate branch or PR). |
+| `open_or_update_pr` | Updates the agent's existing open PR when one exists — even if the branch name differs, the runner finds it by author + base — otherwise opens a new one. Best for re-runs and "update the open PR" instructions. |
 | `update_existing_pr` | Adds a commit to the existing branch/PR; opens one if none exists yet. |
 | `patch_artifact` | Saves the diff as a downloadable file and returns `patchUrl`. Nothing is pushed. |
 
@@ -69,15 +70,17 @@ OpenCode Go's model roster changes often, so the **Model** field is populated li
 | `diff` | Git patch when files changed |
 | `changedFiles` | Changed file paths |
 | `branchName` | Working branch name |
-| `pullRequestUrl` | PR URL in `draft_pr`, `open_pr`, and `update_existing_pr` modes |
+| `pullRequestUrl` | PR URL in `draft_pr`, `open_pr`, `open_or_update_pr`, and `update_existing_pr` modes |
 | `pushedBranch` | Branch that was pushed in commit/PR modes |
 | `patchUrl` | Download link for the diff in `patch_artifact` mode |
 
 ## UI screenshots on pull requests
 
-For UI/frontend tasks, OpenCode should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, the runner prompt allows a targeted package install (for example `bun install`) plus a short-lived preview/`bun run dev` solely to capture the UI. After Heym opens or updates the pull request, it uploads those images to a single shared GitHub **prerelease** (`opencode-pr-assets`) as assets named `pr-<number>-…`, then embeds them in the PR description.
+For UI/frontend tasks, OpenCode should save PNG screenshots under a gitignored path such as `frontend/.e2e-artifacts/` (not in source). If frontend dependencies are missing, the runner prompt allows a targeted package install (for example `bun install`) plus a short-lived preview/`bun run dev` solely to capture the UI. Heym uploads those images to a single shared GitHub **prerelease** (`opencode-pr-assets`) as assets named `<branch>-…`, then embeds them in the PR description **before the pull request is opened**, so a new PR is created already containing its screenshots (existing PRs are updated in place).
 
 OpenCode is also instructed to end with a `PR_TITLE: …` line so Heym can open the pull request with a meaningful subject instead of placeholders such as `Done.`
+
+OpenCode sometimes ends a turn mid-task ("…Now let me take a screenshot"), which would finalize the run before the screenshot is captured. To prevent that, the runner prompt requires capturing screenshots **before** the final message, and if the run still finishes with no publishable summary or with a UI change but no screenshot, Heym runs one more OpenCode pass in the same workspace to finish. If a UI change still has no screenshot afterwards, a visible note is added to the PR body so the gap is never silent.
 
 ## What gets published to GitHub
 

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -431,6 +431,7 @@ export interface NodeData {
     | "commit_push"
     | "direct_commit"
     | "update_existing_pr"
+    | "open_or_update_pr"
     | "patch_artifact";
   branchName?: string;
   codexModel?: string;


### PR DESCRIPTION
## Why

Two reproducible failures on the board → coding-agent flow (seen on #401 and #402), fixed for **both** the Codex and OpenCode Go runners.

### 1. Screenshots never landed — the agent quit right before capturing one

Both PRs ended on narration:
- #401: *"Backend code is clean. Let me now take a screenshot."*
- #402: *"All checks pass … Now let me take a screenshot of the new badge."*

The run finalized on that message, so no screenshot was captured **and** the PR body fell back to "did not return a change summary".

**Fix (both runners):**
- Prompts now require capturing screenshots **before** the final report and forbid ending on a pending-step announcement.
- If a run finishes with changes but no publishable summary, **or** a UI change with no screenshot, the runner does **one** more pass in the same workspace to finish (capture the screenshot + write a real summary). Bounded and best-effort — never breaks the primary run.
- If a UI change still has no screenshot afterwards, a visible **⚠️ note** is added to the PR body so the gap is never silent.

### 2. "Update the open PR" opened a NEW PR

`publishMode` was `open_pr`, and the runner (not the agent) owns all git — so a task-prompt instruction like *"update PR #401 / use the same branch"* can't change anything. `update_existing_pr` also trusted a branch name that the board's LLM planner generated per run (`reuse-branch-from-pr-401`), which never matched #401's real branch (`feat/running-workflow-count-badge`).

**Fix:**
- `update_existing_pr` now resolves the agent's real open PR (scoped by token author + base branch) and adopts its head branch **before** cloning, so re-runs update it instead of opening a new PR.
- New publishMode **`open_or_update_pr`** (both runners + properties panel + DSL + docs): updates the agent's open PR when one exists, else opens a new one. This is the intuitive single mode for re-runs.

### 3. PRs now open *with* the screenshot

Screenshots are uploaded and embedded into the PR body **before** `create_pull_request`, so a new PR opens already containing them (existing PRs are updated in place). Release assets are now keyed on the branch (not the PR number), which also dedupes re-runs on the same branch.

## Scope

- `pr_publish.py` shared helpers: existing-PR branch resolution, UI-change detection, finishing-pass preamble, missing-screenshot note, branch-slug asset naming.
- `GitHubService.get_authenticated_user()` for author-scoped PR discovery.
- Codex + OpenCode runners; OpenCode/Codex node handlers; `workflow.ts` union; properties-panel option + description; DSL prompt; codex/opencode node docs.

## Verification

`./check.sh` passes — **2432 backend tests**, frontend lint + typecheck, ruff. New/updated tests cover branch resolution, the finishing pass (both agents), the `open_or_update_pr` routing, and screenshot-before-open.

Replaces #401 and #402 (both closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)