### PR TITLE
impl/expression-dialog-and-gdrive

### DIFF
--- a/backend/app/services/google_drive_service.py
+++ b/backend/app/services/google_drive_service.py
@@ -175,9 +175,7 @@ class GoogleDriveService:
         files: list[dict[str, Any]] = []
         page_token = ""
         while max_results is None or len(files) < max_results:
-            remaining = (
-                _MAX_PAGE_SIZE if max_results is None else max_results - len(files)
-            )
+            remaining = _MAX_PAGE_SIZE if max_results is None else max_results - len(files)
             params: dict[str, Any] = {
                 "q": " and ".join(clauses),
                 "pageSize": min(remaining, _MAX_PAGE_SIZE),

--- a/backend/app/services/google_drive_service.py
+++ b/backend/app/services/google_drive_service.py
@@ -154,11 +154,16 @@ class GoogleDriveService:
     def list_folder_files(
         self,
         folder_id: str,
-        max_results: int = 100,
+        max_results: int | None = 100,
         query: str = "",
         include_trashed: bool = False,
     ) -> dict:
-        """List files inside a folder. Empty folder_id lists the Drive root."""
+        """List files inside a folder. Empty folder_id lists the Drive root.
+
+        Pass ``max_results=None`` to page through the entire folder (Drive pageSize
+        is still capped at 1000 per request). Each file includes ``size_bytes`` when
+        Google reports a size (folders and Google-native docs are ``null``).
+        """
         target = parse_drive_id(folder_id) or "root"
         clauses = [f"'{target}' in parents"]
         if not include_trashed:
@@ -169,8 +174,10 @@ class GoogleDriveService:
 
         files: list[dict[str, Any]] = []
         page_token = ""
-        while len(files) < max_results:
-            remaining = max_results - len(files)
+        while max_results is None or len(files) < max_results:
+            remaining = (
+                _MAX_PAGE_SIZE if max_results is None else max_results - len(files)
+            )
             params: dict[str, Any] = {
                 "q": " and ".join(clauses),
                 "pageSize": min(remaining, _MAX_PAGE_SIZE),
@@ -206,7 +213,8 @@ class GoogleDriveService:
             if not page_token:
                 break
 
-        files = files[:max_results]
+        if max_results is not None:
+            files = files[:max_results]
         return {
             "status": "success",
             "operation": "listFolderFiles",

--- a/backend/app/services/node_execution/nodes/google_drive_node.py
+++ b/backend/app/services/node_execution/nodes/google_drive_node.py
@@ -157,13 +157,21 @@ def execute(ctx: NodeExecutionContext) -> object:
         service = GoogleDriveService(credential_id, gd_config, db)
 
         if operation == "listFolderFiles":
-            raw_max = field("gdMaxResults", "100")
-            try:
-                max_results = int(float(raw_max or "100"))
-            except (ValueError, TypeError):
-                max_results = 100
-            if max_results < 1:
-                max_results = 100
+            raw_max_value = node_data.get("gdMaxResults")
+            if raw_max_value is None:
+                max_results: int | None = 100
+            else:
+                stripped = field("gdMaxResults").strip()
+                # Empty or 0 = page through the entire folder (optional unlimited listing).
+                if stripped == "" or stripped == "0":
+                    max_results = None
+                else:
+                    try:
+                        max_results = int(float(stripped))
+                    except (ValueError, TypeError):
+                        max_results = 100
+                    if max_results < 1:
+                        max_results = 100
             return service.list_folder_files(
                 field("gdFolderId"),
                 max_results=max_results,

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -4376,7 +4376,7 @@ Use ONLY: `str()`, `int()`, `float()`, `bool()`, `list()`, `dict(key=value)`, `l
   - `gdOperation`: Operation type - "listFolderFiles" | "downloadFile" | "syncToHeymDrive" | "updateFile" | "removeFile" | "removeFolder"
   - `gdFolderId`: Folder ID or full Drive folder URL (listFolderFiles, removeFolder). Empty means the Drive root. Supports expressions.
   - `gdFileId`: File ID or full Drive/Docs URL (downloadFile, syncToHeymDrive, updateFile, removeFile). Supports expressions.
-  - `gdMaxResults`: for `listFolderFiles` — maximum files to return, default 100. Supports expressions.
+  - `gdMaxResults`: for `listFolderFiles` — maximum files to return, default 100. Empty or `0` pages through the entire folder. Supports expressions.
   - `gdQuery`: for `listFolderFiles` — optional extra Drive query ANDed with the parent filter, e.g. `mimeType='application/pdf'`. Supports expressions.
   - `gdIncludeTrashed`: boolean, optional for `listFolderFiles` — when true, trashed files are included. Default false.
   - `gdExportFormat`: for `downloadFile` and `syncToHeymDrive` — optional `"pdf"` | `"docx"` | `"xlsx"` | `"pptx"` | `"csv"` | `"txt"`. Empty means automatic. Ignored for non-Google-native files.

--- a/backend/tests/test_google_drive_node.py
+++ b/backend/tests/test_google_drive_node.py
@@ -302,7 +302,7 @@ class TestBlankOptionalFields(GoogleDriveNodeTestBase):
         self.assertEqual(kwargs["new_parent_id"], "")
         self.assertIsNone(kwargs["content"])
 
-    def test_blank_max_results_falls_back_to_default(self) -> None:
+    def test_blank_max_results_fetches_all(self) -> None:
         from app.services.node_execution.nodes import google_drive_node
 
         self.service.list_folder_files.return_value = {"status": "success"}
@@ -315,7 +315,22 @@ class TestBlankOptionalFields(GoogleDriveNodeTestBase):
                 }
             )
         )
-        self.assertEqual(self.service.list_folder_files.call_args.kwargs["max_results"], 100)
+        self.assertIsNone(self.service.list_folder_files.call_args.kwargs["max_results"])
+
+    def test_zero_max_results_fetches_all(self) -> None:
+        from app.services.node_execution.nodes import google_drive_node
+
+        self.service.list_folder_files.return_value = {"status": "success"}
+        google_drive_node.execute(
+            _ctx(
+                {
+                    "credentialId": "cred-1",
+                    "gdOperation": "listFolderFiles",
+                    "gdMaxResults": "0",
+                }
+            )
+        )
+        self.assertIsNone(self.service.list_folder_files.call_args.kwargs["max_results"])
 
     def test_expressions_still_resolve(self) -> None:
         """The blank-field guard must not stop real templates from being evaluated."""

--- a/backend/tests/test_google_drive_service.py
+++ b/backend/tests/test_google_drive_service.py
@@ -255,6 +255,30 @@ class TestListFolderFiles(unittest.TestCase):
 
         self.assertEqual(result["count"], 2)
 
+    def test_none_max_results_pages_until_exhausted(self) -> None:
+        service = _valid_service()
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            "files": [{"id": "f1", "name": "n1", "mimeType": "text/plain"}],
+            "nextPageToken": "token-2",
+        }
+        page2 = MagicMock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            "files": [{"id": "f2", "name": "n2", "mimeType": "text/plain"}],
+        }
+
+        with patch(
+            "app.services.google_drive_service.httpx.get", side_effect=[page1, page2]
+        ) as get:
+            result = service.list_folder_files("folder-1", max_results=None)
+
+        self.assertEqual(get.call_count, 2)
+        self.assertEqual(get.call_args_list[0].kwargs["params"]["pageSize"], 1000)
+        self.assertEqual(result["count"], 2)
+        self.assertEqual([f["id"] for f in result["files"]], ["f1", "f2"])
+
 
 class TestDownloadFile(unittest.TestCase):
     def test_binary_file_uses_alt_media(self) -> None:

--- a/frontend/src/components/Panels/propertiesPanel/nodes/GoogleDriveNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/GoogleDriveNodeProperties.vue
@@ -133,11 +133,11 @@ const {
       <!-- listFolderFiles extras -->
       <template v-if="selectedNode.data.gdOperation === 'listFolderFiles'">
         <div class="space-y-2">
-          <Label>Max Results</Label>
+          <Label>Max Results (optional)</Label>
           <ExpressionInput
             ref="googleDriveMaxResultsExpressionInputRef"
-            :model-value="selectedNode.data.gdMaxResults || '100'"
-            placeholder="100"
+            :model-value="selectedNode.data.gdMaxResults ?? '100'"
+            placeholder="100 — leave empty or 0 for all"
             :nodes="workflowStore.nodes"
             :node-results="workflowStore.nodeResults"
             :edges="workflowStore.edges"
@@ -152,6 +152,10 @@ const {
             @register-field-index="onGoogleDriveRegisterExpressionFieldIndex"
             @update:model-value="updateNodeData('gdMaxResults', $event)"
           />
+          <p class="text-xs text-muted-foreground">
+            Caps how many files are returned. Empty or <code>0</code> loads the whole folder
+            (paged). Each file includes <code>size_bytes</code> when Drive reports a size.
+          </p>
         </div>
 
         <div class="space-y-2">

--- a/frontend/src/components/ui/ExpressionInput.vue
+++ b/frontend/src/components/ui/ExpressionInput.vue
@@ -189,6 +189,15 @@ const dialogSelectionEnd = ref(0);
 const dialogHistory = ref<DialogHistoryEntry[]>([]);
 const dialogHistoryIndex = ref(-1);
 const applyingDialogHistory = ref(false);
+const navigatorPlatformIsMac = computed((): boolean => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  return (
+    navigator.platform.toLowerCase().startsWith("mac") ||
+    navigator.userAgent.includes("Mac")
+  );
+});
 const lastRunRequestNodeResults = ref<EvaluatedNodeResultInput[] | null>(null);
 const lastRunDialogSnapshot = ref<string | null>(null);
 const lastInspectedSignature = ref<string | null>(null);
@@ -1492,7 +1501,8 @@ function handleDialogShortcutKeyDown(event: KeyboardEvent): void {
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
-    applyDialogChanges({ closeDialog: false });
+    // Match the Apply button: write the value back and close the dialog.
+    applyDialogChanges();
     return;
   }
 
@@ -2438,6 +2448,7 @@ defineExpose({
         />
 
         <div
+          data-expression-evaluate-dialog
           class="pointer-events-auto relative z-10 mx-3 flex h-[min(92dvh,900px)] w-[min(96vw,1400px)] flex-col overflow-hidden rounded-lg border bg-background shadow-2xl sm:mx-4"
         >
           <div
@@ -2938,10 +2949,14 @@ defineExpose({
               </button>
               <button
                 type="button"
-                class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                class="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                :title="navigatorPlatformIsMac ? 'Apply (⌘Enter)' : 'Apply (Ctrl+Enter)'"
                 @click="applyDialogChanges()"
               >
                 Apply
+                <span class="text-[11px] font-normal tracking-wide text-primary-foreground/90">{{
+                  navigatorPlatformIsMac ? "⌘↵" : "⌃↵"
+                }}</span>
               </button>
             </div>
           </div>

--- a/frontend/src/docs/content/nodes/google-drive-node.md
+++ b/frontend/src/docs/content/nodes/google-drive-node.md
@@ -21,7 +21,7 @@ The **Google Drive** node lists, downloads, updates, and deletes files and folde
 | `gdOperation` | string | Operation: `listFolderFiles`, `downloadFile`, `syncToHeymDrive`, `updateFile`, `removeFile`, `removeFolder` |
 | `gdFolderId` | expression | Folder ID or full Drive folder URL. Used by `listFolderFiles` and `removeFolder`. Empty means the Drive root. |
 | `gdFileId` | expression | File ID or full Drive/Docs URL. Used by `downloadFile`, `syncToHeymDrive`, `updateFile`, `removeFile`. |
-| `gdMaxResults` | expression | For `listFolderFiles`: maximum files to return (default 100). |
+| `gdMaxResults` | expression | For `listFolderFiles`: max files to return (default 100). Empty or `0` loads the whole folder via paging. Each listed file includes `size_bytes` when Drive reports a size. |
 | `gdQuery` | expression | For `listFolderFiles`: extra Drive query ANDed with the folder filter, e.g. `mimeType='application/pdf'`. |
 | `gdIncludeTrashed` | boolean | For `listFolderFiles`: include trashed files. Default false. |
 | `gdExportFormat` | string | For `downloadFile` / `syncToHeymDrive`: `pdf`, `docx`, `xlsx`, `pptx`, `csv`, `txt`. Empty means automatic. Ignored for regular files. |

--- a/frontend/src/docs/content/reference/expression-evaluation-dialog.md
+++ b/frontend/src/docs/content/reference/expression-evaluation-dialog.md
@@ -14,7 +14,7 @@ The Expression Evaluation Dialog is the expanded editor for expression-capable f
 - The header shows **Evaluate — {field name}** when the field label is known.
 - The editor keeps autocomplete, field-to-field navigation, and the usual **Apply** / **Cancel** actions.
 - The preview refreshes automatically about **300 ms** after you stop typing.
-- Press `Ctrl` / `Cmd` + `Enter` to apply the current text back to the field without closing the dialog.
+- Press `Ctrl` / `Cmd` + `Enter` to apply the current text back to the field and close the dialog (same as **Apply**).
 
 ## Output Section
 
@@ -88,7 +88,7 @@ The generator receives the node outputs from the last test run on the canvas. If
 | Shortcut | Action |
 |---|---|
 | Typing pause (~300 ms) | Refresh backend preview |
-| `Ctrl` / `Cmd` + `Enter` | Apply without closing |
+| `Ctrl` / `Cmd` + `Enter` | Apply and close the dialog |
 | `Escape` | Close autocomplete first, otherwise close the dialog |
 
 ## Nested `$` in method arguments

--- a/frontend/src/docs/content/reference/keyboard-shortcuts.md
+++ b/frontend/src/docs/content/reference/keyboard-shortcuts.md
@@ -85,7 +85,7 @@ These shortcuts are active while the Evaluate dialog is open.
 
 | Shortcut | Action |
 |----------|--------|
-| `Ctrl + Enter` / `Cmd + Enter` | Run the evaluator |
+| `Ctrl + Enter` / `Cmd + Enter` | Apply expression and close the dialog |
 | `Ctrl + Z` / `Cmd + Z` | Undo changes in the expression editor |
 | `Ctrl + Shift + Z` / `Cmd + Shift + Z` | Redo changes in the expression editor |
 | `Ctrl + Y` / `Cmd + Y` | Redo changes in the expression editor (alternate) |

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -517,9 +517,13 @@ function isTypingTarget(target: EventTarget | null): boolean {
 async function handleKeyDown(event: KeyboardEvent): Promise<void> {
   const isMeta = event.metaKey || event.ctrlKey;
 
-  // Run Workflow: Ctrl+Enter — works even when an input/textarea is focused
+  // Run Workflow: Ctrl+Enter — works even when an input/textarea is focused.
+  // Expression evaluate dialog owns this shortcut while open (apply + close).
   if (isMeta && event.key === "Enter") {
     if (showCommandPalette.value) {
+      return;
+    }
+    if (document.querySelector("[data-expression-evaluate-dialog]")) {
       return;
     }
     event.preventDefault();


### PR DESCRIPTION
* Enhance file listing with pagination and documentation updates

- Updated `list_folder_files` method to accept `max_results` as `None`, allowing pagination through all files in a folder.
- Adjusted related logic in the Google Drive node execution to handle `gdMaxResults` as `None` or `0` for unlimited results.
- Improved documentation to clarify the behavior of `max_results` and added tests to ensure correct functionality for edge cases.