### PR TITLE
Add live active workflow badge to the toolbar

### DIFF
--- a/backend/tests/test_active_executions_api.py
+++ b/backend/tests/test_active_executions_api.py
@@ -88,6 +88,31 @@ class ListActiveWorkflowExecutionsTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(result[0], ActiveExecutionItem)
         db.execute.assert_not_called()
 
+    async def test_returns_every_execution_for_the_same_workflow(self) -> None:
+        user = MagicMock()
+        user.id = uuid.uuid4()
+
+        workflow_id = uuid.uuid4()
+        execution_ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
+        records = [_make_record(workflow_id, execution_id) for execution_id in execution_ids]
+        db = AsyncMock()
+
+        with (
+            patch(
+                "app.api.workflows.list_persisted_active_executions_for_user",
+                AsyncMock(return_value=records),
+            ),
+            patch("app.api.workflows.list_active_executions", return_value=[]),
+        ):
+            result = await list_active_workflow_executions(current_user=user, db=db)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(
+            {item.execution_id for item in result},
+            {str(execution_id) for execution_id in execution_ids},
+        )
+        self.assertEqual({item.workflow_id for item in result}, {str(workflow_id)})
+
     async def test_filters_local_fallback_to_accessible_workflows(self) -> None:
         user = MagicMock()
         user.id = uuid.uuid4()

