### PR TITLE
fix/mcp-work-dir-issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,23 @@ HEYM_PYTHON_TOOL_SANDBOX=auto
 # Image used for the Docker sandbox. Empty = auto-detect the running backend image.
 HEYM_PYTHON_TOOL_IMAGE=
 
+# MCP stdio sandbox. Runs caller-supplied stdio commands in a hardened throwaway
+# container. Separate from HEYM_PYTHON_TOOL_SANDBOX above.
+#   auto/docker - Docker sandbox, fail-closed.
+#   subprocess  - runs on the backend host. NOT a security boundary.
+HEYM_MCP_STDIO_SANDBOX=auto
+# Empty = deployment default (Compose and the GHCR image both set it).
+HEYM_MCP_STDIO_IMAGE=
+# No Heym storage reaches MCP servers unless you name a volume or host dir here.
+HEYM_MCP_STDIO_FILES_VOLUME=
+HEYM_MCP_STDIO_FILES_SUBPATH=
+HEYM_MCP_STDIO_FILES_HOST_DIR=
+HEYM_MCP_STDIO_FILES_WRITABLE=false
+HEYM_MCP_STDIO_TMPFS_SIZE=512m
+HEYM_MCP_STDIO_MEMORY=512m
+HEYM_MCP_STDIO_CPUS=2
+HEYM_MCP_STDIO_PIDS=256
+
 # MCP egress guard (SSRF protection). When false (default), sse/streamable_http
 # MCP servers must resolve to a public address; loopback, private, link-local,
 # and cloud-metadata targets are refused. Set true only on trusted self-hosted

--- a/.github/workflows/publish-release-image.yml
+++ b/.github/workflows/publish-release-image.yml
@@ -71,6 +71,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             APP_VERSION=${{ steps.version.outputs.value }}
+            HEYM_RELEASE_IMAGE=ghcr.io/${{ github.repository_owner }}/heym:${{ steps.version.outputs.value }}
             VITE_HEYM_WEB_URL=${{ vars.HEYM_WEB_URL || 'https://heym.run' }}
             OCI_SOURCE=https://github.com/heymrun/heym
             OCI_URL=https://heym.run

--- a/ENVIRONMENT-VARIABLES.md
+++ b/ENVIRONMENT-VARIABLES.md
@@ -89,7 +89,7 @@ The Playwright node's **Run Code** mode (`playwrightCode`) is off by default. Wh
 |----------|-------------|---------|
 | `HEYM_PLAYWRIGHT_CUSTOM_CODE_ENABLED` | Allow executing custom `playwrightCode` / Run Code mode. | `false` |
 | `HEYM_PLAYWRIGHT_SANDBOX` | `auto`/`docker` (sibling container, fail-closed) or `subprocess` (in-process; trusted/local only). `./run.sh` sets `subprocess` when no image is configured. | `auto` |
-| `HEYM_PLAYWRIGHT_SANDBOX_IMAGE` | Sibling runner image. Compose defaults to `heym-backend:local`; GHCR release image defaults to `ghcr.io/heymrun/heym:<version>`. Empty falls back to `HEYM_CODEX_DOCKER_IMAGE`, then container inspect. | — |
+| `HEYM_PLAYWRIGHT_SANDBOX_IMAGE` | Sibling runner image. Compose defaults to `HEYM_BACKEND_IMAGE`; GHCR release image defaults to `ghcr.io/heymrun/heym:<version>`. Empty falls back to `HEYM_CODEX_DOCKER_IMAGE`, then container inspect. | — |
 | `HEYM_PLAYWRIGHT_SANDBOX_PYTHON` | Interpreter inside the sibling image. Empty auto-detects `/app/backend/.venv/bin/python` (GHCR) or `/app/.venv/bin/python` (Compose). | auto |
 
 ## Agent Python tool sandbox
@@ -130,6 +130,10 @@ A `docker run [flags] IMAGE [args]` command keeps working: Heym starts `IMAGE` i
 
 Inside the container the root filesystem is read-only and `/tmp` is a throwaway tmpfs, so the sandbox sets `HOME` and the npm/uv cache directories to paths under `/tmp` and mounts that tmpfs with `exec`. Without those, `npx` and `uvx` servers cannot run at all: the sandbox user's passwd home is `/nonexistent`, and Docker applies `noexec` to every `--tmpfs` that does not name `exec` explicitly. Values you set on the connection are applied after these defaults, so you can override them.
 
