### PR TITLE
impl/evaluator-iteration

### DIFF
--- a/backend/app/api/expressions.py
+++ b/backend/app/api/expressions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -40,6 +41,11 @@ router = APIRouter()
 # Enough room for brief reasoning plus long expressions; low values truncate completions and break parsing.
 EXPRESSION_GENERATE_MAX_OUTPUT_TOKENS = 8192
 
+# One keystroke can offer a full method list; cap the batch so a single request stays bounded.
+COMPLETION_PREVIEW_MAX_EXPRESSIONS = 40
+# Previews sit on one dropdown row, so keep them short instead of shipping whole payloads.
+COMPLETION_PREVIEW_MAX_CHARS = 160
+
 
 class NodeResultItem(BaseModel):
     """A node result supplied by the frontend canvas after a test run."""
@@ -49,16 +55,44 @@ class NodeResultItem(BaseModel):
     output: Any
 
 
-class ExpressionEvaluateRequest(BaseModel):
-    """Request payload for the unified expression evaluator endpoint."""
+class ExpressionContextRequest(BaseModel):
+    """Evaluation context shared by the evaluate and completion-preview endpoints."""
 
-    expression: str = Field(..., max_length=EXPRESSION_MAX_LENGTH)
     workflow_id: UUID
     current_node_id: str
     field_name: str | None = None
     input_body: Any = None
     selected_loop_iteration_index: int | None = None
     node_results: list[NodeResultItem] = Field(default_factory=list)
+
+
+class ExpressionEvaluateRequest(ExpressionContextRequest):
+    """Request payload for the unified expression evaluator endpoint."""
+
+    expression: str = Field(..., max_length=EXPRESSION_MAX_LENGTH)
+
+
+class ExpressionCompletionPreviewRequest(ExpressionContextRequest):
+    """Candidate expressions from the autocomplete dropdown, one per suggestion row."""
+
+    expressions: list[str] = Field(
+        default_factory=list,
+        max_length=COMPLETION_PREVIEW_MAX_EXPRESSIONS,
+    )
+
+
+class ExpressionCompletionPreviewItem(BaseModel):
+    """Preview for one candidate; `preview` is null when the candidate has no answer."""
+
+    expression: str
+    preview: str | None = None
+    result_type: str | None = None
+
+
+class ExpressionCompletionPreviewResponse(BaseModel):
+    """Previews in the same order as the requested expressions."""
+
+    previews: list[ExpressionCompletionPreviewItem]
 
 
 class ExpressionGeneratePriorAttempt(BaseModel):
