### PR TITLE
Show ActiveWorkflowsBadge on all dashboard tabs

### DIFF
--- a/frontend/src/components/Layout/AppHeader.vue
+++ b/frontend/src/components/Layout/AppHeader.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { BookOpen, ExternalLink, LogOut, Moon, Search, Settings, Sun } from "lucide-vue-next";
 
+import ActiveWorkflowsBadge from "@/components/Layout/ActiveWorkflowsBadge.vue";
 import UserSettingsDialog from "@/components/Layout/UserSettingsDialog.vue";
 import Button from "@/components/ui/Button.vue";
 import { onDismissOverlays, pushOverlayState } from "@/composables/useOverlayBackHandler";
@@ -101,6 +102,7 @@ async function handleLogout(): Promise<void> {
       </div>
 
       <div class="flex items-center gap-1.5 sm:gap-2">
+        <ActiveWorkflowsBadge />
         <slot name="before-docs" />
         <router-link
           v-if="!hideDocsLink"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1423,7 +1423,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
     <div class="min-h-screen bg-background overflow-x-hidden">
       <AppHeader :on-open-command-palette="() => { showCommandPalette = true; pushOverlayState(); }">
         <template #before-docs>
-          <ActiveWorkflowsBadge v-if="activeTab === 'workflows'" />
+          <ActiveWorkflowsBadge />
         </template>
         <template #actions>
           <Button

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -42,7 +42,7 @@ import DockerLogsViewer from "@/components/LogsTab/DockerLogsViewer.vue";
 import FolderTreeItem from "@/components/Folders/FolderTreeItem.vue";
 import WorkflowFolderDropPlaceholder from "@/components/Folders/WorkflowFolderDropPlaceholder.vue";
 import GlobalVariablesPanel from "@/components/GlobalVariables/GlobalVariablesPanel.vue";
-import ActiveWorkflowsBadge from "@/components/Layout/ActiveWorkflowsBadge.vue";
+
 import AppHeader from "@/components/Layout/AppHeader.vue";
 import DashboardNav from "@/components/Layout/DashboardNav.vue";
 import WorkspaceShell from "@/components/Layout/WorkspaceShell.vue";
@@ -1422,9 +1422,6 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
   >
     <div class="min-h-screen bg-background overflow-x-hidden">
       <AppHeader :on-open-command-palette="() => { showCommandPalette = true; pushOverlayState(); }">
-        <template #before-docs>
-          <ActiveWorkflowsBadge />
-        </template>
         <template #actions>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Change Summary

Moved the `ActiveWorkflowsBadge` from `DashboardView.vue`'s `#before-docs` slot into `AppHeader.vue` itself, so the live workflow counter badge appears consistently in the header across ALL views that use AppHeader (Dashboard, Evals, Chats, Docs). Previously the badge was only rendered inside DashboardView, which meant the dedicated Evals (`/evals`) and Chats (`/chats`) routes had no live workflow counter in their header.

**Changes:**
- `frontend/src/components/Layout/AppHeader.vue`: Added import and rendering of `<ActiveWorkflowsBadge />` before the `#before-docs` slot in the header's right-side action bar
- `frontend/src/views/DashboardView.vue`: Removed the now-unnecessary import of `ActiveWorkflowsBadge` and its `#before-docs` slot placement

The Editor/Canvas view is unaffected because it uses its own custom header (`editor-header`), not `AppHeader`.

## Screenshots

![feat-add-live-workflow-counter-badge-chats.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/feat-add-live-workflow-counter-badge-chats.png)

![feat-add-live-workflow-counter-badge-dashboard-1.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/feat-add-live-workflow-counter-badge-dashboard-1.png)

![feat-add-live-workflow-counter-badge-evals-2.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/feat-add-live-workflow-counter-badge-evals-2.png)

![feat-add-live-workflow-counter-badge-header-closeup-3.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/feat-add-live-workflow-counter-badge-header-closeup-3.png)
