### PR TITLE
fix: playwright typecheck error

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -14,12 +14,8 @@ const frontendPort = Number(process.env.E2E_FRONTEND_PORT || "4018");
 const backendPort = Number(process.env.E2E_BACKEND_PORT || "10106");
 const frontendUrl = `http://127.0.0.1:${frontendPort}`;
 const backendUrl = `http://127.0.0.1:${backendPort}`;
-
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL is required for Playwright E2E tests. Run ./run_e2e.sh from the repository root.",
-  );
-}
+const missingDatabaseUrlMessage =
+  "DATABASE_URL is required for Playwright E2E tests. Run ./run_e2e.sh from the repository root.";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -58,6 +54,7 @@ export default defineConfig({
     {
       command: [
         "cd ../backend &&",
+        `test -n "$DATABASE_URL" || { echo "${missingDatabaseUrlMessage}" >&2; exit 1; } &&`,
         "SECRET_KEY=e2e-test-secret-key-for-playwright-only",
         "ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
         `FRONTEND_URL=${frontendUrl}`,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -29,7 +29,8 @@
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
-    "src/**/*.vue"
+    "src/**/*.vue",
+    "playwright.config.ts"
   ],
   "references": [
     {

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
+    "types": ["node"],
     "outDir": "./node_modules/.tmp/vite-config",
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "strict": true


### PR DESCRIPTION
# Summary 

1. Move the `DATABASE_URL` check out of top-level `playwright.config.ts` into the backend webServer command, so config load / typecheck no longer throws when the env var is unset.
2. Include `playwright.config.ts` in frontend TypeScript checks and add Node types in `tsconfig.node.json` so the Playwright config is covered by bun run typecheck.