--- a/frontend/e2e/active-workflows-badge.spec.ts
+++ b/frontend/e2e/active-workflows-badge.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+import { prepareAuthenticatedPage } from "./support";
+
+interface ActiveExecutionFixture {
+  execution_id: string;
+  workflow_id: string;
+  workflow_name: string;
+  started_at: string;
+  inputs: Record<string, unknown>;
+  running_node_ids: string[];
+  node_results: [];
+}
+
+function makeActiveExecution(index: number): ActiveExecutionFixture {
+  const suffix = String(index).padStart(12, "0");
+  return {
+    execution_id: `10000000-0000-4000-8000-${suffix}`,
+    workflow_id: `20000000-0000-4000-8000-${suffix}`,
+    workflow_name: `Running workflow ${index}`,
+    started_at: new Date(Date.UTC(2026, 0, 1, 12, index)).toISOString(),
+    inputs: {},
+    running_node_ids: [`node-${index}`],
+    node_results: [],
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  await prepareAuthenticatedPage(page);
+});
+
+test("polls, scrolls active workflows, and opens a live workflow", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.clock.install();
+
+  const allActiveExecutions = Array.from({ length: 5 }, (_, index) =>
+    makeActiveExecution(index + 1),
+  );
+  let activeExecutions = allActiveExecutions.slice(0, 2);
+  let requestCount = 0;
+  await page.route("**/api/workflows/executions/active", async (route) => {
+    requestCount += 1;
+    await route.fulfill({ json: activeExecutions });
+  });
+
+  await page.goto("/");
+
+  const badge = page.getByTestId("active-workflows-badge");
+  await expect(badge).toHaveText("2");
+  await expect(badge).toHaveAttribute("aria-expanded", "false");
+
+  activeExecutions = allActiveExecutions;
+  await page.clock.fastForward(10_000);
+  await expect.poll(() => requestCount).toBeGreaterThanOrEqual(2);
+  await expect(badge).toHaveText("5");
+
+  await badge.click();
+  const dropdown = page.getByTestId("active-workflows-dropdown");
+  const scrollArea = page.getByTestId("active-workflows-scroll-area");
+  await expect(dropdown).toBeVisible();
+  await expect(dropdown.getByRole("menuitem")).toHaveCount(5);
+  await expect(badge).toHaveAttribute("aria-expanded", "true");
+  expect(
+    await scrollArea.evaluate((element) => element.scrollHeight > element.clientHeight),
+  ).toBe(true);
+
+  await page
+    .getByRole("menuitem", { name: "Open Running workflow 2 live view" })
+    .click();
+  await expect(page).toHaveURL(
+    "/workflows/20000000-0000-4000-8000-000000000002/10000000-0000-4000-8000-000000000002",
+  );
+});
+
+test("keeps the zero state non-interactive and hides the badge on mobile", async ({ page }) => {
+  await page.route("**/api/workflows/executions/active", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/");
+
+  const counter = page.getByTestId("active-workflows-counter");
+  await expect(page.getByTestId("active-workflows-badge-empty")).toHaveText("0");
+  await expect(counter.getByRole("button")).toHaveCount(0);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(counter).toHaveCount(0);
+});
+
+test("shows a non-interactive error badge when the initial refresh fails", async ({ page }) => {
+  await page.route("**/api/workflows/executions/active", async (route) => {
+    await route.fulfill({
+      status: 503,
+      json: { detail: "Active workflow status is temporarily unavailable" },
+    });
+  });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/");
+
+  const counter = page.getByTestId("active-workflows-counter");
+  await expect(page.getByTestId("active-workflows-badge-error")).toBeVisible();
+  await expect(counter.getByRole("button")).toHaveCount(0);
+});

--- a/frontend/e2e/active-workflows-badge.spec.ts
+++ b/frontend/e2e/active-workflows-badge.spec.ts
@@ -12,12 +12,16 @@ interface ActiveExecutionFixture {
   node_results: [];
 }
 
-function makeActiveExecution(index: number): ActiveExecutionFixture {
+function makeActiveExecution(
+  index: number,
+  workflowIndex = index,
+): ActiveExecutionFixture {
   const suffix = String(index).padStart(12, "0");
+  const workflowSuffix = String(workflowIndex).padStart(12, "0");
   return {
     execution_id: `10000000-0000-4000-8000-${suffix}`,
-    workflow_id: `20000000-0000-4000-8000-${suffix}`,
-    workflow_name: `Running workflow ${index}`,
+    workflow_id: `20000000-0000-4000-8000-${workflowSuffix}`,
+    workflow_name: `Running workflow ${workflowIndex}`,
     started_at: new Date(Date.UTC(2026, 0, 1, 12, index)).toISOString(),
     inputs: {},
     running_node_ids: [`node-${index}`],
@@ -34,7 +38,7 @@ test("polls, scrolls active workflows, and opens a live workflow", async ({ page
   await page.clock.install();
 
   const allActiveExecutions = Array.from({ length: 5 }, (_, index) =>
-    makeActiveExecution(index + 1),
+    makeActiveExecution(index + 1, index < 3 ? 1 : index + 1),
   );
   let activeExecutions = allActiveExecutions.slice(0, 2);
   let requestCount = 0;
@@ -48,6 +52,12 @@ test("polls, scrolls active workflows, and opens a live workflow", async ({ page
   const badge = page.getByTestId("active-workflows-badge");
   await expect(badge).toHaveText("2");
   await expect(badge).toHaveAttribute("aria-expanded", "false");
+  expect(
+    await badge.evaluate((element) => {
+      const bounds = element.getBoundingClientRect();
+      return Math.abs(bounds.width - bounds.height) < 0.5;
+    }),
+  ).toBe(true);
 
   activeExecutions = allActiveExecutions;
   await page.clock.fastForward(10_000);
@@ -65,10 +75,10 @@ test("polls, scrolls active workflows, and opens a live workflow", async ({ page
   ).toBe(true);
 
   await page
-    .getByRole("menuitem", { name: "Open Running workflow 2 live view" })
+    .getByRole("menuitem", { name: "Open Running workflow 4 live view" })
     .click();
   await expect(page).toHaveURL(
-    "/workflows/20000000-0000-4000-8000-000000000002/10000000-0000-4000-8000-000000000002",
+    "/workflows/20000000-0000-4000-8000-000000000004/10000000-0000-4000-8000-000000000004",
   );
 });
 
@@ -81,7 +91,7 @@ test("keeps the zero state non-interactive and hides the badge on mobile", async
   await page.goto("/");
 
   const counter = page.getByTestId("active-workflows-counter");
-  await expect(page.getByTestId("active-workflows-badge-empty")).toHaveText("0");
+  await expect(counter).toHaveCSS("height", "0px");
   await expect(counter.getByRole("button")).toHaveCount(0);
 
   await page.setViewportSize({ width: 390, height: 844 });

--- a/frontend/src/components/Layout/ActiveWorkflowsBadge.vue
+++ b/frontend/src/components/Layout/ActiveWorkflowsBadge.vue
@@ -24,17 +24,7 @@ let requestInFlight = false;
 let requestGeneration = 0;
 let isUnmounted = false;
 
-const activeWorkflows = computed<ActiveExecutionItem[]>(() => {
-  const workflowsById = new Map<string, ActiveExecutionItem>();
-  for (const execution of executions.value) {
-    if (!workflowsById.has(execution.workflow_id)) {
-      workflowsById.set(execution.workflow_id, execution);
-    }
-  }
-  return Array.from(workflowsById.values());
-});
-
-const activeWorkflowCount = computed((): number => activeWorkflows.value.length);
+const activeWorkflowCount = computed((): number => executions.value.length);
 const badgeTitle = computed((): string => {
   if (refreshFailed.value) {
     return activeWorkflowCount.value > 0
@@ -160,24 +150,14 @@ onUnmounted(() => {
       <CircleAlert class="h-4 w-4" />
     </span>
 
-    <span
-      v-else-if="activeWorkflowCount === 0"
-      class="flex h-9 w-9 cursor-default items-center justify-center rounded-full border border-border/70 bg-muted/45 text-xs font-semibold tabular-nums text-muted-foreground"
-      :title="badgeTitle"
-      aria-label="No active workflows"
-      data-testid="active-workflows-badge-empty"
-    >
-      0
-    </span>
-
     <DropdownMenuRoot
-      v-else
+      v-else-if="activeWorkflowCount > 0"
       v-model:open="isOpen"
     >
       <DropdownMenuTrigger as-child>
         <button
           type="button"
-          class="group relative flex h-9 w-9 items-center justify-center rounded-full border border-emerald-500/35 bg-emerald-500/12 text-xs font-bold tabular-nums text-emerald-700 shadow-sm shadow-emerald-500/10 outline-none transition-all duration-200 hover:-translate-y-0.5 hover:border-emerald-500/55 hover:bg-emerald-500/18 hover:shadow-md focus-visible:ring-2 focus-visible:ring-emerald-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-emerald-300"
+          class="active-workflows-badge group relative flex items-center justify-center border border-emerald-500/35 bg-emerald-500/12 text-xs font-bold tabular-nums text-emerald-700 shadow-sm shadow-emerald-500/10 outline-none transition-all duration-200 hover:-translate-y-0.5 hover:border-emerald-500/55 hover:bg-emerald-500/18 hover:shadow-md focus-visible:ring-2 focus-visible:ring-emerald-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-emerald-300"
           :aria-label="`${activeWorkflowCount} active workflows. Open live workflow list`"
           :title="badgeTitle"
           data-testid="active-workflows-badge"
@@ -191,10 +171,20 @@ onUnmounted(() => {
       </DropdownMenuTrigger>
 
       <ActiveWorkflowsDropdown
-        :workflows="activeWorkflows"
+        :workflows="executions"
         :refresh-failed="refreshFailed"
         @select="openLiveWorkflow"
       />
     </DropdownMenuRoot>
   </div>
 </template>
+
+<style scoped>
+.active-workflows-badge {
+  aspect-ratio: 1 / 1;
+  block-size: 2.25rem;
+  flex: 0 0 2.25rem;
+  inline-size: 2.25rem;
+  border-radius: 50%;
+}
+</style>

--- a/frontend/src/components/Layout/ActiveWorkflowsBadge.vue
+++ b/frontend/src/components/Layout/ActiveWorkflowsBadge.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from "vue";
+import { useMediaQuery } from "@vueuse/core";
+import { CircleAlert, LoaderCircle } from "lucide-vue-next";
+import { DropdownMenuRoot, DropdownMenuTrigger } from "radix-vue";
+import { useRouter } from "vue-router";
+
+import type { ActiveExecutionItem } from "@/types/workflow";
+import ActiveWorkflowsDropdown from "@/components/Layout/ActiveWorkflowsDropdown.vue";
+import { workflowApi } from "@/services/api";
+
+const POLL_INTERVAL_MS = 10_000;
+
+const router = useRouter();
+const isDesktop = useMediaQuery("(min-width: 768px)");
+const executions = ref<ActiveExecutionItem[]>([]);
+const isOpen = ref(false);
+const hasLoaded = ref(false);
+const isInitialLoading = ref(false);
+const refreshFailed = ref(false);
+
+let pollingInterval: number | null = null;
+let requestInFlight = false;
+let requestGeneration = 0;
+let isUnmounted = false;
+
+const activeWorkflows = computed<ActiveExecutionItem[]>(() => {
+  const workflowsById = new Map<string, ActiveExecutionItem>();
+  for (const execution of executions.value) {
+    if (!workflowsById.has(execution.workflow_id)) {
+      workflowsById.set(execution.workflow_id, execution);
+    }
+  }
+  return Array.from(workflowsById.values());
+});
+
+const activeWorkflowCount = computed((): number => activeWorkflows.value.length);
+const badgeTitle = computed((): string => {
+  if (refreshFailed.value) {
+    return activeWorkflowCount.value > 0
+      ? `${activeWorkflowCount.value} active workflows · Latest refresh failed`
+      : "Active workflows unavailable";
+  }
+  if (activeWorkflowCount.value === 0) {
+    return "No active workflows";
+  }
+  return `${activeWorkflowCount.value} active workflows`;
+});
+
+async function refreshActiveWorkflows(): Promise<void> {
+  if (!isDesktop.value || requestInFlight) return;
+
+  requestInFlight = true;
+  const generation = ++requestGeneration;
+  if (!hasLoaded.value) {
+    isInitialLoading.value = true;
+  }
+
+  try {
+    const response = await workflowApi.getActiveExecutions();
+    if (isUnmounted || generation !== requestGeneration || !isDesktop.value) return;
+    executions.value = response;
+    hasLoaded.value = true;
+    refreshFailed.value = false;
+  } catch {
+    if (isUnmounted || generation !== requestGeneration || !isDesktop.value) return;
+    refreshFailed.value = true;
+  } finally {
+    requestInFlight = false;
+    if (generation === requestGeneration) {
+      isInitialLoading.value = false;
+    }
+  }
+}
+
+function stopPolling(): void {
+  if (pollingInterval !== null) {
+    window.clearInterval(pollingInterval);
+    pollingInterval = null;
+  }
+  requestGeneration += 1;
+}
+
+function startPolling(): void {
+  stopPolling();
+  void refreshActiveWorkflows();
+  pollingInterval = window.setInterval(() => {
+    void refreshActiveWorkflows();
+  }, POLL_INTERVAL_MS);
+}
+
+function openLiveWorkflow(workflow: ActiveExecutionItem): void {
+  isOpen.value = false;
+  void router.push({
+    name: "editor",
+    params: {
+      id: workflow.workflow_id,
+      executionId: workflow.execution_id,
+    },
+  });
+}
+
+watch(
+  isDesktop,
+  (desktop) => {
+    if (desktop) {
+      startPolling();
+      return;
+    }
+    isOpen.value = false;
+    stopPolling();
+  },
+  { immediate: true },
+);
+
+watch(activeWorkflowCount, (count) => {
+  if (count === 0) {
+    isOpen.value = false;
+  }
+});
+
+onUnmounted(() => {
+  isUnmounted = true;
+  stopPolling();
+});
+</script>
+
+<template>
+  <div
+    v-if="isDesktop"
+    class="relative flex items-center"
+    data-testid="active-workflows-counter"
+  >
+    <span
+      class="sr-only"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {{ activeWorkflowCount }} active workflows
+    </span>
+
+    <span
+      v-if="isInitialLoading"
+      class="flex h-9 w-9 items-center justify-center rounded-full border border-border/70 bg-muted/40 text-muted-foreground"
+      aria-label="Loading active workflows"
+      title="Loading active workflows"
+      data-testid="active-workflows-badge-loading"
+    >
+      <LoaderCircle class="h-4 w-4 animate-spin" />
+    </span>
+
+    <span
+      v-else-if="refreshFailed && !hasLoaded"
+      class="flex h-9 w-9 items-center justify-center rounded-full border border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+      aria-label="Active workflows unavailable"
+      title="Active workflows unavailable"
+      data-testid="active-workflows-badge-error"
+    >
+      <CircleAlert class="h-4 w-4" />
+    </span>
+
+    <span
+      v-else-if="activeWorkflowCount === 0"
+      class="flex h-9 w-9 cursor-default items-center justify-center rounded-full border border-border/70 bg-muted/45 text-xs font-semibold tabular-nums text-muted-foreground"
+      :title="badgeTitle"
+      aria-label="No active workflows"
+      data-testid="active-workflows-badge-empty"
+    >
+      0
+    </span>
+
+    <DropdownMenuRoot
+      v-else
+      v-model:open="isOpen"
+    >
+      <DropdownMenuTrigger as-child>
+        <button
+          type="button"
+          class="group relative flex h-9 w-9 items-center justify-center rounded-full border border-emerald-500/35 bg-emerald-500/12 text-xs font-bold tabular-nums text-emerald-700 shadow-sm shadow-emerald-500/10 outline-none transition-all duration-200 hover:-translate-y-0.5 hover:border-emerald-500/55 hover:bg-emerald-500/18 hover:shadow-md focus-visible:ring-2 focus-visible:ring-emerald-500/45 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-emerald-300"
+          :aria-label="`${activeWorkflowCount} active workflows. Open live workflow list`"
+          :title="badgeTitle"
+          data-testid="active-workflows-badge"
+        >
+          {{ activeWorkflowCount }}
+          <span class="absolute -right-0.5 -top-0.5 flex h-2.5 w-2.5">
+            <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60 motion-reduce:animate-none" />
+            <span class="relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500 ring-2 ring-background" />
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+
+      <ActiveWorkflowsDropdown
+        :workflows="activeWorkflows"
+        :refresh-failed="refreshFailed"
+        @select="openLiveWorkflow"
+      />
+    </DropdownMenuRoot>
+  </div>
+</template>

--- a/frontend/src/components/Layout/ActiveWorkflowsDropdown.vue
+++ b/frontend/src/components/Layout/ActiveWorkflowsDropdown.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+import {
+  DropdownMenuArrow,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+} from "radix-vue";
+import { Activity, ArrowUpRight, CircleAlert } from "lucide-vue-next";
+
+import type { ActiveExecutionItem } from "@/types/workflow";
+
+interface Props {
+  workflows: ActiveExecutionItem[];
+  refreshFailed?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  refreshFailed: false,
+});
+
+const emit = defineEmits<{
+  (event: "select", workflow: ActiveExecutionItem): void;
+}>();
+
+const startedAtFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+function formatStartedAt(value: string): string {
+  const startedAt = new Date(value);
+  if (Number.isNaN(startedAt.getTime())) {
+    return "Running now";
+  }
+  return `Started at ${startedAtFormatter.format(startedAt)}`;
+}
+</script>
+
+<template>
+  <DropdownMenuPortal>
+    <DropdownMenuContent
+      :side-offset="10"
+      :collision-padding="12"
+      align="end"
+      class="active-workflows-dropdown z-[200] w-80 overflow-hidden rounded-2xl border border-border/70 bg-popover/95 text-popover-foreground shadow-2xl shadow-slate-950/15 backdrop-blur-xl"
+      data-testid="active-workflows-dropdown"
+    >
+      <div class="flex items-center justify-between border-b border-border/60 px-4 py-3">
+        <div class="flex items-center gap-2">
+          <span class="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-500/12 text-emerald-600 dark:text-emerald-400">
+            <Activity class="h-4 w-4" />
+          </span>
+          <div>
+            <p class="text-sm font-semibold leading-tight">
+              Active workflows
+            </p>
+            <p class="mt-0.5 text-[11px] leading-tight text-muted-foreground">
+              Select a workflow to open its live view
+            </p>
+          </div>
+        </div>
+        <span class="rounded-full bg-emerald-500/12 px-2 py-0.5 text-xs font-semibold tabular-nums text-emerald-700 dark:text-emerald-300">
+          {{ workflows.length }}
+        </span>
+      </div>
+
+      <div
+        v-if="refreshFailed"
+        class="flex items-center gap-1.5 border-b border-amber-500/20 bg-amber-500/8 px-4 py-2 text-[11px] text-amber-700 dark:text-amber-300"
+        role="status"
+      >
+        <CircleAlert class="h-3.5 w-3.5 shrink-0" />
+        Showing the last successful update
+      </div>
+
+      <div
+        class="active-workflows-scroll max-h-[232px] overflow-y-auto overscroll-contain p-1"
+        data-testid="active-workflows-scroll-area"
+      >
+        <DropdownMenuItem
+          v-for="workflow in workflows"
+          :key="workflow.execution_id"
+          class="group flex h-14 cursor-pointer select-none items-center gap-3 rounded-xl px-3 outline-none transition-colors data-[highlighted]:bg-emerald-500/10 data-[highlighted]:text-foreground"
+          :aria-label="`Open ${workflow.workflow_name} live view`"
+          :data-testid="`active-workflow-${workflow.execution_id}`"
+          @select="emit('select', workflow)"
+        >
+          <span class="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">
+            <Activity class="h-4 w-4" />
+            <span class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-emerald-500 ring-2 ring-popover" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span
+              class="block truncate text-sm font-medium"
+              :title="workflow.workflow_name"
+            >
+              {{ workflow.workflow_name }}
+            </span>
+            <span class="mt-0.5 block text-[11px] text-muted-foreground">
+              {{ formatStartedAt(workflow.started_at) }}
+            </span>
+          </span>
+          <ArrowUpRight class="h-4 w-4 shrink-0 text-muted-foreground/60 transition-colors group-data-[highlighted]:text-emerald-600 dark:group-data-[highlighted]:text-emerald-400" />
+        </DropdownMenuItem>
+      </div>
+
+      <DropdownMenuArrow class="fill-popover stroke-border/70" />
+    </DropdownMenuContent>
+  </DropdownMenuPortal>
+</template>
+
+<style scoped>
+.active-workflows-dropdown {
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+}
+
+.active-workflows-dropdown[data-state="open"] {
+  animation: active-workflows-open 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.active-workflows-dropdown[data-state="closed"] {
+  animation: active-workflows-close 120ms ease-in;
+}
+
+.active-workflows-scroll {
+  scrollbar-color: hsl(var(--muted-foreground) / 0.35) transparent;
+  scrollbar-width: thin;
+}
+
+@keyframes active-workflows-open {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes active-workflows-close {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-3px) scale(0.98);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .active-workflows-dropdown[data-state] {
+    animation: none;
+  }
+}
+</style>

--- a/frontend/src/components/Layout/ActiveWorkflowsDropdown.vue
+++ b/frontend/src/components/Layout/ActiveWorkflowsDropdown.vue
@@ -74,7 +74,7 @@ function formatStartedAt(value: string): string {
       </div>
 
       <div
-        class="active-workflows-scroll max-h-[232px] overflow-y-auto overscroll-contain p-1"
+        class="active-workflows-scroll overflow-y-auto overscroll-contain p-1"
         data-testid="active-workflows-scroll-area"
       >
         <DropdownMenuItem
@@ -123,6 +123,7 @@ function formatStartedAt(value: string): string {
 }
 
 .active-workflows-scroll {
+  max-block-size: 14.5rem;
   scrollbar-color: hsl(var(--muted-foreground) / 0.35) transparent;
   scrollbar-width: thin;
 }

--- a/frontend/src/docs/content/tabs/workflows-tab.md
+++ b/frontend/src/docs/content/tabs/workflows-tab.md
@@ -13,6 +13,14 @@ The **Workflows** tab is the default dashboard view. It shows your workflow list
 - Use **Ctrl+click** (or **Cmd+click**) to open in a new tab
 - Pin frequently used workflows in the [Quick Drawer](../reference/quick-drawer.md) so you can run them quickly from the Workflows tab and other internal pages
 
+## Active Workflows
+
+On desktop, the circular badge in the top toolbar shows how many workflows are currently
+running and refreshes automatically every 10 seconds. Click a non-zero badge to open the active
+workflow list, which shows up to four rows before scrolling. Select a workflow name to attach the
+editor to that run's live view. The zero badge is informational and cannot be opened, and the
+badge is hidden on mobile screens.
+
 ## Search
 
 Use the workflow search field beside **New Folder**, or press **Ctrl+F** (or **Cmd+F**), to filter workflows by title or description. Matching workflows inside folders are shown with their folder branches expanded. Press **Escape** to clear the search.

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -42,6 +42,7 @@ import DockerLogsViewer from "@/components/LogsTab/DockerLogsViewer.vue";
 import FolderTreeItem from "@/components/Folders/FolderTreeItem.vue";
 import WorkflowFolderDropPlaceholder from "@/components/Folders/WorkflowFolderDropPlaceholder.vue";
 import GlobalVariablesPanel from "@/components/GlobalVariables/GlobalVariablesPanel.vue";
+import ActiveWorkflowsBadge from "@/components/Layout/ActiveWorkflowsBadge.vue";
 import AppHeader from "@/components/Layout/AppHeader.vue";
 import DashboardNav from "@/components/Layout/DashboardNav.vue";
 import WorkspaceShell from "@/components/Layout/WorkspaceShell.vue";
@@ -1421,6 +1422,9 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
   >
     <div class="min-h-screen bg-background overflow-x-hidden">
       <AppHeader :on-open-command-palette="() => { showCommandPalette = true; pushOverlayState(); }">
+        <template #before-docs>
+          <ActiveWorkflowsBadge v-if="activeTab === 'workflows'" />
+        </template>
         <template #actions>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Change Summary

- Count every running workflow instance, including concurrent runs of the same workflow.
- Collapse the zero state, enforce circular badge dimensions, and limit the dropdown to four visible rows before scrolling.
- Cover duplicate instances, navigation, overflow, zero/mobile behavior, and API results.

## Screenshots

![feature-workflow-counter-badge-active-workflows-counter.png](https://github.com/heymrun/heym/releases/download/codex-pr-assets/feature-workflow-counter-badge-active-workflows-counter.png)
