### PR TITLE
docs(dsl): expand converter node guidance in the workflow DSL prompt

### DIFF
--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -1296,12 +1296,30 @@ The http node ALWAYS returns a structured response object:
   - `label`: Node identifier
   - `conversion`: `"csvToJson"` (CSV text -> array of row objects) or `"jsonToCsv"` (array of objects/rows -> CSV text)
   - `source`: Expression for the input to convert (e.g. `"$previousNode.body"` or `"$userInput.body.text"`). If empty, the first input is used.
-  - `delimiter`: Single-character field delimiter (default `,`)
-  - `hasHeader`: Boolean, `csvToJson` only — first row is the header (default true)
-  - `trimValues`: Boolean, `csvToJson` only — strip whitespace around header names and cell values (default true)
+  - `delimiter`: Single-character field delimiter (default `,`). Use `"\\t"` for tab-separated values.
+  - `hasHeader`: Boolean, `csvToJson` only — first row is the header (default true). When false each row is an array of cell values instead of an object.
+  - `trimValues`: Boolean, `csvToJson` only — strip whitespace around header names and cell values (default true). Set false to keep whitespace inside quoted fields exactly as written.
   - `includeHeader`: Boolean, `jsonToCsv` only — write a header row (default true)
-  - `converterColumns`: Optional explicit column order for `jsonToCsv` (comma-separated string)
-- **Output**: `$label.result` — parsed rows for `csvToJson`, CSV string for `jsonToCsv`.
+  - `converterColumns`: Optional explicit column order for `jsonToCsv` (comma-separated string). When omitted, columns are inferred from the row keys.
+- **Output**: `$label.result` — parsed rows for `csvToJson`, CSV string for `jsonToCsv`. `$label.conversion` echoes the conversion that ran.
+
+**Example** (CSV text -> rows):
+```json
+{
+  "type": "converter",
+  "data": {
+    "label": "toRows",
+    "conversion": "csvToJson",
+    "source": "$userInput.body.text",
+    "delimiter": ",",
+    "hasHeader": true,
+    "trimValues": true
+  }
+}
+```
+For `name,age\\nAda,36` downstream nodes read `$toRows.result` -> `[{ "name": "Ada", "age": "36" }]`.
+
+**⚠️ USE `converter` INSTEAD OF `execute`/`llm` FOR CSV**: When the user asks to parse, read, or build CSV/TSV, use a `converter` node. Do NOT write Python in an `execute` node and do NOT ask an LLM to reformat the rows — quoting, embedded newlines, and BOM handling are already correct here. Loop over `$label.result` with a `loop` node to process rows one by one.
 
 ### 14. sticky (Note)
 - **Purpose**: Add documentation notes to canvas (not executed)


### PR DESCRIPTION
## Summary

The `converter` node landed in #429 with a minimal DSL entry that listed its fields but not their behavior. The assistant had no signal about *when* to reach for the node, or what the non-default settings actually do. This fills that in.

Prompt text only, no behavior change.

## What changed

Section `13b. converter` in `workflow_dsl_prompt.py`:

- Document `"\t"` as the delimiter for tab-separated values
- Note that `hasHeader: false` yields arrays of cell values rather than objects
- Explain what `trimValues: false` preserves inside quoted fields
- Note that `converterColumns` falls back to inferring columns from row keys
- Document the `$label.conversion` echo key alongside `$label.result`
- Add a worked `csvToJson` example with its resolved output
- Steer CSV work to the converter node instead of an `execute` or `llm` node, since RFC 4180 quoting, embedded newlines, and BOM stripping are already handled there

Each item reflects behavior already implemented in `node_execution/nodes/converter_node.py` and already described in `docs/content/nodes/converter-node.md`; this brings the DSL prompt up to the same level of detail.

## Testing

- `./check.sh` — exit 0, 2676/2676 backend tests, vue-tsc + eslint + ruff clean
- `ruff format --check` and `ruff check` clean on the touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)