### PR TITLE
fix/hitl-approvals

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -4124,6 +4124,42 @@ class WorkflowExecutor:
         return any(re.search(pattern, lowered) for pattern in once_patterns)
 
     @staticmethod
+    def _hitl_policy_limits_to_single_review(policy_text: str) -> bool:
+        """True when the HITL instructions allow only one human-review pause per run.
+
+        Covers phrasings like "ask only once ... then never ask again". This governs the
+        generic `request_human_review` tool (a single pause for the whole run), distinct from
+        the per-tool MCP "once" scope handled by ``_resolve_mcp_approval_mode``.
+        """
+        lowered = (policy_text or "").lower()
+        if not lowered.strip():
+            return False
+        # "once per tool / per call / each" is the per-tool MCP scope, not a whole-run cap.
+        if re.search(r"\bonce\b\s*(?:per|for each|each|every)\b", lowered):
+            return False
+        single_review_patterns = (
+            r"\bnever ask again\b",
+            r"\bnever\b.{0,16}\bask\b.{0,16}\bagain\b",
+            r"\b(do not|don't|dont)\b.{0,16}\bask\b.{0,16}\bagain\b",
+            r"\bask\b.{0,24}\bonly once\b",
+            r"\bonly\b.{0,10}\bask\b.{0,10}\bonce\b",
+            r"\bjust once\b",
+            r"\bask\b.{0,24}\bfor (approval|review)\b.{0,24}\bonly once\b",
+        )
+        return any(re.search(pattern, lowered) for pattern in single_review_patterns)
+
+    def _build_single_review_consumed_tool_result(self) -> dict[str, str]:
+        return {
+            "status": "not_required",
+            "message": (
+                "Human review has already been completed once for this run. The HITL guidelines "
+                "for this agent say to ask only once and then never ask again, so this checkpoint "
+                "is already satisfied. Do not request human review again. Continue now and produce "
+                "the final answer directly using the already approved content."
+            ),
+        }
+
+    @staticmethod
     def _normalize_mcp_approval_mode(mode: str | None) -> str | None:
         normalized = (mode or "").strip().lower().replace("-", "_").replace(" ", "_")
         if normalized in {"always", "every_time", "each_time", "for_each", "on_each"}:
@@ -4551,8 +4587,15 @@ class WorkflowExecutor:
         node_id: str | None,
         hitl_fallback_summary: str | None = None,
         hitl_mcp_policy: dict | None = None,
+        hitl_suppress_after_first_review: bool = False,
     ) -> Callable:
-        """Build tool executor for agent nodes, including HITL, sub-agents, and sub-workflows."""
+        """Build tool executor for agent nodes, including HITL, sub-agents, and sub-workflows.
+
+        ``hitl_suppress_after_first_review`` is set on a resume when the node's HITL guidelines
+        allow only one review for the whole run and a prior checkpoint was already approved. It
+        makes further ``request_human_review`` calls resolve without pausing again, so a model
+        that ignores the "ask only once" instruction cannot loop back into another review.
+        """
 
         from app.services.llm_service import HumanReviewPause, _unified_tool_executor
 
@@ -4567,6 +4610,8 @@ class WorkflowExecutor:
             if tool_source == "hitl":
                 if edited_hitl_checkpoint is not None:
                     return self._build_edited_hitl_tool_result(edited_hitl_checkpoint)
+                if hitl_suppress_after_first_review:
+                    return self._build_single_review_consumed_tool_result()
                 review_markdown = str(
                     args.get("review_markdown") or args.get("markdown") or args.get("text") or ""
                 ).strip()
@@ -4815,6 +4860,11 @@ class WorkflowExecutor:
             else None
         )
 
+        # A "ask only once / never ask again" HITL policy caps the whole run to a single review.
+        hitl_single_review = hitl_enabled and self._hitl_policy_limits_to_single_review(
+            "\n\n".join(part for part in (base_system_instruction or "", hitl_guidelines) if part)
+        )
+
         skills = node_data.get("skills") or []
         skills_used: list[str] = [s.get("name", "") for s in skills if s.get("name")]
         skills_content_parts: list[str] = []
@@ -4912,6 +4962,35 @@ class WorkflowExecutor:
             edited_checkpoint_block = (
                 f"{edited_checkpoint_note}\n\n" if edited_checkpoint_note else ""
             )