+The working directory is that same tmpfs, not the runner image's `WORKDIR`: `/app` in the backend image is the Heym backend project itself, so a `uv run …` server would try to sync it and fail on the read-only root filesystem. A `docker run IMAGE` command keeps its own image's `WORKDIR` unless it passes `-w`.
+
+These variables are wired through `docker-compose.yml`, so setting them in `.env` works for `./deploy.sh`.
+
 Only the env vars set on the connection reach the server. The backend's own environment (`SECRET_KEY`, `ENCRYPTION_KEY`, `DATABASE_URL`, provider API keys) is never forwarded; the MCP SDK supplies a safe default `PATH`/`HOME`/`SHELL`/`TERM`/`USER`/`LOGNAME` set on top.
 
 > **Operator-only escape hatches.** `HEYM_MCP_STDIO_SANDBOX=subprocess` and `HEYM_MCP_STDIO_FILES_HOST_DIR` are never settable by a workflow author, only by whoever runs the deployment. Both can remove the isolation this section describes, so treat them as trusted single-user / single-tenant options and leave them unset on anything multi-user.
@@ -137,7 +141,7 @@ Only the env vars set on the connection reach the server. The backend's own envi
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `HEYM_MCP_STDIO_SANDBOX` | Isolation for MCP `stdio` servers: `auto` (Docker required, fail-closed), `docker` (never falls back), or `subprocess`. Independent of `HEYM_PYTHON_TOOL_SANDBOX`. ⚠️ `subprocess` removes the boundary entirely and runs the caller's command on the backend host, which is the GHSA-378x-q589-34mv condition: **trusted single-user instances only, never on a shared or hosted deployment.** | `auto` |
-| `HEYM_MCP_STDIO_IMAGE` | Image used to run non-`docker` stdio commands (`npx`, `uvx`, `node`, `python`, …). Falls back to `HEYM_PYTHON_TOOL_IMAGE`, then `HEYM_CODEX_DOCKER_IMAGE` (which Compose and the single GHCR image both set), then `docker inspect` of the running backend container. If none resolve, stdio fails closed with an explanation rather than guessing a tag. The `docker run <image>` command form names its own image and is unaffected. | — |
+| `HEYM_MCP_STDIO_IMAGE` | Image used to run non-`docker` stdio commands (`npx`, `uvx`, `node`, `python`, …). Compose defaults it to `HEYM_BACKEND_IMAGE`, the GHCR image to its own release tag; set it only for native `run.sh` (`heym-backend:local`) or a custom runner. Falls back to `HEYM_PYTHON_TOOL_IMAGE`, then `HEYM_CODEX_DOCKER_IMAGE`, then container inspect, then fails closed. The `docker run <image>` form names its own image. | — |
 | `HEYM_MCP_STDIO_FILES_PATH` | Mount point inside the sandbox for the optional file mount below. | `/mnt/heym-files` |
 | `HEYM_MCP_STDIO_FILES_VOLUME` | Docker volume to expose to MCP servers. **Nothing is mounted unless you set this** (or the host-dir variant); there is no fallback to application volumes. | — |
 | `HEYM_MCP_STDIO_FILES_SUBPATH` | Mount only this subpath of the volume, so a shared volume can be scoped per tenant or per purpose. | — |
@@ -227,6 +231,7 @@ The [OpenCode Go node](frontend/src/docs/content/nodes/opencode-go-node.md) runs
 |----------|-------------|---------|
 | `HEYM_LLM_PRICING_SYNC_ENABLED` | Periodically sync model pricing data. | `true` |
 | `APP_VERSION` | Override the reported app version. Empty reads the `VERSION` file. | — |
+| `HEYM_BACKEND_IMAGE` | Compose only (`./deploy.sh`): tag the backend is built and run as. Every sibling sandbox image (MCP stdio, Playwright, Codex, OpenCode) defaults to it. | `heym-backend:local` |
 
 ## Frontend build-time
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ docker run \
 Open the editor in your browser at port `4017` in either setup.
 See [ENVIRONMENT-VARIABLES.md](ENVIRONMENT-VARIABLES.md) for the full list of configuration variables and their defaults.
 For direct `docker run` setups, the `data/files` mount keeps Drive uploads, skill-generated files, and team-shared Drive files available across container restarts. The `heym-codex-workspaces` volume is the shared workspace that Python skills (and the Codex node) run in as a hardened sibling container; keep it mounted or skill execution fails closed. Per-run sandbox isolation needs Docker Engine 25.0+.