@@ -286,18 +320,23 @@ async def get_workflow_by_id(
     return await get_workflow_for_user(db, workflow_id, user.id)
 
 
-@router.post(
-    "/evaluate",
-    response_model=ExpressionEvaluateResponse,
-    status_code=status.HTTP_200_OK,
-)
-async def evaluate_expression(
-    request: ExpressionEvaluateRequest,
+@dataclass
+class EvaluationSetup:
+    """Everything needed to evaluate expressions for one canvas evaluation request."""
+
+    service: ExpressionEvaluatorService
+    context: dict[str, Any]
+    workflow_nodes: list[Any]
+    workflow_edges: list[Any]
+
+
+async def build_evaluation_setup(
+    request: ExpressionContextRequest,
     http_request: Request,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-) -> ExpressionEvaluateResponse:
-    """Evaluate an expression or template using pinned data and last-run node outputs."""
+    db: AsyncSession,
+    current_user: User,
+) -> EvaluationSetup:
+    """Load the workflow and build the evaluator context shared by both evaluate endpoints."""
     workflow = await get_workflow_by_id(request.workflow_id, db, current_user)
     if workflow is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found")
@@ -343,19 +382,112 @@ async def evaluate_expression(
         workflow_description=workflow.description or "",
         public_base_url=build_public_base_url(http_request),
     )
-    response = service.evaluate(
+    return EvaluationSetup(
+        service=service,
+        context=context,
+        workflow_nodes=workflow_nodes,
+        workflow_edges=workflow_edges,
+    )
+
+
+def format_completion_preview(
+    evaluated: ExpressionEvaluateResponse,
+    expression: str,
+) -> str | None:
+    """Render a one-line example answer, or None when the candidate produced no answer."""
+    if evaluated.error is not None or evaluated.result is None:
+        return None
+
+    value = evaluated.result
+    # Unresolved references echo the source text back; that is not an answer worth showing.
+    if isinstance(value, str) and value.strip() == expression.strip():
+        return None
+
+    try:
+        rendered = json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        rendered = str(value)
+
+    collapsed = " ".join(rendered.split())
+    if not collapsed:
+        return None
+    if len(collapsed) > COMPLETION_PREVIEW_MAX_CHARS:
+        return collapsed[: COMPLETION_PREVIEW_MAX_CHARS - 1] + "…"
+    return collapsed
+
+
+@router.post(
+    "/evaluate",
+    response_model=ExpressionEvaluateResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def evaluate_expression(
+    request: ExpressionEvaluateRequest,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ExpressionEvaluateResponse:
+    """Evaluate an expression or template using pinned data and last-run node outputs."""
+    setup = await build_evaluation_setup(request, http_request, db, current_user)
+    response = setup.service.evaluate(
         request.expression,
-        context,
+        setup.context,
         current_node_id=request.current_node_id,
     )
     response.selected_loop_total = get_selected_loop_total(
-        workflow_nodes,
-        workflow_edges,
+        setup.workflow_nodes,
+        setup.workflow_edges,
         request.current_node_id,
-        context,
-        service,
+        setup.context,
+        setup.service,
     )
     return response
+
+
+@router.post(
+    "/completion-previews",
+    response_model=ExpressionCompletionPreviewResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def preview_completion_expressions(
+    request: ExpressionCompletionPreviewRequest,
+    http_request: Request,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> ExpressionCompletionPreviewResponse:
+    """Evaluate autocomplete candidates so the dialog can show an example answer per suggestion."""
+    if not request.expressions:
+        return ExpressionCompletionPreviewResponse(previews=[])
+
+    setup = await build_evaluation_setup(request, http_request, db, current_user)
+
+    previews: list[ExpressionCompletionPreviewItem] = []
+    for expression in request.expressions:
+        candidate = expression.strip()
+        if not candidate or len(candidate) > EXPRESSION_MAX_LENGTH:
+            previews.append(ExpressionCompletionPreviewItem(expression=expression))
+            continue
+
+        try:
+            evaluated = setup.service.evaluate(
+                candidate,
+                setup.context,
+                current_node_id=request.current_node_id,
+            )
+        except Exception:
+            # A broken candidate is expected here - it must leave its row blank, not fail the batch.
+            previews.append(ExpressionCompletionPreviewItem(expression=expression))
+            continue
+
+        previews.append(
+            ExpressionCompletionPreviewItem(
+                expression=expression,
+                preview=format_completion_preview(evaluated, candidate),
+                result_type=evaluated.result_type if evaluated.error is None else None,
+            )
+        )
+
+    return ExpressionCompletionPreviewResponse(previews=previews)
 
 
 @router.post(

--- a/backend/tests/test_expression_evaluator_api.py
+++ b/backend/tests/test_expression_evaluator_api.py
@@ -5,7 +5,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-from app.api.expressions import ExpressionEvaluateRequest, evaluate_expression
+from app.api.expressions import (
+    COMPLETION_PREVIEW_MAX_CHARS,
+    COMPLETION_PREVIEW_MAX_EXPRESSIONS,
+    ExpressionCompletionPreviewRequest,
+    ExpressionEvaluateRequest,
+    evaluate_expression,
+    format_completion_preview,
+    preview_completion_expressions,
+)
+from app.services.expression_evaluator import ExpressionEvaluateResponse
 
 
 class ExpressionEvaluateApiTests(unittest.IsolatedAsyncioTestCase):
@@ -623,6 +632,189 @@ class ExpressionEvaluateApiTests(unittest.IsolatedAsyncioTestCase):
                 current_node_id=self.current_node_id,
                 node_results=[],
             )
+
+
+class ExpressionCompletionPreviewApiTests(unittest.IsolatedAsyncioTestCase):
+    """Autocomplete rows show an example answer per suggestion, blank when there is none."""
+
+    def setUp(self) -> None:
+        self.user = MagicMock()
+        self.user.id = uuid.uuid4()
+        self.workflow_id = uuid.uuid4()
+        self.current_node_id = "node-target"
+        self.db = AsyncMock()
+
+    def _workflow(self, pinned: dict) -> MagicMock:
+        workflow = MagicMock()
+        workflow.id = self.workflow_id
+        workflow.owner_id = self.user.id
+        workflow.nodes = [
+            {
+                "id": "node-upstream",
+                "type": "set",
+                "data": {"label": "set", "pinnedData": pinned},
+            },
+            {"id": self.current_node_id, "type": "output", "data": {"label": "finalOutput"}},
+        ]
+        workflow.edges = [{"id": "e1", "source": "node-upstream", "target": self.current_node_id}]
+        return workflow
+
+    def _request(self, expressions: list[str]) -> ExpressionCompletionPreviewRequest:
+        return ExpressionCompletionPreviewRequest(
+            expressions=expressions,
+            workflow_id=self.workflow_id,
+            current_node_id=self.current_node_id,
+            field_name="mapped",
+            input_body=None,
+            selected_loop_iteration_index=None,
+            node_results=[],
+        )
+
+    def _http_request(self) -> MagicMock:
+        req = MagicMock()
+        req.headers.get.return_value = None
+        return req
+
+    async def _preview(self, pinned: dict, expressions: list[str]) -> list:
+        workflow = self._workflow(pinned)
+        with (
+            patch("app.api.expressions.get_workflow_by_id", AsyncMock(return_value=workflow)),
+            patch("app.api.expressions.get_credentials_context", AsyncMock(return_value={})),
+            patch(
+                "app.api.expressions.get_global_variables_context",
+                AsyncMock(return_value={}),
+            ),
+        ):
+            response = await preview_completion_expressions(
+                self._request(expressions),
+                http_request=self._http_request(),
+                db=self.db,
+                current_user=self.user,
+            )
+        return response.previews
+
+    async def test_route_is_registered(self) -> None:
+        from app.main import app
+
+        paths = {route.path for route in app.router.routes}
+        self.assertIn("/api/expressions/completion-previews", paths)
+
+    async def test_previews_follow_request_order(self) -> None:
+        previews = await self._preview(
+            {"listItems": [1, 2, 3, 4, 5], "title": "hey"},
+            [
+                "$set.listItems.length",
+                "$set.listItems.first()",
+                "$set.title.upper()",
+            ],
+        )
+
+        self.assertEqual(
+            [item.expression for item in previews],
+            ["$set.listItems.length", "$set.listItems.first()", "$set.title.upper()"],
+        )
+        self.assertEqual([item.preview for item in previews], ["5", "1", '"HEY"'])
+
+    async def test_chained_method_candidate_is_previewed(self) -> None:
+        previews = await self._preview(
+            {"listItems": [1, 2, 3, 4, 5]},
+            ["$set.listItems.first().toString().upper()"],
+        )
+
+        self.assertEqual(previews[0].preview, '"1"')
+        self.assertEqual(previews[0].result_type, "string")
+
+    async def test_unresolvable_candidate_leaves_row_blank(self) -> None:
+        previews = await self._preview(
+            {"listItems": [1, 2, 3]},
+            ["$set.listItems.notARealMethod()", "$set.missingKey"],
+        )
+
+        self.assertIsNone(previews[0].preview)
+        self.assertIsNone(previews[1].preview)
+
+    async def test_blank_candidates_are_skipped(self) -> None:
+        previews = await self._preview({"title": "hey"}, ["", "   ", "$set.title"])
+
+        self.assertEqual([item.preview for item in previews], [None, None, '"hey"'])
+
+    async def test_long_preview_is_truncated_to_one_line(self) -> None:
+        previews = await self._preview(
+            {"text": "line one\nline    two " + ("x" * 400)},
+            ["$set.text"],
+        )
+
+        preview = previews[0].preview
+        self.assertIsNotNone(preview)
+        self.assertEqual(len(preview), COMPLETION_PREVIEW_MAX_CHARS)
+        self.assertTrue(preview.endswith("…"))
+        # A dropdown row is one line: newlines stay JSON-escaped and runs of spaces collapse.
+        self.assertNotIn("\n", preview)
+        self.assertIn("line one\\nline two", preview)
+
+    async def test_empty_expressions_skips_workflow_lookup(self) -> None:
+        lookup = AsyncMock()
+        with patch("app.api.expressions.get_workflow_by_id", lookup):
+            response = await preview_completion_expressions(
+                self._request([]),
+                http_request=self._http_request(),
+                db=self.db,
+                current_user=self.user,
+            )
+
+        self.assertEqual(response.previews, [])
+        lookup.assert_not_awaited()
+
+    async def test_workflow_not_found_returns_404(self) -> None:
+        with patch("app.api.expressions.get_workflow_by_id", AsyncMock(return_value=None)):
+            with self.assertRaises(HTTPException) as context:
+                await preview_completion_expressions(
+                    self._request(["$set.title"]),
+                    http_request=self._http_request(),
+                    db=self.db,
+                    current_user=self.user,
+                )
+
+        self.assertEqual(context.exception.status_code, 404)
+
+    def test_request_rejects_oversized_batch(self) -> None:
+        with self.assertRaises(ValidationError):
+            ExpressionCompletionPreviewRequest(
+                expressions=["$set.title"] * (COMPLETION_PREVIEW_MAX_EXPRESSIONS + 1),
+                workflow_id=self.workflow_id,
+                current_node_id=self.current_node_id,
+                node_results=[],
+            )
+
+    def test_format_drops_errors_nulls_and_echoed_source(self) -> None:
+        error_response = ExpressionEvaluateResponse(
+            result=None, result_type="null", preserved_type=False, error="boom"
+        )
+        null_response = ExpressionEvaluateResponse(
+            result=None, result_type="null", preserved_type=False, error=None
+        )
+        echo_response = ExpressionEvaluateResponse(
+            result="$set.title.nope()", result_type="string", preserved_type=False, error=None
+        )
+
+        self.assertIsNone(format_completion_preview(error_response, "$set.title"))
+        self.assertIsNone(format_completion_preview(null_response, "$set.title"))
+        self.assertIsNone(format_completion_preview(echo_response, "$set.title.nope()"))
+
+    def test_format_renders_values_as_compact_json(self) -> None:
+        def response(result: object, result_type: str) -> ExpressionEvaluateResponse:
+            return ExpressionEvaluateResponse(
+                result=result, result_type=result_type, preserved_type=True, error=None
+            )
+
+        self.assertEqual(format_completion_preview(response(5, "number"), "$set.n"), "5")
+        self.assertEqual(format_completion_preview(response(True, "boolean"), "$set.b"), "true")
+        self.assertEqual(
+            format_completion_preview(response([1, 2], "array"), "$set.items"), "[1, 2]"
+        )
+        self.assertEqual(
+            format_completion_preview(response({"a": "ç"}, "object"), "$set.obj"), '{"a": "ç"}'
+        )
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/ui/ExpressionInput.vue
+++ b/frontend/src/components/ui/ExpressionInput.vue
@@ -206,6 +206,12 @@ const lastRunNodeId = ref<string | null>(null);
 const finalResultCopied = ref(false);
 const forceOutputScrollTopOnNextUpdate = ref(false);
 const AUTO_EVALUATE_THROTTLE_MS = 250;
+const COMPLETION_PREVIEW_DEBOUNCE_MS = 180;
+/** Matches the backend batch cap so one keystroke never fans out into an unbounded request. */
+const COMPLETION_PREVIEW_MAX_CANDIDATES = 40;
+/** Candidate expression -> example answer; empty string means "evaluated, no answer to show". */
+const completionPreviews = ref<Map<string, string>>(new Map());
+const dialogSuggestionCursorPos = ref(0);
 /** True while openExpandDialog is applying dialogValue/showExpandDialog so batched watchers do not also schedule auto-eval. */
 const openingExpandDialog = ref(false);
 const hintWorkflowRunLoading = ref(false);
@@ -213,6 +219,8 @@ const suppressNextLoopSelectionAutoEvaluate = ref(false);
 const lastAutoEvaluateStartedAtMs = ref<number | null>(null);
 /** Cleared when opening the inline dropdown so a stale blur timeout cannot hide it (e.g. after Run hint). */
 let inlineBlurHideTimer: ReturnType<typeof setTimeout> | null = null;
+let completionPreviewTimer: ReturnType<typeof setTimeout> | null = null;
+let completionPreviewRequestId = 0;
 let pendingOutputBottomStickTimer: ReturnType<typeof setTimeout> | null = null;
 let autoEvaluateTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingAutoEvaluateShouldResetOutputPathPicker = false;
@@ -793,7 +801,7 @@ const showNavigation = computed((): boolean => props.navigationEnabled && props.
 const canNavigatePrev = computed((): boolean => props.navigationIndex > 0);
 const canNavigateNext = computed((): boolean => props.navigationIndex < props.navigationTotal - 1);
 
-const { getSuggestions, applyCompletion } = useExpressionCompletion({
+const { getSuggestions, applyCompletion, parseExpressionContext } = useExpressionCompletion({
   get nodes() {
     return props.nodes;
   },
@@ -873,8 +881,17 @@ watch(dialogValue, (): void => {
   scheduleExpressionEvaluation({ resetOutputPathPicker: true });
 });
 
+// Previews are answers against the current run data, so a new run or loop item invalidates them.
+watch([availableNodeResults, selectedLoopIterationIndex], (): void => {
+  resetCompletionPreviews();
+  if (showExpandDialog.value && showDialogDropdown.value) {
+    scheduleCompletionPreviews();
+  }
+});
+
 watch(showExpandDialog, (isOpen): void => {
   if (!isOpen) {
+    resetCompletionPreviews();
     clearAutoEvaluateTimer();
     pendingAutoEvaluateShouldResetOutputPathPicker = false;
     queuedEvaluateAfterCurrentRun = false;
@@ -1282,6 +1299,127 @@ function updateSuggestions(): void {
   }
 }
 
+/**
+ * Zero-argument calls and bare properties evaluate on their own, so they can be previewed.
+ * Argument-taking ones (map/filter/replace/...) only mean something once the user fills them in.
+ */
+function isPreviewableCompletion(suggestion: CompletionSuggestion): boolean {
+  if (suggestion.type === "hint") {
+    return false;
+  }
+  if (!suggestion.insertText.includes("(")) {
+    return true;
+  }
+  return /^[A-Za-z_][A-Za-z0-9_]*\(\)$/.test(suggestion.insertText);
+}
+
+/** The full `$…` expression this suggestion would produce, used as the preview cache key. */
+function completionPreviewExpression(suggestion: CompletionSuggestion): string | null {
+  const { newText, newCursorPos } = applyCompletion(
+    dialogValue.value,
+    dialogSuggestionCursorPos.value,
+    suggestion,
+  );
+  const match = findDollarExpressions(newText).find(
+    (expression) => newCursorPos >= expression.start && newCursorPos <= expression.end,
+  );
+  return match ? match.expr : null;
+}
+
+/** Candidate expression per dropdown row (null when that row cannot be previewed). */
+const dialogSuggestionPreviewExpressions = computed((): (string | null)[] => {
+  if (!showDialogDropdown.value || dialogSuggestions.value.length === 0) {
+    return [];
+  }
+
+  const context = parseExpressionContext(dialogValue.value, dialogSuggestionCursorPos.value);
+  // Only method/property chains on an existing `$…` reference resolve to a standalone value.
+  if (!context || context.triggerKind !== "property" || context.isInsideFilterExpr) {
+    return [];
+  }
+
+  return dialogSuggestions.value.map((suggestion) =>
+    isPreviewableCompletion(suggestion) ? completionPreviewExpression(suggestion) : null,
+  );
+});
+
+function dialogSuggestionPreview(index: number): string {
+  const expression = dialogSuggestionPreviewExpressions.value[index];
+  if (!expression) {
+    return "";
+  }
+  return completionPreviews.value.get(expression) ?? "";
+}
+
+function clearCompletionPreviewTimer(): void {
+  if (completionPreviewTimer !== null) {
+    clearTimeout(completionPreviewTimer);
+    completionPreviewTimer = null;
+  }
+}
+
+function resetCompletionPreviews(): void {
+  clearCompletionPreviewTimer();
+  completionPreviewRequestId += 1;
+  completionPreviews.value = new Map();
+}
+
+function scheduleCompletionPreviews(): void {
+  clearCompletionPreviewTimer();
+  completionPreviewTimer = setTimeout((): void => {
+    completionPreviewTimer = null;
+    void fetchCompletionPreviews();
+  }, COMPLETION_PREVIEW_DEBOUNCE_MS);
+}
+
+async function fetchCompletionPreviews(): Promise<void> {
+  const workflowId = workflowStore.currentWorkflow?.id;
+  const currentNodeId = props.currentNodeId;
+  if (!workflowId || !currentNodeId || !showExpandDialog.value || !showDialogDropdown.value) {
+    return;
+  }
+
+  const pending = [
+    ...new Set(
+      dialogSuggestionPreviewExpressions.value.filter(
+        (expression): expression is string =>
+          expression !== null && !completionPreviews.value.has(expression),
+      ),
+    ),
+  ].slice(0, COMPLETION_PREVIEW_MAX_CANDIDATES);
+  if (pending.length === 0) {
+    return;
+  }
+
+  const requestId = ++completionPreviewRequestId;
+  try {
+    const response = await expressionApi.previewCompletions({
+      expressions: pending,
+      workflow_id: workflowId,
+      current_node_id: currentNodeId,
+      field_name: props.dialogKeyLabel || undefined,
+      input_body: workflowStore.buildExecutionRequestBody(),
+      selected_loop_iteration_index: selectedLoopIterationIndex.value,
+      node_results: availableNodeResults.value.map((result) => ({
+        node_id: result.node_id,
+        label: result.node_label,
+        output: result.output,
+      })),
+    });
+    if (requestId !== completionPreviewRequestId) {
+      return;
+    }
+
+    const nextPreviews = new Map(completionPreviews.value);
+    for (const item of response.previews) {
+      nextPreviews.set(item.expression, item.preview ?? "");
+    }
+    completionPreviews.value = nextPreviews;
+  } catch {
+    // Previews are advisory: a failed batch just leaves those rows blank.
+  }
+}
+
 function updateDialogSuggestions(): void {
   const element = dialogTextareaRef.value;
   if (!element) {
@@ -1290,10 +1428,14 @@ function updateDialogSuggestions(): void {
 
   const cursorPos = element.selectionStart || 0;
   dialogSuggestions.value = getSuggestions(dialogValue.value, cursorPos);
+  dialogSuggestionCursorPos.value = cursorPos;
   dialogSelectedIndex.value = 0;
   showDialogDropdown.value = dialogSuggestions.value.length > 0;
   if (showDialogDropdown.value) {
     updateDialogDropdownPosition();
+    scheduleCompletionPreviews();
+  } else {
+    clearCompletionPreviewTimer();
   }
 }
 
@@ -2217,6 +2359,7 @@ onUnmounted((): void => {
   unsubDismissOverlays?.();
   clearInlineBlurHideTimer();
   clearAutoEvaluateTimer();
+  clearCompletionPreviewTimer();
   clearPendingOutputBottomStickTimer();
   clearFinalResultCopyResetTimer();
 });
@@ -2865,12 +3008,23 @@ defineExpose({
                       :is="getTypeIcon(suggestion)"
                       :class="cn('h-4 w-4 shrink-0', getTypeColor(suggestion))"
                     />
-                    <span class="flex-1 font-mono">{{ suggestion.label }}</span>
+                    <span class="shrink-0 font-mono">{{ suggestion.label }}</span>
                     <span
                       v-if="suggestion.detail"
-                      class="text-xs text-muted-foreground"
+                      class="min-w-0 flex-1 truncate text-xs text-muted-foreground"
                     >
                       {{ suggestion.detail }}
+                    </span>
+                    <span
+                      v-else
+                      class="flex-1"
+                    />
+                    <span
+                      v-if="dialogSuggestionPreview(index)"
+                      class="max-w-[45%] shrink-0 truncate font-mono text-xs font-bold text-foreground"
+                      :title="dialogSuggestionPreview(index)"
+                    >
+                      {{ dialogSuggestionPreview(index) }}
                     </span>
                   </button>
                 </template>

--- a/frontend/src/composables/useExpressionCompletion.ts
+++ b/frontend/src/composables/useExpressionCompletion.ts
@@ -1321,7 +1321,10 @@ export function useExpressionCompletion(
           ? `${prefix}${context.nodeLabel}.${context.propertyPath.join(".")}.`
           : `${prefix}${context.nodeLabel}.`;
 
-      const fullExpression = basePath + insertText;
+      // Index suggestions attach directly to the path: `$node.items[0]`, never `$node.items.[0]`.
+      const fullExpression = insertText.startsWith("[")
+        ? basePath.slice(0, -1) + insertText
+        : basePath + insertText;
       const newText = beforeExpression + fullExpression + afterCursor;
 
       let newCursorPos = beforeExpression.length + fullExpression.length;

--- a/frontend/src/docs/content/reference/expression-evaluation-dialog.md
+++ b/frontend/src/docs/content/reference/expression-evaluation-dialog.md
@@ -61,6 +61,16 @@ When the backend result is an object or array, the Output area can show an inter
 - Press `Tab` or `Enter` to insert the selected suggestion.
 - Use `↑` / `↓` to move through the suggestion list.
 
+### Example Answers
+
+When you continue a `$…` reference with a dot, each suggestion row shows the answer that suggestion would produce, in bold on the right of the row.
+
+- Typing `$set.listItems.first().toString().u` lists `upper`, `urlEncode`, `urlDecode`, and `unescape`, each with its evaluated result — so you can pick by outcome instead of by name.
+- Results are evaluated on the backend against the same pinned data and last-run outputs the dialog preview uses, so they match what the field will produce.
+- Only suggestions that stand on their own are evaluated: zero-argument methods (`upper()`, `first()`, `keys()`) and plain properties (`length`, `year`). Suggestions that need arguments first — `map`, `filter`, `sort`, `replace` — are left blank.
+- A row stays blank when the candidate produces no answer: an error, a `null`, or a method that does not apply to that value.
+- Answers are shortened to one line. Hover a shortened answer to see more of it.
+
 ## Build with AI
 
 The **Build with AI** button appears in the top-right corner of the evaluate dialog when a workflow is loaded. It opens a nested modal where you can describe the expression you want in plain text and have an LLM generate it for you.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -45,6 +45,8 @@ import type {
   AllExecutionHistoryEntryLight,
   CodexFollowup,
   CodexFollowupAnswerPayload,
+  ExpressionCompletionPreviewRequest,
+  ExpressionCompletionPreviewResponse,
   ExpressionEvaluateRequest,
   ExpressionEvaluateResponse,
   ExecutionResult,
@@ -3603,6 +3605,16 @@ export const expressionApi = {
   ): Promise<ExpressionEvaluateResponse> => {
     const response = await api.post<ExpressionEvaluateResponse>(
       "/expressions/evaluate",
+      request,
+    );
+    return response.data;
+  },
+
+  previewCompletions: async (
+    request: ExpressionCompletionPreviewRequest,
+  ): Promise<ExpressionCompletionPreviewResponse> => {
+    const response = await api.post<ExpressionCompletionPreviewResponse>(
+      "/expressions/completion-previews",
       request,
     );
     return response.data;

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1103,6 +1103,26 @@ export interface ExpressionEvaluateResponse {
   selected_loop_total?: number | null;
 }
 
+export interface ExpressionCompletionPreviewRequest {
+  expressions: string[];
+  workflow_id: string;
+  current_node_id: string;
+  field_name?: string;
+  input_body?: unknown;
+  selected_loop_iteration_index?: number | null;
+  node_results: ExpressionEvaluateCanvasResult[];
+}
+
+export interface ExpressionCompletionPreviewItem {
+  expression: string;
+  preview: string | null;
+  result_type: string | null;
+}
+
+export interface ExpressionCompletionPreviewResponse {
+  previews: ExpressionCompletionPreviewItem[];
+}
+
 export interface AgentProgressEntry {
   name: string;
   arguments: Record<string, unknown>;


### PR DESCRIPTION
 Implement expression completion previews in the API and frontend


- Added new API endpoint for fetching completion previews based on candidate expressions.
- Introduced data models for `ExpressionCompletionPreviewRequest` and `ExpressionCompletionPreviewResponse`.
- Updated the `evaluate_expression` function to support the new completion preview logic.
- Enhanced the frontend to handle completion previews, including debounce logic and UI updates for displaying evaluated results.
- Added tests for the new completion preview functionality to ensure correct behavior and integration with existing workflows.

<img width="1449" height="764" alt="Screenshot 2026-07-28 at 1 47 23 PM" src="https://github.com/user-attachments/assets/34e45fe5-f30e-4881-9591-4725caeb6dbe" />