+            # When the policy allows only one review, the resume prompt must not invite the model
+            # to ask again; otherwise it contradicts the "ask only once / never again" guideline.
+            if hitl_single_review:
+                resume_followup_clause = (
+                    "Do not request human review again for the rest of this run; the guidelines "
+                    "allow only one review. Continue and produce the final answer directly using "
+                    "the approved content."
+                )
+                review_context_followup = (
+                    "Do not request human review again; the guidelines allow only one review. "
+                    "Continue the task from here and finish without asking again."
+                )
+                task_followup_clause = (
+                    "Do not request another human review; only one review is allowed. Finish the "
+                    "task now using the approved plan."
+                )
+            else:
+                resume_followup_clause = (
+                    "If a different later step also requires human review, you may request another "
+                    "one at that point."
+                )
+                review_context_followup = (
+                    "If a later, different action still requires human review, you may request it "
+                    "again when needed."
+                )
+                task_followup_clause = (
+                    "You may ask for another human review later only if a different step genuinely "
+                    "requires it."
+                )
             approval_resume_text = (
                 "Human review decision received for a previous approval checkpoint.\n"
                 f"Decision: {hitl_decision}\n"
@@ -4921,16 +5000,14 @@ class WorkflowExecutor:
                 f"{edited_checkpoint_block}"
             ) + (
                 "Continue from this approved checkpoint. Do not repeat the same approval request "
-                "unless the approved plan materially changes. If a different later step also "
-                "requires human review, you may request another one at that point."
+                f"unless the approved plan materially changes. {resume_followup_clause}"
             )
             approval_resume_text = approval_resume_text.strip()
             review_context = (
                 "A human reviewer has already reviewed a prior checkpoint in this agent run.\n"
                 f"Decision: {hitl_decision}\n"
                 "Treat the approved Markdown below as the source of truth for that checkpoint.\n"
-                "Continue the task from there. If a later, different action still requires human "
-                "review, you may request it again when needed.\n\n"
+                f"Continue the task from there. {review_context_followup}\n\n"
                 f"{approved_markdown}"
             ).strip()
             if edited_checkpoint_note:
@@ -4944,8 +5021,8 @@ class WorkflowExecutor:
                 f"{edited_checkpoint_block}"
             ) + (
                 "Execute the approved plan now. Use tools, sub-agents, or sub-workflows only as "
-                "needed to carry it out. Do not repeat the exact same approval request. You may "
-                "ask for another human review later only if a different step genuinely requires it."
+                f"needed to carry it out. Do not repeat the exact same approval request. "
+                f"{task_followup_clause}"
             )
             user_message = user_message.strip()
             approval_history = [
@@ -5099,8 +5176,14 @@ class WorkflowExecutor:
                 "- `review_markdown`: a single Markdown body describing the plan or action to approve\n"
                 "- `reason`: the action currently blocked on human approval\n"
                 "If you omit `summary`, Heym derives one from the review Markdown.\n"
-                "You may call it multiple times in the same run if new approval-required steps "
-                "appear later."
+                + (
+                    "Request human review at most once for this entire run. After that single "
+                    "approval, continue and never request human review again; produce the final "
+                    "answer directly."
+                    if hitl_single_review
+                    else "You may call it multiple times in the same run if new approval-required "
+                    "steps appear later."
+                )
             )
             if system_instruction:
                 system_instruction = f"{system_instruction}\n\n{hitl_guidance}"
@@ -5402,11 +5485,18 @@ class WorkflowExecutor:
                     else:
                         attempt_system_instruction = interpreted_mcp_policy_hint
 
+            # Under a single-review policy, once a prior checkpoint has been approved/edited on
+            # this resume, suppress any further request_human_review pauses so the agent cannot
+            # loop back into another review of re-done work.
+            hitl_suppress_after_first_review = hitl_single_review and any(
+                str(entry.get("decision") or "") in {"accepted", "edited"} for entry in hitl_history
+            )
             custom_tool_executor = (
                 self._build_agent_tool_executor(
                     node_id=node_id,
                     hitl_fallback_summary=hitl_fallback_summary,
                     hitl_mcp_policy=effective_hitl_mcp_policy,
+                    hitl_suppress_after_first_review=hitl_suppress_after_first_review,
                 )
                 if needs_custom_executor
                 else None

--- a/backend/tests/test_agent_node_tools.py
+++ b/backend/tests/test_agent_node_tools.py
@@ -492,3 +492,69 @@ class TestAgentNodeToolIntegration(unittest.TestCase):
         self.assertEqual(drive_tool["_actor_user_id"], str(actor_user_id))
         self.assertIs(plain_tool["_drive_files_enabled"], False)
         self.assertIn("Drive files are enabled for this skill", captured_system_instructions[0])
+
+
+class TestHitlSingleReviewPolicy(unittest.TestCase):
+    """A HITL "ask only once / never ask again" policy must not re-pause after approval."""
+
+    def _make_executor(self) -> WorkflowExecutor:
+        ex = WorkflowExecutor.__new__(WorkflowExecutor)
+        ex.nodes = {}
+        ex.edges = []
+        ex.node_results = {}
+        ex.actor_user_id = None
+        ex.hitl_resume_context = {}
+        return ex
+
+    def test_policy_detection_single_review(self) -> None:
+        ex = self._make_executor()
+        single = (
+            "First prepare the post but before posting the final prepared tweet, ask only "
+            "once for approval then continue and never ask again."
+        )
+        multi = (
+            "Ask for human review before deleting records and before sending emails. "
+            "Different critical steps each need their own approval."
+        )
+        self.assertTrue(ex._hitl_policy_limits_to_single_review(single))
+        self.assertTrue(ex._hitl_policy_limits_to_single_review("Always ask only once using HITL."))
+        self.assertFalse(ex._hitl_policy_limits_to_single_review(multi))
+        self.assertFalse(ex._hitl_policy_limits_to_single_review(""))
+        # "once per step" is a per-tool/per-step scope, not a whole-run single review.
+        self.assertFalse(
+            ex._hitl_policy_limits_to_single_review(
+                "For each step, ask once per step for approval."
+            )
+        )
+
+    def test_executor_suppresses_second_review_after_first_approval(self) -> None:
+        from app.services.llm_service import HumanReviewPause
+
+        ex = self._make_executor()
+        tool_def = {"name": "request_human_review", "_source": "hitl"}
+        args = {
+            "review_markdown": "## Proposed Tweet\nAnother distinct tweet",
+            "reason": "Tweet proposal for multi-agent orchestration feature",
+        }
+
+        # Prior approval already happened AND policy is single-review -> do not pause again.
+        suppressed_executor = ex._build_agent_tool_executor(
+            node_id="n3",
+            hitl_fallback_summary="agent requires review.",
+            hitl_mcp_policy=None,
+            hitl_suppress_after_first_review=True,
+        )
+        result = suppressed_executor(tool_def, "request_human_review", args, 30.0)
+        self.assertNotIsInstance(result, HumanReviewPause)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("status"), "not_required")
+
+        # Without a satisfied single-review policy, the tool still pauses for review.
+        normal_executor = ex._build_agent_tool_executor(
+            node_id="n3",
+            hitl_fallback_summary="agent requires review.",
+            hitl_mcp_policy=None,
+            hitl_suppress_after_first_review=False,
+        )
+        pause = normal_executor(tool_def, "request_human_review", args, 30.0)
+        self.assertIsInstance(pause, HumanReviewPause)