-The Docker socket mount supports Docker-based MCP stdio tools and grants broad host control. Docker log access remains disabled unless you also set `DOCKER_LOGS_ENABLED=true` and `DOCKER_LOGS_ALLOWED_EMAILS=admin@example.com` for trusted users. Create the trusted admin account before enabling Docker logs, or keep `ALLOW_REGISTER=false`, so an unverified self-registration cannot claim an allow-listed email.
+The Docker socket mount lets Heym start hardened sibling containers and grants broad host control. Every MCP `stdio` server needs it, since the caller-supplied command always runs in a throwaway container rather than on the backend host; without a Docker daemon, stdio fails closed. Docker log access remains disabled unless you also set `DOCKER_LOGS_ENABLED=true` and `DOCKER_LOGS_ALLOWED_EMAILS=admin@example.com` for trusted users. Create the trusted admin account before enabling Docker logs, or keep `ALLOW_REGISTER=false`, so an unverified self-registration cannot claim an allow-listed email.
 
 ## Deploy & Call Workflows
 

--- a/backend/app/services/mcp_stdio_sandbox.py
+++ b/backend/app/services/mcp_stdio_sandbox.py
@@ -129,6 +129,9 @@ _DOCKER_REFUSED_FLAGS = {
 # mounted here unless an operator names a volume or host directory explicitly.
 _FILES_MOUNT_PATH = (os.getenv("HEYM_MCP_STDIO_FILES_PATH") or "").strip() or "/mnt/heym-files"
 
+# The only writable path in the sandbox, so also the only usable working directory.
+_SANDBOX_TMPFS_PATH = "/tmp"
+
 # Nobody:nogroup. Root in the sandbox is refused even if explicitly configured.
 _DEFAULT_SANDBOX_USER = "65534:65534"
 
@@ -257,12 +260,9 @@ def reset_docker_available_cache() -> None:
 def _sandbox_image() -> str | None:
     """Resolve the image used for non-``docker`` commands (it ships node and uv).
 
-    Mirrors the Playwright and Python tool runners so every deployment shape
-    works: an explicit override first, then the Codex/OpenCode runner image
-    (Compose and the GHCR release image both set ``HEYM_CODEX_DOCKER_IMAGE`` to
-    the backend image), then ``docker inspect`` of this container. Hardcoding a
-    Compose-only tag here would break the single GHCR image, where that tag does
-    not exist. Returns None when nothing resolves, so the caller can fail with an
+    Compose and the GHCR release image both set ``HEYM_MCP_STDIO_IMAGE``; the
+    Codex and ``docker inspect`` fallbacks cover deployments that do not.
+    Returns None when nothing resolves, so the caller can fail with an
     explanation instead of running ``docker run`` against a missing image.
     """
     override = (
@@ -350,7 +350,7 @@ def _sandbox_user() -> str:
     return f"{uid}:{gid}"
 
 
-def _hardening_flags(name: str, network: str = "bridge") -> list[str]:
+def _hardening_flags(name: str, network: str = "bridge", workdir: str | None = None) -> list[str]:
     """Flags shared by every sandboxed MCP server container.
 
     ``-i`` is mandatory: the MCP protocol is a bidirectional stream over the
@@ -373,6 +373,12 @@ def _hardening_flags(name: str, network: str = "bridge") -> list[str]:
     * cache directories. npm and uv both want to write under ``HOME`` or
       ``XDG_CACHE_HOME``; pointing them at the tmpfs keeps them off the
       read-only rootfs.
+
+    ``workdir`` is passed for the backend-image path only. The backend image's
+    WORKDIR is ``/app``, which *is* the Heym backend project, so ``uv run ...``
+    discovers it and dies syncing it against the read-only rootfs. Starting in
+    the tmpfs is a narrowing, not a loosening. The ``docker run IMAGE`` form
+    keeps its own image's WORKDIR.
     """
     return [
         "--rm",
@@ -383,7 +389,8 @@ def _hardening_flags(name: str, network: str = "bridge") -> list[str]:
         network,
         "--read-only",
         "--tmpfs",
-        f"/tmp:rw,exec,nosuid,size={_tunable('HEYM_MCP_STDIO_TMPFS_SIZE', '512m')}",
+        f"{_SANDBOX_TMPFS_PATH}:rw,exec,nosuid,size={_tunable('HEYM_MCP_STDIO_TMPFS_SIZE', '512m')}",
+        *(["--workdir", workdir] if workdir else []),
         "--env",
         "HOME=/tmp",
         "--env",
@@ -555,7 +562,13 @@ def build_sandboxed_command(
             "be resolved. Set HEYM_MCP_STDIO_IMAGE (or HEYM_PYTHON_TOOL_IMAGE) to the backend "
             "image, or use the `docker run <image>` form, which names its own image."
         )
-    argv = ["docker", "run", *_hardening_flags(name), "--entrypoint", command]
+    argv = [
+        "docker",
+        "run",
+        *_hardening_flags(name, workdir=_SANDBOX_TMPFS_PATH),
+        "--entrypoint",
+        command,
+    ]
     for key, value in (env or {}).items():
         argv.extend(["--env", f"{key}={value}"])
     argv.extend([image, *args])

--- a/backend/tests/test_mcp_stdio_sandbox.py
+++ b/backend/tests/test_mcp_stdio_sandbox.py
@@ -12,6 +12,7 @@ properties that keep that from being host command execution:
 
 import os
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -591,6 +592,125 @@ class ContainerRuntimeUsabilityTests(unittest.TestCase):
         with patch.dict(os.environ, {"HEYM_MCP_STDIO_TMPFS_SIZE": "1g"}):
             spec = self._tmpfs_spec(build_sandboxed_command("npx", [], None).argv)
         self.assertIn("size=1g", spec)
+
+
+class SandboxWorkingDirectoryTests(unittest.TestCase):
+    """The sandbox must not start in the backend image's own project directory.
+
+    /app is the Heym backend project, so `uv run ...` discovered it, tried to
+    sync it, and died on the read-only rootfs before speaking MCP.
+    """
+
+    def setUp(self) -> None:
+        reset_docker_available_cache()
+        self.addCleanup(reset_docker_available_cache)
+        self._patches = [
+            patch.dict(
+                os.environ,
+                {
+                    "HEYM_MCP_STDIO_SANDBOX": "docker",
+                    "HEYM_MCP_STDIO_IMAGE": "heym-backend:local",
+                },
+            ),
+            patch("app.services.mcp_stdio_sandbox.docker_available", return_value=True),
+        ]
+        for p in self._patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_backend_image_commands_start_in_the_writable_tmpfs(self) -> None:
+        for command in ("uv", "uvx", "npx", "node", "python"):
+            with self.subTest(command=command):
+                argv = build_sandboxed_command(command, ["run"], None).argv
+                self.assertEqual(_flag_value(argv, "--workdir"), "/tmp")
+
+    def test_workdir_is_the_tmpfs_mount_point(self) -> None:
+        """A workdir outside the tmpfs would be read-only, so the two must agree."""
+        argv = build_sandboxed_command("uv", ["run", "server"], None).argv
+        workdir = _flag_value(argv, "--workdir") or ""
+        self.assertTrue((_flag_value(argv, "--tmpfs") or "").startswith(f"{workdir}:"))
+
+    def test_workdir_is_never_the_backend_project_directory(self) -> None:
+        argv = build_sandboxed_command("uv", ["run", "server"], None).argv
+        self.assertNotIn(_flag_value(argv, "--workdir"), ("/app", "/app/backend"))
+
+    def test_moving_the_workdir_did_not_loosen_the_sandbox(self) -> None:
+        argv = build_sandboxed_command("uv", ["run", "server"], None).argv
+        self.assertIn("--read-only", argv)
+        self.assertEqual(_flag_value(argv, "--cap-drop"), "ALL")
+        self.assertEqual(_flag_value(argv, "--user"), "65534:65534")
+        self.assertNotIn("docker.sock", " ".join(argv))
+
+    def test_docker_run_form_keeps_its_own_image_workdir(self) -> None:
+        """Only Heym's image has the /app collision; caller images keep theirs."""
+        argv = build_sandboxed_command("docker", ["run", "mcp/fetch"], None).argv
+        self.assertIsNone(_flag_value(argv, "--workdir"))
+
+    def test_docker_run_form_honours_an_explicit_caller_workdir(self) -> None:
+        argv = build_sandboxed_command("docker", ["run", "-w", "/srv/app", "mcp/fetch"], None).argv
+        self.assertEqual(_flag_value(argv, "--workdir"), "/srv/app")
+
+
+class DeploymentWiringTests(unittest.TestCase):
+    """Every HEYM_MCP_STDIO_* knob must actually reach the backend container.
+
+    Compose forwards nothing it has not declared, so a documented variable
+    missing from docker-compose.yml is silently inert under ./deploy.sh.
+    """
+
+    _REPO_ROOT = Path(__file__).resolve().parents[2]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._compose = (cls._REPO_ROOT / "docker-compose.yml").read_text()
+        cls._release_dockerfile = (cls._REPO_ROOT / "docker" / "release.Dockerfile").read_text()
+
+    def test_compose_declares_every_documented_knob(self) -> None:
+        for var in (
+            "HEYM_MCP_STDIO_SANDBOX",
+            "HEYM_MCP_STDIO_IMAGE",
+            "HEYM_MCP_STDIO_FILES_PATH",
+            "HEYM_MCP_STDIO_FILES_VOLUME",
+            "HEYM_MCP_STDIO_FILES_SUBPATH",
+            "HEYM_MCP_STDIO_FILES_HOST_DIR",
+            "HEYM_MCP_STDIO_FILES_WRITABLE",
+            "HEYM_MCP_STDIO_TMPFS_SIZE",
+            "HEYM_MCP_STDIO_MEMORY",
+            "HEYM_MCP_STDIO_CPUS",
+            "HEYM_MCP_STDIO_PIDS",
+            "HEYM_MCP_STDIO_USER",
+        ):
+            with self.subTest(var=var):
+                # assertTrue, not assertIn: assertIn dumps the whole compose file.
+                self.assertTrue(
+                    f"{var}: " in self._compose,
+                    f"{var} is documented but docker-compose.yml never declares it",
+                )
+
+    def test_compose_sandbox_image_follows_the_backend_image(self) -> None:
+        """A deployment that repoints the backend must not chase a tag it never built."""
+        self.assertTrue(
+            "HEYM_MCP_STDIO_IMAGE: "
+            "${HEYM_MCP_STDIO_IMAGE:-${HEYM_BACKEND_IMAGE:-heym-backend:local}}" in self._compose,
+            "Compose must default the MCP stdio sandbox image to HEYM_BACKEND_IMAGE",
+        )
+
+    def test_release_image_names_its_own_sandbox_image(self) -> None:
+        self.assertTrue(
+            "HEYM_MCP_STDIO_IMAGE=${HEYM_RELEASE_IMAGE}" in self._release_dockerfile,
+            "the single GHCR image must name its own MCP stdio sandbox image",
+        )
+
+    def test_release_self_reference_is_never_a_dangling_tag(self) -> None:
+        """An argless local build must not bake in `ghcr.io/heymrun/heym:`."""
+        self.assertTrue(
+            "ARG HEYM_RELEASE_IMAGE=ghcr.io/heymrun/heym:latest" in self._release_dockerfile,
+            "the release self-reference needs a valid default for argless local builds",
+        )
+        self.assertFalse(
+            "ghcr.io/heymrun/heym:${APP_VERSION}" in self._release_dockerfile,
+            "APP_VERSION is empty on local builds, so it must not be used as an image tag",
+        )
 
 
 class DockerRunRewriteTests(unittest.TestCase):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,13 +72,13 @@ services:
       # in-process path for trusted / local dev only.
       HEYM_PLAYWRIGHT_CUSTOM_CODE_ENABLED: ${HEYM_PLAYWRIGHT_CUSTOM_CODE_ENABLED:-false}
       HEYM_PLAYWRIGHT_SANDBOX: ${HEYM_PLAYWRIGHT_SANDBOX:-auto}
-      # Same default as HEYM_BACKEND_IMAGE / Codex runner so sibling sandbox
-      # resolution does not depend on `docker inspect` of the container hostname.
-      HEYM_PLAYWRIGHT_SANDBOX_IMAGE: ${HEYM_PLAYWRIGHT_SANDBOX_IMAGE:-heym-backend:local}
+      # Sibling sandbox images follow HEYM_BACKEND_IMAGE, so repointing the
+      # backend does not leave them chasing a tag this deployment never built.
+      HEYM_PLAYWRIGHT_SANDBOX_IMAGE: ${HEYM_PLAYWRIGHT_SANDBOX_IMAGE:-${HEYM_BACKEND_IMAGE:-heym-backend:local}}
       # Codex node: run Codex CLI in a dedicated sibling runner container so
       # bubblewrap sandboxing works inside Docker without exposing backend secrets.
       HEYM_CODEX_CLI_COMMAND: ${HEYM_CODEX_CLI_COMMAND:-/usr/local/bin/heym-codex-docker}
-      HEYM_CODEX_DOCKER_IMAGE: ${HEYM_CODEX_DOCKER_IMAGE:-heym-backend:local}
+      HEYM_CODEX_DOCKER_IMAGE: ${HEYM_CODEX_DOCKER_IMAGE:-${HEYM_BACKEND_IMAGE:-heym-backend:local}}
       HEYM_CODEX_DOCKER_WORKSPACE_VOLUME: ${HEYM_CODEX_DOCKER_WORKSPACE_VOLUME:-heym-codex-workspaces}
       HEYM_CODEX_WORKSPACE_DIR: ${HEYM_CODEX_WORKSPACE_DIR:-/app/data/codex-workspaces}
       HEYM_CODEX_NETWORK_ACCESS: ${HEYM_CODEX_NETWORK_ACCESS:-true}
@@ -87,7 +87,7 @@ services:
       # OpenCode Go node: run the OpenCode CLI in a dedicated hardened sibling runner container
       # sharing the workspace named volume (mirrors the Codex setup).
       HEYM_OPENCODE_CLI_COMMAND: ${HEYM_OPENCODE_CLI_COMMAND:-/usr/local/bin/heym-opencode-docker}
-      HEYM_OPENCODE_DOCKER_IMAGE: ${HEYM_OPENCODE_DOCKER_IMAGE:-heym-backend:local}
+      HEYM_OPENCODE_DOCKER_IMAGE: ${HEYM_OPENCODE_DOCKER_IMAGE:-${HEYM_BACKEND_IMAGE:-heym-backend:local}}
       HEYM_OPENCODE_DOCKER_WORKSPACE_VOLUME: ${HEYM_OPENCODE_DOCKER_WORKSPACE_VOLUME:-heym-opencode-workspaces}
       HEYM_OPENCODE_WORKSPACE_DIR: ${HEYM_OPENCODE_WORKSPACE_DIR:-/app/data/opencode-workspaces}
       HEYM_OPENCODE_DOCKER_CPUS: ${HEYM_OPENCODE_DOCKER_CPUS:-2}
@@ -97,6 +97,21 @@ services:
       # Empty image = auto-detect this backend image.
       HEYM_PYTHON_TOOL_SANDBOX: ${HEYM_PYTHON_TOOL_SANDBOX:-auto}
       HEYM_PYTHON_TOOL_IMAGE: ${HEYM_PYTHON_TOOL_IMAGE:-}
+      # MCP stdio sandbox (GHSA-378x-q589-34mv). Its own setting, independent of
+      # HEYM_PYTHON_TOOL_SANDBOX. Declared here because Compose forwards nothing
+      # it has not declared; blank means "use the default".
+      HEYM_MCP_STDIO_SANDBOX: ${HEYM_MCP_STDIO_SANDBOX:-auto}
+      HEYM_MCP_STDIO_IMAGE: ${HEYM_MCP_STDIO_IMAGE:-${HEYM_BACKEND_IMAGE:-heym-backend:local}}
+      HEYM_MCP_STDIO_FILES_VOLUME: ${HEYM_MCP_STDIO_FILES_VOLUME:-}
+      HEYM_MCP_STDIO_FILES_SUBPATH: ${HEYM_MCP_STDIO_FILES_SUBPATH:-}
+      HEYM_MCP_STDIO_FILES_HOST_DIR: ${HEYM_MCP_STDIO_FILES_HOST_DIR:-}
+      HEYM_MCP_STDIO_FILES_PATH: ${HEYM_MCP_STDIO_FILES_PATH:-}
+      HEYM_MCP_STDIO_FILES_WRITABLE: ${HEYM_MCP_STDIO_FILES_WRITABLE:-}
+      HEYM_MCP_STDIO_TMPFS_SIZE: ${HEYM_MCP_STDIO_TMPFS_SIZE:-}
+      HEYM_MCP_STDIO_MEMORY: ${HEYM_MCP_STDIO_MEMORY:-}
+      HEYM_MCP_STDIO_CPUS: ${HEYM_MCP_STDIO_CPUS:-}
+      HEYM_MCP_STDIO_PIDS: ${HEYM_MCP_STDIO_PIDS:-}
+      HEYM_MCP_STDIO_USER: ${HEYM_MCP_STDIO_USER:-}
       # OpenTelemetry tracing. When run inside compose, the backend reaches the
       # bundled Jaeger by its service name (not localhost, which is the host-only
       # value used by run.sh). Toggle with HEYM_OTEL_ENABLED in .env.

--- a/docker/release.Dockerfile
+++ b/docker/release.Dockerfile
@@ -84,6 +84,11 @@ RUN pip install uv
 ARG APP_VERSION
 ENV APP_VERSION=${APP_VERSION}
 
+# Image the sibling sandboxes below start. The release workflow passes the
+# published tag; the default keeps an argless local build from baking in a
+# dangling `ghcr.io/heymrun/heym:` (APP_VERSION is empty there).
+ARG HEYM_RELEASE_IMAGE=ghcr.io/heymrun/heym:latest
+
 ARG OCI_SOURCE=https://github.com/heymrun/heym
 ARG OCI_URL=https://heym.run
 ARG OCI_DOCUMENTATION_URL=https://github.com/heymrun/heym
@@ -119,13 +124,14 @@ COPY docker/heym-codex-docker /usr/local/bin/heym-codex-docker
 RUN cd /app/backend && uv run python -m playwright install --with-deps chromium
 
 ENV HEYM_CODEX_CLI_COMMAND=/usr/local/bin/heym-codex-docker \
-    HEYM_CODEX_DOCKER_IMAGE=ghcr.io/heymrun/heym:${APP_VERSION} \
+    HEYM_CODEX_DOCKER_IMAGE=${HEYM_RELEASE_IMAGE} \
     HEYM_CODEX_DOCKER_WORKSPACE_VOLUME=heym-codex-workspaces \
     HEYM_CODEX_NETWORK_ACCESS=true \
     HEYM_CODEX_WORKSPACE_DIR=/app/data/codex-workspaces \
-    HEYM_SKILL_IMAGE=ghcr.io/heymrun/heym:${APP_VERSION} \
-    HEYM_PLAYWRIGHT_SANDBOX_IMAGE=ghcr.io/heymrun/heym:${APP_VERSION} \
-    HEYM_PLAYWRIGHT_SANDBOX_PYTHON=/app/backend/.venv/bin/python
+    HEYM_SKILL_IMAGE=${HEYM_RELEASE_IMAGE} \
+    HEYM_PLAYWRIGHT_SANDBOX_IMAGE=${HEYM_RELEASE_IMAGE} \
+    HEYM_PLAYWRIGHT_SANDBOX_PYTHON=/app/backend/.venv/bin/python \
+    HEYM_MCP_STDIO_IMAGE=${HEYM_RELEASE_IMAGE}
 
 RUN chmod +x /app/release-entrypoint.sh /usr/local/bin/heym-codex-docker
 


### PR DESCRIPTION
* feat: add MCP stdio sandbox configuration to .env and docker-compose 

- Introduced new environment variables for MCP stdio sandbox in .env.example, including settings for image, file volume, and resource limits.
- Updated docker-compose.yml to reference the new MCP stdio sandbox variables, ensuring proper configuration for sibling containers.
- Enhanced documentation in ENVIRONMENT-VARIABLES.md to reflect the new variables and their usage.
- Added tests to verify the correct wiring of MCP stdio settings in the deployment process.