### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 <br/>
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
+[![MCP status](https://mcpvitals.com/badge/46f18385ee.svg?theme=flat-square)](https://mcpvitals.com/status/46f18385ee)
 [![Commons Clause](https://img.shields.io/badge/Condition-Commons%20Clause-orange.svg?style=flat-square)](COMMONS-CLAUSE.md)
 [![Heym Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fheymrun%2Fheym%2Fmain%2Ffrontend%2Fpackage.json&query=%24.version&label=Heym&prefix=v&color=blueviolet&style=flat-square)](https://github.com/heymrun/heym/releases)
 [![Python](https://img.shields.io/badge/Python-3.11+-3776AB?style=flat-square&logo=python&logoColor=white)](https://python.org)


### PR DESCRIPTION
Hi Heym team 👋

I built [MCP Vitals](https://mcpvitals.com) and set up a free public monitor for your hosted MCP endpoint (`heym.run/mcp`) — real handshake checks every few minutes, currently healthy with 4 tools.

This PR adds a small live status badge to the badge row (up/down at a glance + tool-schema drift detection):

[![MCP status](https://mcpvitals.com/badge/46f18385ee.svg?theme=flat-square)](https://mcpvitals.com/status/46f18385ee)

Free, links to a public uptime page, no signup. Happy to hand the monitor over to you if you'd like to own it. Close if it's not for you 🙏