--- a/frontend/e2e/active-workflows-badge.spec.ts
+++ b/frontend/e2e/active-workflows-badge.spec.ts
@@ -29,6 +29,34 @@ function makeActiveExecution(
   };
 }
 
+function makeWorkflowFixture(id: string, name: string): Record<string, unknown> {
+  const timestamp = new Date(Date.UTC(2026, 0, 1, 12, 0)).toISOString();
+  return {
+    id,
+    name,
+    description: null,
+    nodes: [],
+    edges: [],
+    auth_type: "jwt",
+    auth_header_key: null,
+    auth_header_value: null,
+    webhook_body_mode: "legacy",
+    allow_anonymous: false,
+    owner_id: "00000000-0000-4000-8000-000000000000",
+    cache_ttl_seconds: null,
+    rate_limit_requests: null,
+    rate_limit_window_seconds: null,
+    sse_enabled: false,
+    sse_node_config: {},
+    auto_recover_runs: false,
+    error_workflow_id: null,
+    minutes_saved_per_run: null,
+    workflow_timeout_seconds: null,
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+}
+
 test.beforeEach(async ({ page }) => {
   await prepareAuthenticatedPage(page);
 });
@@ -45,6 +73,15 @@ test("polls, scrolls active workflows, and opens a live workflow", async ({ page
   await page.route("**/api/workflows/executions/active", async (route) => {
     requestCount += 1;
     await route.fulfill({ json: activeExecutions });
+  });
+
+  // Opening a live workflow navigates to the editor, which loads the workflow and redirects
+  // back to the dashboard if that GET fails. The active-execution fixtures use synthetic ids
+  // that do not exist in the backend, so stub the workflow load to keep the editor mounted.
+  const liveWorkflowId = "20000000-0000-4000-8000-000000000004";
+  const liveExecutionId = "10000000-0000-4000-8000-000000000004";
+  await page.route(`**/api/workflows/${liveWorkflowId}`, async (route) => {
+    await route.fulfill({ json: makeWorkflowFixture(liveWorkflowId, "Running workflow 4") });
   });
 
   await page.goto("/");
@@ -77,9 +114,7 @@ test("polls, scrolls active workflows, and opens a live workflow", async ({ page
   await page
     .getByRole("menuitem", { name: "Open Running workflow 4 live view" })
     .click();
-  await expect(page).toHaveURL(
-    "/workflows/20000000-0000-4000-8000-000000000004/10000000-0000-4000-8000-000000000004",
-  );
+  await expect(page).toHaveURL(`/workflows/${liveWorkflowId}/${liveExecutionId}`);
 });
 
 test("keeps the zero state non-interactive and hides the badge on mobile", async ({ page }) => {


### PR DESCRIPTION
* feat: implement HITL single review policy and related functionality

Added a static method to detect HITL policies that allow only one human review per run. Updated the workflow executor to suppress further review requests after the first approval when such a policy is in effect. Enhanced the executor's behavior to provide appropriate follow-up messages based on the review policy. Added unit tests to validate the new functionality and ensure correct behavior under various scenarios.