### PR TITLE
fix/live-execution-progress

### DIFF
--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -454,10 +454,11 @@ async def portal_execute_stream(
 
     event_queue: queue.Queue = queue.Queue()
     final_result: dict = {}
+    was_cancelled: bool = False
     progress_tracker = PortalProgressTracker()
 
     def run_executor():
-        nonlocal final_result
+        nonlocal final_result, was_cancelled
         try:
             for event in execute_workflow_streaming(
                 workflow_id=workflow.id,
@@ -481,13 +482,14 @@ async def portal_execute_stream(
                 if event.get("type") == "execution_complete":
                     final_result = event
         except WorkflowCancelledError:
+            was_cancelled = True
             return
         finally:
             event_queue.put(None)
             clear_active_execution(execution_id)
 
     async def event_generator():
-        nonlocal final_result
+        nonlocal final_result, was_cancelled
         loop = asyncio.get_event_loop()
         with ThreadPoolExecutor(max_workers=1) as pool:
             future = loop.run_in_executor(pool, run_executor)
@@ -506,6 +508,8 @@ async def portal_execute_stream(
             while True:
                 if await request.is_disconnected():
                     cancel_event.set()
+                    was_cancelled = True
+                    await asyncio.shield(future)
                     break
                 try:
                     event = event_queue.get(block=True, timeout=0.01)
@@ -634,7 +638,31 @@ async def portal_execute_stream(
                     cancel_event.set()
                     break
 
-            if final_result and final_result.get("status") != "pending":
+            if was_cancelled and not final_result:
+                # Without this row the run simply disappears: canvases observing it
+                # (live view in another tab) never receive a terminal event.
+                db.add(
+                    ExecutionHistory(
+                        id=execution_id,
+                        workflow_id=workflow.id,
+                        inputs=enriched_inputs,
+                        outputs={},
+                        node_results=[],
+                        status="cancelled",
+                        execution_time_ms=0,
+                        trigger_source="portal",
+                    )
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=workflow.id,
+                    owner_id=workflow.owner_id,
+                    workflow_name_snapshot=workflow.name,
+                    status="cancelled",
+                    execution_time_ms=0.0,
+                )
+                await db.flush()
+            elif final_result and final_result.get("status") != "pending":
                 await _persist_global_variables_from_execution(
                     db,
                     workflow.owner_id,

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -80,8 +80,10 @@ from app.services.execution_cancellation import (
     clear_execution as clear_active_execution,
 )
 from app.services.execution_cancellation import (
+    get_active_execution_events,
     get_active_execution_inputs,
     get_active_execution_progress,
+    get_active_execution_stream_snapshot,
     list_active_executions,
     list_pending_review_executions_for_user,
     list_persisted_active_executions_for_user,
@@ -125,6 +127,9 @@ _SENSITIVE_HEADERS: frozenset[str] = frozenset(
 _INTERNAL_STREAM_TRIGGER_SOURCES: frozenset[str] = frozenset({"Canvas", "Quick Drawer"})
 WORKFLOW_SSE_HEARTBEAT_SECONDS = 10.0
 WORKFLOW_STREAM_QUEUE_POLL_SECONDS = 0.01
+# Observe-stream polls at 0.25s; give a vanished execution 10s to surface its
+# history entry before telling the canvas the run is gone for good.
+WORKFLOW_OBSERVE_MISSING_TICK_LIMIT = 40
 
 
 @contextmanager
@@ -1116,8 +1121,27 @@ async def stream_active_workflow_execution(
         emitted_result_count = 0
         emitted_running_node_ids: set[str] = set()
         missing_ticks = 0
+        # "derived" rebuilds coarse node lifecycle from the progress snapshot (used for
+        # runs owned by another worker); "events" replays the runner's own SSE stream,
+        # which also carries agent tool progress and sub-agent node lifecycle.
+        stream_mode = "derived"
+        event_cursor = 0
         loop = asyncio.get_running_loop()
         last_heartbeat_at = loop.time()
+
+        def derived_catch_up_frames(
+            running_node_ids: list[str],
+            node_results: list[dict],
+        ) -> Iterator[str]:
+            """Rebuild node lifecycle frames from a coarse progress snapshot."""
+            nonlocal emitted_result_count, emitted_running_node_ids
+            for node_result in node_results[emitted_result_count:]:
+                yield f"data: {json.dumps({'type': 'node_complete', **node_result})}\n\n"
+            emitted_result_count = max(emitted_result_count, len(node_results))
+            current_running_node_ids = set(running_node_ids)
+            for node_id in sorted(current_running_node_ids - emitted_running_node_ids):
+                yield "data: " + json.dumps({"type": "node_start", "node_id": node_id}) + "\n\n"
+            emitted_running_node_ids = current_running_node_ids
 
         yield (
             "data: "
@@ -1139,13 +1163,58 @@ async def stream_active_workflow_execution(
             node_results: list[dict] = []
             active_found = False
 
-            local_progress = get_active_execution_progress(
+            snapshot = get_active_execution_stream_snapshot(
                 execution_id,
                 workflow_id=workflow_id,
             )
-            if local_progress is not None:
+            if snapshot is not None and snapshot.publishes_progress_events:
+                missing_ticks = 0
+                emitted_event = False
+                if stream_mode == "derived":
+                    nothing_emitted_yet = emitted_result_count == 0 and not emitted_running_node_ids
+                    if nothing_emitted_yet and snapshot.dropped_event_count == 0:
+                        # Attaching mid-run: replay the whole stream so the canvas shows
+                        # the agent log from the beginning.
+                        for payload in snapshot.events:
+                            yield f"data: {payload}\n\n"
+                            emitted_event = True
+                    else:
+                        # The buffer already lost its head: fall back to the snapshot for
+                        # the catch-up, then follow the live events from here on.
+                        for frame in derived_catch_up_frames(
+                            snapshot.running_node_ids,
+                            snapshot.node_results,
+                        ):
+                            yield frame
+                            emitted_event = True
+                    event_cursor = snapshot.next_event_seq
+                    stream_mode = "events"
+                else:
+                    pending_events = get_active_execution_events(
+                        execution_id,
+                        workflow_id=workflow_id,
+                        after_seq=event_cursor,
+                    )
+                    if pending_events is not None:
+                        payloads, next_seq = pending_events
+                        for payload in payloads:
+                            yield f"data: {payload}\n\n"
+                            emitted_event = True
+                        event_cursor = next_seq
+
+                now = loop.time()
+                if emitted_event:
+                    last_heartbeat_at = now
+                elif now - last_heartbeat_at >= WORKFLOW_SSE_HEARTBEAT_SECONDS:
+                    last_heartbeat_at = now
+                    yield ": heartbeat\n\n"
+                await asyncio.sleep(0.25)
+                continue
+
+            if snapshot is not None:
                 active_found = True
-                running_node_ids, node_results = local_progress
+                running_node_ids = snapshot.running_node_ids
+                node_results = snapshot.node_results
             else:
                 async with async_session_maker() as stream_db:
                     active_result = await stream_db.execute(
@@ -1164,18 +1233,12 @@ async def stream_active_workflow_execution(
             if active_found:
                 missing_ticks = 0
                 emitted_event = False
-                for node_result in node_results[emitted_result_count:]:
-                    yield f"data: {json.dumps({'type': 'node_complete', **node_result})}\n\n"
-                    emitted_event = True
-                emitted_result_count = max(emitted_result_count, len(node_results))
-
-                current_running_node_ids = set(running_node_ids)
-                for node_id in sorted(current_running_node_ids - emitted_running_node_ids):
-                    yield (
-                        "data: " + json.dumps({"type": "node_start", "node_id": node_id}) + "\n\n"
-                    )
-                    emitted_event = True
-                emitted_running_node_ids = current_running_node_ids
+                # Once the runner's own events have been streamed, never fall back to the
+                # coarse snapshot: its node results were already emitted as live events.
+                if stream_mode == "derived":
+                    for frame in derived_catch_up_frames(running_node_ids, node_results):
+                        yield frame
+                        emitted_event = True
                 now = loop.time()
                 if emitted_event:
                     last_heartbeat_at = now
@@ -1214,12 +1277,13 @@ async def stream_active_workflow_execution(
                 break
 
             missing_ticks += 1
-            if missing_ticks >= 40:
+            if missing_ticks >= WORKFLOW_OBSERVE_MISSING_TICK_LIMIT:
                 yield (
                     "data: "
                     + json.dumps(
                         {
                             "type": "error",
+                            "code": "execution_gone",
                             "message": "Execution is no longer active",
                         }
                     )

--- a/backend/app/services/execution_cancellation.py
+++ b/backend/app/services/execution_cancellation.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import logging
 import os
 import queue
@@ -7,6 +8,8 @@ import socket
 import threading
 import time
 import uuid
+from collections import deque
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
@@ -21,6 +24,17 @@ ACTIVE_EXECUTION_STALE_AFTER_SECONDS = 300
 RECOVERY_STALE_AFTER_SECONDS = 60
 _REGISTRY_POLL_SECONDS = 0.5
 _REGISTRY_CLEANUP_SECONDS = 30.0
+# Live SSE events kept per execution so a canvas that attaches mid-run replays the
+# same stream the runner emitted (agent tool progress, sub-agent node lifecycle).
+# Bounded by both count and total bytes: the oldest events are dropped first.
+MAX_PROGRESS_EVENTS = 2000
+MAX_PROGRESS_EVENT_BYTES = 8 * 1024 * 1024
+# A single oversized payload (large node output) is buffered without its payload
+# fields; the full value still reaches the canvas with the final history entry.
+MAX_PROGRESS_EVENT_PAYLOAD_BYTES = 256 * 1024
+# Events the observer synthesizes itself, plus executor-internal plumbing that is
+# not JSON serializable.
+_UNBUFFERED_EVENT_TYPES = frozenset({"execution_started", "execution_complete"})
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +60,23 @@ class ExecutionCancellationHandle:
     node_results: list[dict[str, Any]] = field(default_factory=list)
     progress_version: int = 0
     synced_progress_version: int = 0
+    publishes_progress_events: bool = False
+    progress_events: deque[tuple[int, str]] = field(default_factory=deque)
+    progress_event_bytes: int = 0
+    next_progress_event_seq: int = 0
+    dropped_progress_events: int = 0
+
+
+@dataclass(frozen=True)
+class ActiveExecutionStreamSnapshot:
+    """Atomic view of one execution's live progress, taken under the registry lock."""
+
+    publishes_progress_events: bool
+    running_node_ids: list[str]
+    node_results: list[dict[str, Any]]
+    events: list[str]
+    next_event_seq: int
+    dropped_event_count: int
 
 
 @dataclass(frozen=True)
@@ -201,6 +232,120 @@ def record_execution_node_completed(
         handle.running_node_ids.discard(str(node_id))
         handle.node_results.append(node_result)
         handle.progress_version += 1
+
+
+def mark_execution_publishes_progress_events(execution_id: str) -> None:
+    """Flag a run as emitting live SSE events so observers stream them instead of polling."""
+    handle = _handle_for_execution_id(execution_id)
+    if handle is None:
+        return
+    with _LOCK:
+        handle.publishes_progress_events = True
+
+
+def _serialize_progress_event(event: dict[str, Any]) -> str | None:
+    try:
+        payload = json.dumps(event)
+    except (TypeError, ValueError):
+        return None
+    if len(payload) <= MAX_PROGRESS_EVENT_PAYLOAD_BYTES:
+        return payload
+    # Keep the node lifecycle (type/id/label/status) and drop the bulky payload
+    # fields so one large output cannot dominate the buffer.
+    trimmed: dict[str, Any] = {
+        key: value
+        for key, value in event.items()
+        if value is None or isinstance(value, (str, int, float, bool))
+    }
+    trimmed["_truncated"] = True
+    try:
+        return json.dumps(trimmed)
+    except (TypeError, ValueError):
+        return None
+
+
+def record_execution_progress_event(execution_id: str, event: dict[str, Any]) -> None:
+    """Buffer one live SSE event so other tabs can replay the runner's stream."""
+    event_type = event.get("type")
+    if not isinstance(event_type, str) or event_type.startswith("_"):
+        return
+    if event_type in _UNBUFFERED_EVENT_TYPES:
+        return
+    handle = _handle_for_execution_id(execution_id)
+    if handle is None:
+        return
+    payload = _serialize_progress_event(event)
+    if payload is None:
+        logger.debug("Skipping non-serializable live event %s", event_type)
+        return
+
+    with _LOCK:
+        events = handle.progress_events
+        events.append((handle.next_progress_event_seq, payload))
+        handle.next_progress_event_seq += 1
+        handle.progress_event_bytes += len(payload)
+        while events and (
+            len(events) > MAX_PROGRESS_EVENTS
+            or handle.progress_event_bytes > MAX_PROGRESS_EVENT_BYTES
+        ):
+            _seq, dropped_payload = events.popleft()
+            handle.progress_event_bytes -= len(dropped_payload)
+            handle.dropped_progress_events += 1
+
+
+def buffer_live_execution_events(
+    events: Iterator[dict[str, Any]],
+    execution_id: str,
+) -> Iterator[dict[str, Any]]:
+    """Pass a runner's SSE events through while recording them for late observers."""
+    mark_execution_publishes_progress_events(execution_id)
+    for event in events:
+        record_execution_progress_event(execution_id, event)
+        yield event
+
+
+def get_active_execution_stream_snapshot(
+    execution_id: uuid.UUID,
+    *,
+    workflow_id: uuid.UUID,
+) -> ActiveExecutionStreamSnapshot | None:
+    """Return node progress and the buffered live events in one consistent read."""
+    with _LOCK:
+        handle = _ACTIVE_EXECUTIONS.get(execution_id)
+        if handle is None or handle.workflow_id != workflow_id or handle.event.is_set():
+            return None
+        return ActiveExecutionStreamSnapshot(
+            publishes_progress_events=handle.publishes_progress_events,
+            running_node_ids=sorted(handle.running_node_ids),
+            node_results=list(handle.node_results),
+            events=[payload for _seq, payload in handle.progress_events],
+            next_event_seq=handle.next_progress_event_seq,
+            dropped_event_count=handle.dropped_progress_events,
+        )
+
+
+def get_active_execution_events(
+    execution_id: uuid.UUID,
+    *,
+    workflow_id: uuid.UUID,
+    after_seq: int,
+) -> tuple[list[str], int] | None:
+    """Return live events newer than ``after_seq`` plus the next cursor value."""
+    with _LOCK:
+        handle = _ACTIVE_EXECUTIONS.get(execution_id)
+        if handle is None or handle.workflow_id != workflow_id or handle.event.is_set():
+            return None
+        payloads = [payload for seq, payload in handle.progress_events if seq >= after_seq]
+        return payloads, handle.next_progress_event_seq
+
+
+def _handle_for_execution_id(execution_id: str) -> ExecutionCancellationHandle | None:
+    try:
+        parsed_execution_id = uuid.UUID(str(execution_id))
+    except (TypeError, ValueError):
+        return None
+    with _LOCK:
+        return _ACTIVE_EXECUTIONS.get(parsed_execution_id)
 
 
 class ActiveExecutionRegistry:

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -39,11 +39,12 @@ from app.services.chart_payload import (
     build_chart_payload,  # noqa: F401 - public patch alias for node handlers
 )
 from app.services.execution_cancellation import (
-    clear_execution as _clear_sub_execution,
-)
-from app.services.execution_cancellation import (
+    buffer_live_execution_events,
     record_execution_node_completed,
     record_execution_node_started,
+)
+from app.services.execution_cancellation import (
+    clear_execution as _clear_sub_execution,
 )
 from app.services.execution_cancellation import (
     register_execution as _register_sub_execution,
@@ -9481,7 +9482,15 @@ def build_node_start_message(
 
 
 def execute_workflow_streaming(**kwargs):
-    """Public streaming entry: wrap the run in an OTel root span (no-op when disabled).
+    """Public streaming entry: record live events so late observers replay them."""
+    yield from buffer_live_execution_events(
+        _execute_workflow_streaming_traced(**kwargs),
+        str(kwargs.get("execution_id") or ""),
+    )
+
+
+def _execute_workflow_streaming_traced(**kwargs):
+    """Wrap the run in an OTel root span (no-op when disabled).
 
     The canvas "Run" and portal use the streaming path, which has its own node
     loop and does not call ``WorkflowExecutor.execute``. This wrapper opens the

--- a/backend/tests/test_active_executions_api.py
+++ b/backend/tests/test_active_executions_api.py
@@ -1,4 +1,6 @@
+import asyncio
 import datetime
+import json
 import threading
 import unittest
 import uuid
@@ -10,16 +12,22 @@ from app.api.workflows import (
 )
 from app.models.schemas import ActiveExecutionItem
 from app.services.execution_cancellation import (
+    MAX_PROGRESS_EVENT_PAYLOAD_BYTES,
+    MAX_PROGRESS_EVENTS,
     ActiveExecutionRecord,
     ExecutionCancellationHandle,
     active_execution_registry,
     clear_execution,
+    get_active_execution_events,
     get_active_execution_inputs,
     get_active_execution_progress,
+    get_active_execution_stream_snapshot,
     list_active_executions,
     list_persisted_active_executions_for_user,
+    mark_execution_publishes_progress_events,
     record_execution_node_completed,
     record_execution_node_started,
+    record_execution_progress_event,
     register_execution,
 )
 from app.services.workflow_executor import (
@@ -38,6 +46,17 @@ def _make_handle(workflow_id: uuid.UUID, execution_id: uuid.UUID) -> ExecutionCa
         started_at=datetime.datetime(2025, 1, 1, 12, 0, 0),
         inputs={"text": "local input"},
     )
+
+
+async def _drain_frames(iterator, *, limit: int, timeout: float = 1.0) -> list[str]:
+    """Collect SSE frames until the stream goes quiet, so extra frames are detectable."""
+    frames: list[str] = []
+    try:
+        while len(frames) < limit:
+            frames.append(await asyncio.wait_for(anext(iterator), timeout))
+    except (TimeoutError, asyncio.TimeoutError, StopAsyncIteration):
+        pass
+    return frames
 
 
 def _make_record(workflow_id: uuid.UUID, execution_id: uuid.UUID) -> ActiveExecutionRecord:
@@ -459,6 +478,193 @@ class LiveExecutionSnapshotTests(unittest.IsolatedAsyncioTestCase):
         finally:
             clear_execution(execution_id)
 
+    async def test_stream_replays_runner_events_for_publishing_execution(self) -> None:
+        """A canvas attaching mid-run replays agent progress and sub-agent lifecycle."""
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        register_execution(
+            workflow_id=workflow_id,
+            execution_id=execution_id,
+            inputs={"text": "live input"},
+        )
+        mark_execution_publishes_progress_events(str(execution_id))
+        # Coarse snapshot the observer must NOT re-emit once live events exist.
+        record_execution_node_completed(
+            str(execution_id),
+            "input_1",
+            {
+                "node_id": "input_1",
+                "node_label": "userInput",
+                "node_type": "textInput",
+                "status": "success",
+                "output": {"source": "snapshot"},
+                "execution_time_ms": 1.0,
+                "error": None,
+            },
+        )
+        record_execution_node_started(str(execution_id), "agent_1")
+        for event in (
+            {
+                "type": "node_complete",
+                "node_id": "input_1",
+                "node_label": "userInput",
+                "node_type": "textInput",
+                "status": "success",
+                "output": {"source": "live"},
+                "execution_time_ms": 1.0,
+                "error": None,
+            },
+            {"type": "node_start", "node_id": "agent_1", "node_label": "orchestrator"},
+            {
+                "type": "agent_progress",
+                "node_id": "agent_1",
+                "node_label": "orchestrator",
+                "entry": {"name": "call_sub_agent", "phase": "start"},
+            },
+            {"type": "node_start", "node_id": "agent_2", "node_label": "growthHackerAgent"},
+        ):
+            record_execution_progress_event(str(execution_id), event)
+
+        workflow = MagicMock()
+        workflow.id = workflow_id
+        workflow.nodes = []
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        request = MagicMock()
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        try:
+            with patch(
+                "app.api.workflows.get_workflow_for_user",
+                AsyncMock(return_value=workflow),
+            ):
+                response = await stream_active_workflow_execution(
+                    workflow_id=workflow_id,
+                    execution_id=execution_id,
+                    request=request,
+                    current_user=user,
+                    db=AsyncMock(),
+                )
+
+            iterator = response.body_iterator
+            frames = await _drain_frames(iterator, limit=6)
+            await iterator.aclose()
+
+            self.assertIn('"type": "execution_started"', frames[0])
+            payloads = [json.loads(frame.removeprefix("data: ")) for frame in frames[1:]]
+            self.assertEqual(
+                [(item["type"], item.get("node_id")) for item in payloads],
+                [
+                    ("node_complete", "input_1"),
+                    ("node_start", "agent_1"),
+                    ("agent_progress", "agent_1"),
+                    ("node_start", "agent_2"),
+                ],
+            )
+            self.assertEqual(payloads[0]["output"], {"source": "live"})
+        finally:
+            clear_execution(execution_id)
+
+    async def test_stream_sends_new_runner_events_after_the_initial_replay(self) -> None:
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        register_execution(workflow_id=workflow_id, execution_id=execution_id)
+        mark_execution_publishes_progress_events(str(execution_id))
+        record_execution_progress_event(
+            str(execution_id),
+            {"type": "node_start", "node_id": "agent_1", "node_label": "orchestrator"},
+        )
+
+        workflow = MagicMock()
+        workflow.id = workflow_id
+        workflow.nodes = []
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        request = MagicMock()
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        try:
+            with patch(
+                "app.api.workflows.get_workflow_for_user",
+                AsyncMock(return_value=workflow),
+            ):
+                response = await stream_active_workflow_execution(
+                    workflow_id=workflow_id,
+                    execution_id=execution_id,
+                    request=request,
+                    current_user=user,
+                    db=AsyncMock(),
+                )
+
+            iterator = response.body_iterator
+            self.assertIn('"type": "execution_started"', await anext(iterator))
+            self.assertIn('"node_id": "agent_1"', await anext(iterator))
+
+            record_execution_progress_event(
+                str(execution_id),
+                {
+                    "type": "node_complete",
+                    "node_id": "agent_2",
+                    "node_label": "growthHackerAgent",
+                    "node_type": "agent",
+                    "status": "success",
+                    "output": {"text": "done"},
+                    "execution_time_ms": 12.0,
+                    "error": None,
+                },
+            )
+            follow_up = await anext(iterator)
+            await iterator.aclose()
+
+            self.assertIn('"type": "node_complete"', follow_up)
+            self.assertIn('"node_id": "agent_2"', follow_up)
+        finally:
+            clear_execution(execution_id)
+
+    async def test_stream_marks_a_vanished_execution_as_gone(self) -> None:
+        """Cancelled mid-flight runs must terminate the stream, not stall the canvas."""
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+
+        workflow = MagicMock()
+        workflow.id = workflow_id
+        workflow.nodes = []
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        request = MagicMock()
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        stream_db = AsyncMock()
+        stream_db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        session_context = MagicMock()
+        session_context.__aenter__ = AsyncMock(return_value=stream_db)
+        session_context.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "app.api.workflows.get_workflow_for_user",
+                AsyncMock(return_value=workflow),
+            ),
+            patch("app.api.workflows.async_session_maker", return_value=session_context),
+            patch("app.api.workflows.WORKFLOW_OBSERVE_MISSING_TICK_LIMIT", 1),
+        ):
+            response = await stream_active_workflow_execution(
+                workflow_id=workflow_id,
+                execution_id=execution_id,
+                request=request,
+                current_user=user,
+                db=AsyncMock(),
+            )
+
+            iterator = response.body_iterator
+            self.assertIn('"type": "execution_started"', await anext(iterator))
+            gone = json.loads((await anext(iterator)).removeprefix("data: "))
+            with self.assertRaises(StopAsyncIteration):
+                await anext(iterator)
+
+        self.assertEqual(gone["type"], "error")
+        self.assertEqual(gone["code"], "execution_gone")
+
     async def test_stream_sends_heartbeat_while_active_node_is_idle(self) -> None:
         workflow_id = uuid.uuid4()
         execution_id = uuid.uuid4()
@@ -497,6 +703,115 @@ class LiveExecutionSnapshotTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(heartbeat, ": heartbeat\n\n")
         finally:
             clear_execution(execution_id)
+
+
+class LiveExecutionEventBufferTests(unittest.TestCase):
+    """The live event buffer backs the observe stream for other tabs."""
+
+    def setUp(self) -> None:
+        self.workflow_id = uuid.uuid4()
+        self.execution_id = uuid.uuid4()
+        register_execution(workflow_id=self.workflow_id, execution_id=self.execution_id)
+        self.addCleanup(clear_execution, self.execution_id)
+
+    def _snapshot(self):
+        return get_active_execution_stream_snapshot(
+            self.execution_id,
+            workflow_id=self.workflow_id,
+        )
+
+    def test_marking_the_run_flags_it_for_event_replay(self) -> None:
+        snapshot = self._snapshot()
+        assert snapshot is not None
+        self.assertFalse(snapshot.publishes_progress_events)
+
+        mark_execution_publishes_progress_events(str(self.execution_id))
+        record_execution_progress_event(
+            str(self.execution_id),
+            {"type": "node_start", "node_id": "agent_1"},
+        )
+
+        snapshot = self._snapshot()
+        assert snapshot is not None
+        self.assertTrue(snapshot.publishes_progress_events)
+        self.assertEqual(len(snapshot.events), 1)
+        self.assertEqual(snapshot.next_event_seq, 1)
+        self.assertEqual(snapshot.dropped_event_count, 0)
+
+    def test_skips_internal_and_observer_synthesized_events(self) -> None:
+        for event in (
+            {"type": "_internal_node_result", "result": object()},
+            {"type": "execution_started", "execution_id": str(self.execution_id)},
+            {"type": "execution_complete", "status": "success"},
+            {"type": "node_complete", "node_id": "n1", "output": {"blob": object()}},
+        ):
+            record_execution_progress_event(str(self.execution_id), event)
+
+        snapshot = self._snapshot()
+        assert snapshot is not None
+        self.assertEqual(snapshot.events, [])
+
+    def test_cursor_returns_only_newer_events(self) -> None:
+        for index in range(3):
+            record_execution_progress_event(
+                str(self.execution_id),
+                {"type": "node_start", "node_id": f"node-{index}"},
+            )
+
+        payloads, next_seq = get_active_execution_events(
+            self.execution_id,
+            workflow_id=self.workflow_id,
+            after_seq=1,
+        )
+        self.assertEqual(next_seq, 3)
+        self.assertEqual(
+            [json.loads(payload)["node_id"] for payload in payloads],
+            ["node-1", "node-2"],
+        )
+
+    def test_oversized_event_is_buffered_without_its_payload(self) -> None:
+        record_execution_progress_event(
+            str(self.execution_id),
+            {
+                "type": "node_complete",
+                "node_id": "big",
+                "node_label": "Big",
+                "status": "success",
+                "output": {"blob": "x" * (MAX_PROGRESS_EVENT_PAYLOAD_BYTES + 1)},
+            },
+        )
+
+        snapshot = self._snapshot()
+        assert snapshot is not None
+        payload = json.loads(snapshot.events[0])
+        self.assertEqual(payload["node_id"], "big")
+        self.assertEqual(payload["status"], "success")
+        self.assertTrue(payload["_truncated"])
+        self.assertNotIn("output", payload)
+
+    def test_oldest_events_are_dropped_once_the_count_cap_is_reached(self) -> None:
+        for index in range(MAX_PROGRESS_EVENTS + 5):
+            record_execution_progress_event(
+                str(self.execution_id),
+                {"type": "node_start", "node_id": f"node-{index}"},
+            )
+
+        snapshot = self._snapshot()
+        assert snapshot is not None
+        self.assertEqual(len(snapshot.events), MAX_PROGRESS_EVENTS)
+        self.assertEqual(snapshot.dropped_event_count, 5)
+        self.assertEqual(json.loads(snapshot.events[0])["node_id"], "node-5")
+
+    def test_unknown_execution_id_is_ignored(self) -> None:
+        record_execution_progress_event("not-a-uuid", {"type": "node_start", "node_id": "n"})
+        record_execution_progress_event(
+            str(uuid.uuid4()),
+            {"type": "node_start", "node_id": "n"},
+        )
+
+        snapshot = self._snapshot()
+        assert snapshot is not None
+        self.assertEqual(snapshot.events, [])
 
 
 class SubWorkflowActiveTrackingTests(unittest.TestCase):

--- a/backend/tests/test_sse_streaming.py
+++ b/backend/tests/test_sse_streaming.py
@@ -8,6 +8,11 @@ from unittest.mock import AsyncMock, patch
 
 from app.api.workflows import update_workflow
 from app.models.schemas import NodeResultSchema, WorkflowUpdate
+from app.services.execution_cancellation import (
+    clear_execution,
+    get_active_execution_stream_snapshot,
+    register_execution,
+)
 from app.services.workflow_executor import (
     NodeResult,
     WorkflowExecutor,
@@ -224,6 +229,58 @@ class ExecuteWorkflowStreamingSseTests(unittest.TestCase):
         self.assertEqual(node_complete.get("metadata", {}).get("sequence"), 1)
         self.assertEqual(node_complete.get("metadata", {}).get("started_at_ms"), 1012.5)
         self.assertEqual(node_complete.get("metadata", {}).get("ended_at_ms"), 1025.0)
+
+
+class StreamingRunPublishesLiveEventsTests(unittest.TestCase):
+    """Events yielded by the runner are buffered for canvases attaching later."""
+
+    def test_run_buffers_its_events_on_the_shared_execution_handle(self) -> None:
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        register_execution(workflow_id=workflow_id, execution_id=execution_id)
+        nodes = [{"id": "node-1", "type": "llm", "data": {"label": "LLM"}}]
+
+        try:
+            with patch("app.services.workflow_executor.WorkflowExecutor", _FakeWorkflowExecutor):
+                list(
+                    execute_workflow_streaming(
+                        workflow_id=workflow_id,
+                        nodes=nodes,
+                        edges=[],
+                        inputs={},
+                        execution_id=str(execution_id),
+                    )
+                )
+
+            snapshot = get_active_execution_stream_snapshot(
+                execution_id,
+                workflow_id=workflow_id,
+            )
+            assert snapshot is not None
+            self.assertTrue(snapshot.publishes_progress_events)
+            buffered = [json.loads(payload) for payload in snapshot.events]
+            self.assertEqual(
+                [event["type"] for event in buffered],
+                ["node_start", "node_complete"],
+            )
+            # execution_complete is synthesized by the observer from history instead.
+            self.assertNotIn("execution_complete", [event["type"] for event in buffered])
+        finally:
+            clear_execution(execution_id)
+
+    def test_run_without_execution_id_does_not_raise(self) -> None:
+        nodes = [{"id": "node-1", "type": "llm", "data": {"label": "LLM"}}]
+        with patch("app.services.workflow_executor.WorkflowExecutor", _FakeWorkflowExecutor):
+            events = list(
+                execute_workflow_streaming(
+                    workflow_id=uuid.uuid4(),
+                    nodes=nodes,
+                    edges=[],
+                    inputs={},
+                )
+            )
+
+        self.assertTrue(any(event.get("type") == "node_complete" for event in events))
 
 
 class NodeResultTimingMetadataTests(unittest.TestCase):

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -478,6 +478,61 @@ class PortalExecuteStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
                 await stream.__anext__()
 
 
+class PortalExecuteStreamCancelPersistenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cancelled_portal_run_is_persisted_as_cancelled_history(self) -> None:
+        """Without the row, a canvas observing the run never gets a terminal event."""
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Portal Workflow",
+            nodes=[{"id": "n1", "type": "textInput", "data": {"label": "Input"}}],
+            edges=[],
+        )
+
+        def fake_streaming_executor(**_kwargs: object):
+            raise WorkflowCancelledError("Workflow execution cancelled")
+            yield  # pragma: no cover - makes the callable a generator function
+
+        db = AsyncMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                _ScalarResult(workflow),
+                _ScalarResult(None),
+            ]
+        )
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        analytics = AsyncMock()
+
+        with (
+            patch("app.api.portal.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.portal.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.portal.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.portal.register_execution", return_value=Event()),
+            patch("app.api.portal.clear_active_execution"),
+            patch("app.api.portal.execute_workflow_streaming", fake_streaming_executor),
+            patch("app.api.portal.upsert_workflow_analytics_snapshot", analytics),
+        ):
+            response = await portal_execute_stream(
+                slug="portal-test",
+                execute_data=PortalExecuteRequest(inputs={}),
+                request=make_request(),
+                db=db,
+            )
+
+            stream = response.body_iterator
+            started = json.loads((await stream.__anext__()).removeprefix("data: "))
+            async for _chunk in stream:
+                pass
+
+        persisted = [call.args[0] for call in db.add.call_args_list]
+        self.assertEqual(len(persisted), 1)
+        self.assertEqual(persisted[0].status, "cancelled")
+        self.assertEqual(str(persisted[0].id), started["execution_id"])
+        self.assertEqual(persisted[0].trigger_source, "portal")
+        analytics.assert_awaited_once()
+
+
 class ExecuteWorkflowStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
     async def test_emits_hidden_heartbeat_while_waiting_for_workflow_events(self) -> None:
         workflow = SimpleNamespace(

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -9,6 +9,7 @@ import { AlertCircle, Bot, CheckCircle2, ChevronDown, ChevronUp, ChevronsUp, Clo
 
 import type { CredentialListItem, LLMModel } from "@/types/credential";
 import type {
+  AgentProgressEntry,
   AgentSkill,
   AgentSkillFile,
   NodeResult,
@@ -68,24 +69,24 @@ const workflowLevelError = computed<string | null>(() => {
   const outputs = r.outputs as Record<string, unknown> | undefined;
   return outputs && typeof outputs.error === "string" ? outputs.error : null;
 });
-const runningNodeId = computed(() => workflowStore.runningNodeId);
 const agentProgressLogs = computed(() => workflowStore.agentProgressLogs);
 const selectedNode = computed(() => workflowStore.selectedNode);
 const logsCopied = ref(false);
 const showTimeline = ref(false);
 
-const runningAgentNode = computed(() => {
-  const id = runningNodeId.value;
-  if (!id) return null;
-  const node = workflowStore.nodes.find((n) => n.id === id);
-  return node?.type === "agent" ? node : null;
-});
+/** Every agent currently in flight, not just the last one to start: an
+ *  orchestrator can fan out to several sub-agents at once. */
+const runningAgentNodes = computed(() =>
+  workflowStore.nodes.filter((node) => node.type === "agent" && node.data.status === "running"),
+);
 
-const liveAgentEntries = computed(() => {
-  const id = runningNodeId.value;
-  if (!id) return [];
-  return agentProgressLogs.value.get(id) ?? [];
-});
+function liveAgentEntriesFor(nodeId: string): AgentProgressEntry[] {
+  return agentProgressLogs.value.get(nodeId) ?? [];
+}
+
+const liveAgentEntryCount = computed(() =>
+  runningAgentNodes.value.reduce((total, node) => total + liveAgentEntriesFor(node.id).length, 0),
+);
 
 async function copyLogsAsJson(): Promise<void> {
   const jsonData = getLogsAsJsonData();
@@ -164,7 +165,7 @@ watch(
 );
 
 watch(
-  () => liveAgentEntries.value.length,
+  () => liveAgentEntryCount.value,
   () => {
     if (isExecuting.value) {
       scrollToBottom();
@@ -3385,26 +3386,27 @@ function renderContent(content: string): string {
         </div>
 
         <div
-          v-if="runningAgentNode && isExecuting"
+          v-for="agentNode in (isExecuting ? runningAgentNodes : [])"
+          :key="agentNode.id"
           class="flex items-start gap-3 p-2 rounded-md bg-muted/30"
         >
           <Loader2 class="w-4 h-4 mt-0.5 shrink-0 animate-spin text-yellow-500" />
           <div class="flex-1 min-w-0">
             <div class="flex items-center justify-between">
-              <span class="font-medium">{{ runningAgentNode.data?.label || runningAgentNode.id }}</span>
+              <span class="font-medium">{{ agentNode.data?.label || agentNode.id }}</span>
               <span class="text-[10px] px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-700 dark:text-violet-300">
                 Live
               </span>
             </div>
             <div
-              v-if="liveAgentEntries.length > 0"
+              v-if="liveAgentEntriesFor(agentNode.id).length > 0"
               class="mt-2 space-y-1.5"
             >
               <div class="text-xs font-medium text-muted-foreground">
                 Tool Calls (streaming):
               </div>
               <div
-                v-for="(tc, i) in liveAgentEntries"
+                v-for="(tc, i) in liveAgentEntriesFor(agentNode.id)"
                 :key="i"
                 class="rounded border border-border/50 bg-muted/20 p-2 text-xs"
               >
@@ -3470,7 +3472,7 @@ function renderContent(content: string): string {
         </div>
 
         <div
-          v-else-if="isExecuting"
+          v-if="isExecuting && runningAgentNodes.length === 0"
           class="flex items-center gap-2 text-muted-foreground p-2"
         >
           <Loader2 class="w-4 h-4 animate-spin" />

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -722,6 +722,16 @@ export const workflowApi = {
     onError: (error: Error) => void,
     onDisconnected: () => void,
     signal?: AbortSignal,
+    onNodeRetry?: (data: {
+      node_id: string;
+      node_label: string;
+      attempt: number;
+      max_attempts: number;
+      retry_result?: NodeResult;
+    }) => void,
+    onAgentProgress?: (data: AgentProgressEvent) => void,
+    onLlmBatchProgress?: (data: LLMBatchProgressEvent) => void,
+    onExecutionGone?: () => void,
   ): void => {
     const API_URL = import.meta.env.VITE_API_URL || "";
 
@@ -765,6 +775,12 @@ export const workflowApi = {
               });
             } else if (data.type === "node_start") {
               onNodeStart(data.node_id);
+            } else if (data.type === "node_retry" && onNodeRetry) {
+              onNodeRetry(data);
+            } else if (data.type === "agent_progress" && onAgentProgress) {
+              onAgentProgress(data);
+            } else if (data.type === "llm_batch_progress" && onLlmBatchProgress) {
+              onLlmBatchProgress(data);
             } else if (data.type === "node_complete") {
               onNodeComplete(data);
             } else if (data.type === "execution_complete") {
@@ -780,6 +796,12 @@ export const workflowApi = {
               });
               return;
             } else if (data.type === "error") {
+              if (data.code === "execution_gone" && onExecutionGone) {
+                // Terminal: the run left the registry without a history entry, so
+                // reconnecting would spin forever.
+                onExecutionGone();
+                return;
+              }
               throw new Error(data.message || "Live execution stream failed");
             }
           }

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -82,7 +82,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
   // "overwrite": this tab has edits that would replace the newer server version.
   // "reload": this tab has no edits, so it is simply showing an outdated workflow.
   const staleSaveMode = ref<"overwrite" | "reload">("overwrite");
-  const runningNodeId = ref<string | null>(null);
+  // Every node currently in flight. A set, not a single id: parallel branches and
+  // orchestrator fan-out run several nodes at once. It outlives `clearWorkflow`, so
+  // leaving and re-entering the editor mid-run restores the running highlights.
+  const runningNodeIds = ref<Set<string>>(new Set());
   const propertiesPanelOpen = ref(false);
   const propertiesPanelVisible = ref(false);
   const analysisPanelOpen = ref(false);
@@ -539,7 +542,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     }
 
     isExecuting.value = false;
-    runningNodeId.value = null;
+    runningNodeIds.value.clear();
     abortController.value = null;
     currentExecutionId.value = result.execution_history_id || null;
     currentExecutionWorkflowId.value = null;
@@ -611,6 +614,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
       currentExecutionId.value = null;
       clearNodeStatuses();
     } else {
+      // Taken before the reset below, which clears the set as it marks nodes pending.
+      // The store tracks these across `clearWorkflow`, so they survive leaving and
+      // re-entering the editor while the run continues in the background.
+      const stillRunningNodeIds = [...runningNodeIds.value];
       nodes.value.forEach((node) => setNodeStatus(node.id, "pending"));
       for (const nodeResult of nodeResults.value) {
         setNodeStatus(
@@ -618,8 +625,8 @@ export const useWorkflowStore = defineStore("workflow", () => {
           nodeResult.status as "success" | "error" | "pending" | "skipped",
         );
       }
-      if (runningNodeId.value) {
-        setNodeStatus(runningNodeId.value, "running");
+      for (const nodeId of stillRunningNodeIds) {
+        setNodeStatus(nodeId, "running");
       }
     }
 
@@ -1232,7 +1239,9 @@ export const useWorkflowStore = defineStore("workflow", () => {
       node.data = { ...node.data, status };
     }
     if (status === "running") {
-      runningNodeId.value = id;
+      runningNodeIds.value.add(id);
+    } else {
+      runningNodeIds.value.delete(id);
     }
   }
 
@@ -1253,7 +1262,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
         };
       }
     });
-    runningNodeId.value = null;
+    runningNodeIds.value.clear();
   }
 
   /**
@@ -1423,7 +1432,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
               executionResult.value = { ...result, node_results: [] };
               clearNodeStatuses();
               isExecuting.value = false;
-              runningNodeId.value = null;
+              runningNodeIds.value.clear();
               abortController.value = null;
               currentExecutionId.value = null;
               currentExecutionWorkflowId.value = null;
@@ -1476,7 +1485,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
             }
 
             isExecuting.value = false;
-            runningNodeId.value = null;
+            runningNodeIds.value.clear();
             abortController.value = null;
             currentExecutionId.value = result.execution_history_id || null;
             currentExecutionWorkflowId.value = null;
@@ -1485,7 +1494,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
           (error: Error) => {
             clearNodeStatuses();
             isExecuting.value = false;
-            runningNodeId.value = null;
+            runningNodeIds.value.clear();
             abortController.value = null;
             currentExecutionId.value = null;
             currentExecutionWorkflowId.value = null;
@@ -1588,7 +1597,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     } catch (e: unknown) {
       clearNodeStatuses();
       isExecuting.value = false;
-      runningNodeId.value = null;
+      runningNodeIds.value.clear();
       abortController.value = null;
       currentExecutionId.value = null;
       currentExecutionWorkflowId.value = null;
@@ -1621,6 +1630,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
 
     while (!streamAbort.signal.aborted) {
       let completed = false;
+      let executionGone = false;
 
       await new Promise<void>((resolve) => {
         workflowApi.streamActiveExecution(
@@ -1630,6 +1640,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
             currentExecutionId.value = data.execution_id;
             loadHistoryInputs(data.inputs);
             nodeResults.value = [];
+            // Each (re)connect replays the run's live events from the start, so the
+            // agent/batch logs are rebuilt rather than appended to.
+            agentProgressLogs.value = new Map();
+            llmBatchProgressLogs.value = new Map();
             clearNodeStatuses();
             nodes.value.forEach((node) => setNodeStatus(node.id, "pending"));
           },
@@ -1688,10 +1702,18 @@ export const useWorkflowStore = defineStore("workflow", () => {
             const historyEntry = historyId
               ? await fetchExecutionHistoryEntry(historyId, true)
               : null;
+            // A cancelled run is persisted without per-node results; keep what was
+            // streamed so the log does not empty out on Stop.
+            const streamedRows = nodeResults.value.filter(
+              (nodeResult) => nodeResult.status !== "running",
+            );
             if (historyEntry?.result) {
               applyExecutionHistoryEntry(historyEntry);
             } else {
               applyExecutionResultSnapshot(result);
+            }
+            if (nodeResults.value.length === 0 && streamedRows.length > 0) {
+              nodeResults.value = streamedRows;
             }
             isObservingExecution.value = false;
             resolve();
@@ -1699,6 +1721,71 @@ export const useWorkflowStore = defineStore("workflow", () => {
           (_error) => resolve(),
           () => resolve(),
           streamAbort.signal,
+          (data) => {
+            const node = nodes.value.find((n) => n.id === data.node_id);
+            if (node) {
+              node.data = { ...node.data, retryAttempt: data.attempt };
+            }
+
+            const retryResult = data.retry_result;
+            if (!retryResult || typeof retryResult !== "object") {
+              return;
+            }
+            const row: NodeResult = {
+              node_id: retryResult.node_id,
+              node_label: retryResult.node_label || retryResult.node_id,
+              node_type: retryResult.node_type || "unknown",
+              status: retryResult.status as "success" | "error" | "pending" | "skipped",
+              output: retryResult.output,
+              execution_time_ms: retryResult.execution_time_ms,
+              error: retryResult.error ?? null,
+            };
+            if (retryResult.metadata && typeof retryResult.metadata === "object") {
+              row.metadata = retryResult.metadata;
+            }
+            nodeResults.value = [...nodeResults.value, row];
+          },
+          (data) => {
+            const m = new Map(agentProgressLogs.value);
+            const arr = m.get(data.node_id) ?? [];
+            const entry = data.entry;
+            const toolCallId = entry.tool_call_id;
+            const phase = entry.phase;
+            if (toolCallId && phase && phase !== "start") {
+              const idx = [...arr].map((e) => e.tool_call_id).lastIndexOf(toolCallId);
+              if (idx >= 0) {
+                const next = [...arr];
+                next[idx] = { ...next[idx], ...entry };
+                m.set(data.node_id, next);
+                agentProgressLogs.value = m;
+                return;
+              }
+            }
+            arr.push(entry);
+            m.set(data.node_id, arr);
+            agentProgressLogs.value = m;
+          },
+          (data) => {
+            const m = new Map(llmBatchProgressLogs.value);
+            const arr = m.get(data.node_id) ?? [];
+            arr.push(data.entry);
+            m.set(data.node_id, arr);
+            llmBatchProgressLogs.value = m;
+
+            const node = nodes.value.find((n) => n.id === data.node_id);
+            if (node) {
+              node.data = {
+                ...node.data,
+                batchRuntimeStatus: data.entry.status,
+                batchRuntimeRawStatus: data.entry.rawStatus,
+                batchRuntimeRequestCounts: data.entry.requestCounts,
+              };
+            }
+          },
+          () => {
+            executionGone = true;
+            resolve();
+          },
         );
       });
 
@@ -1708,6 +1795,19 @@ export const useWorkflowStore = defineStore("workflow", () => {
       if (historyEntry?.result) {
         applyExecutionHistoryEntry(historyEntry);
         isObservingExecution.value = false;
+        return;
+      }
+
+      if (executionGone) {
+        // The run is neither active nor recorded (cancelled mid-flight): settle the
+        // canvas instead of reconnecting to a stream that will never report again.
+        isObservingExecution.value = false;
+        isExecuting.value = false;
+        runningNodeIds.value.clear();
+        abortController.value = null;
+        currentExecutionWorkflowId.value = null;
+        dropUnresolvedNodeResults();
+        clearNodeStatuses();
         return;
       }
 
@@ -1725,6 +1825,17 @@ export const useWorkflowStore = defineStore("workflow", () => {
     }
   }
 
+  /** Drop the placeholder rows observation adds on node_start but never resolved.
+   *
+   * They carry no output and would otherwise keep spinning at 0.00ms once the run
+   * is stopped or disappears. A finished run replaces nodeResults wholesale, so
+   * this only ever touches an interrupted observation.
+   */
+  function dropUnresolvedNodeResults(): void {
+    if (!nodeResults.value.some((result) => result.status === "running")) return;
+    nodeResults.value = nodeResults.value.filter((result) => result.status !== "running");
+  }
+
   function disconnectExecutionObservation(): void {
     if (!isObservingExecution.value) return;
     abortController.value?.abort();
@@ -1733,6 +1844,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     isExecuting.value = false;
     currentExecutionId.value = null;
     currentExecutionWorkflowId.value = null;
+    dropUnresolvedNodeResults();
     clearNodeStatuses();
   }
 
@@ -1752,7 +1864,8 @@ export const useWorkflowStore = defineStore("workflow", () => {
     }
     isExecuting.value = false;
     isObservingExecution.value = false;
-    runningNodeId.value = null;
+    runningNodeIds.value.clear();
+    dropUnresolvedNodeResults();
     clearNodeStatuses();
     currentExecutionId.value = null;
     currentExecutionWorkflowId.value = null;
@@ -3322,7 +3435,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     isObservingExecution,
     isSaving,
     hasUnsavedChanges,
-    runningNodeId,
+    runningNodeIds,
     pendingNodeDeletion,
     clipboardNode,
     canUndo,


### PR DESCRIPTION
* Fix live execution progress in the canvas

Observed runs only got coarse node snapshots, so sub-agents stayed pending and the log stalled. Buffer the runner's SSE events on the shared execution handle and replay them to late observers.

Also: persist cancelled portal runs so observers get a terminal event, drop unresolved placeholder rows on stop, and track running nodes as a set so parallel nodes survive leaving and re-entering the editor.