### PR TITLE
fix/cron-timer-on-workers

### DIFF
--- a/backend/alembic/versions/104_add_cron_slot_claims.py
+++ b/backend/alembic/versions/104_add_cron_slot_claims.py
@@ -1,0 +1,53 @@
+"""add cron slot claims
+
+Revision ID: 104_add_cron_slot_claims
+Revises: 103_add_google_drive_cred_type
+Create Date: 2026-08-04 00:00:00.000000
+
+Note: alembic_version.version_num is varchar(32), so the revision id must stay
+within 32 characters.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "104_add_cron_slot_claims"
+down_revision: Union[str, None] = "103_add_google_drive_cred_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cron_slot_claims",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "workflow_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workflows.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("node_id", sa.String(length=255), nullable=False),
+        sa.Column("slot_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("claimed_by", sa.String(length=128), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("workflow_id", "node_id", "slot_at", name="uq_cron_slot_claim"),
+    )
+    op.create_index("ix_cron_slot_claims_workflow_id", "cron_slot_claims", ["workflow_id"])
+    op.create_index("ix_cron_slot_claims_slot_at", "cron_slot_claims", ["slot_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_cron_slot_claims_slot_at", table_name="cron_slot_claims")
+    op.drop_index("ix_cron_slot_claims_workflow_id", table_name="cron_slot_claims")
+    op.drop_table("cron_slot_claims")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -52,6 +52,9 @@ class Settings(BaseSettings):
     allow_register: bool = True
     trust_proxy_headers: bool = False
     timezone: str = ""
+    # How late a cron slot may still run. Protects against a scheduler that was
+    # paused (leadership handoff, restart, host suspend) firing a whole backlog.
+    cron_misfire_grace_seconds: int = 600
     oauth_access_token_expire_seconds: int = 3600
     oauth_refresh_token_expire_days: int = 30
     oauth_auth_code_expire_minutes: int = 10

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1652,6 +1652,35 @@ class WorkflowResponseCache(Base):
     )
 
 
+class CronSlotClaim(Base):
+    """One row per cron slot that has already been claimed for execution.
+
+    Every uvicorn worker runs its own scheduler and only the leader ticks, so a
+    leadership handoff used to hand a worker with stale in-memory state a whole
+    backlog of "missed" slots. The unique constraint makes the claim the single
+    source of truth: a slot runs once, whichever worker inserts the row first.
+    """
+
+    __tablename__ = "cron_slot_claims"
+    __table_args__ = (
+        UniqueConstraint("workflow_id", "node_id", "slot_at", name="uq_cron_slot_claim"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workflow_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workflows.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    node_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    slot_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    claimed_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
 class AgentMemoryNode(Base):
     """Knowledge-graph entity for an agent node (canvas) within a workflow."""
 

--- a/backend/app/services/cron_scheduler.py
+++ b/backend/app/services/cron_scheduler.py
@@ -13,8 +13,10 @@ from app.api.workflows import (
     collect_referenced_workflows,
     get_credentials_context,
 )
+from app.config import settings
 from app.db.models import ExecutionHistory, PortalSession, Workflow, WorkflowVersion
 from app.db.session import async_session_maker
+from app.services.cron_slot_state import claim_cron_slot, cleanup_cron_slot_claims
 from app.services.distributed_lock import lock_service
 from app.services.global_variables_service import get_global_variables_context
 from app.services.hitl_service import build_default_public_base_url, persist_pending_hitl_execution
@@ -35,6 +37,7 @@ class CronScheduler:
         self._last_refresh_token_cleanup_date: str | None = None
         self._last_file_access_token_cleanup_date: str | None = None
         self._last_response_cache_cleanup_date: str | None = None
+        self._last_cron_slot_claim_cleanup_date: str | None = None
 
     async def start(self) -> None:
         if self._running:
@@ -67,6 +70,7 @@ class CronScheduler:
                 await self._check_refresh_token_cleanup()
                 await self._check_file_access_token_cleanup()
                 await self._check_response_cache_cleanup()
+                await self._check_cron_slot_claim_cleanup()
             except Exception as e:
                 logger.exception("Error in cron scheduler loop: %s", e)
             await asyncio.sleep(30)
@@ -87,19 +91,24 @@ class CronScheduler:
                     node_id = node.get("id", "")
                     node_key = f"{workflow.id}_{node_id}"
                     try:
-                        if self._should_trigger(cron_expr, now, node_key):
-                            minute_key = now.strftime("%Y%m%d%H%M")
-                            can_execute = await lock_service.check_cron_execution(
-                                str(workflow.id),
-                                node_id,
-                                minute_key,
+                        slot = self._due_slot(cron_expr, now, node_key)
+                        if slot is not None:
+                            claimed = await claim_cron_slot(
+                                workflow_id=workflow.id,
+                                node_id=node_id,
+                                slot_at=slot,
+                                worker_id=lock_service.worker_id,
                             )
-                            if can_execute:
+                            # Settle the slot either way: a lost claim means another
+                            # worker owns this run, and retrying next pass would only
+                            # risk a duplicate.
+                            self.mark_slot_handled(node_key, slot)
+                            if claimed:
                                 await self._execute_workflow(db, workflow)
-                                self._last_check[node_key] = now
                             else:
                                 logger.debug(
-                                    "Cron execution for %s already handled by another worker",
+                                    "Cron slot %s for %s already claimed by another worker",
+                                    slot.isoformat(),
                                     node_key,
                                 )
                     except Exception as e:
@@ -128,22 +137,42 @@ class CronScheduler:
             if n.get("type") == "cron" and n.get("data", {}).get("active", True) is not False
         ]
 
-    def _should_trigger(self, cron_expr: str, now: datetime, node_key: str) -> bool:
+    def _due_slot(self, cron_expr: str, now: datetime, node_key: str) -> datetime | None:
+        """Return the scheduled slot this pass should run, or None.
+
+        A slot is due when it has passed, this process has not handled it yet,
+        and it is still inside the misfire grace window. Anything older is a
+        backlog entry (paused scheduler, leadership handoff, restart) and is
+        dropped instead of being replayed hours late.
+        """
         try:
-            cron = croniter(cron_expr, now)
-            prev_time = cron.get_prev(datetime)
-            last_check = self._last_check.get(node_key)
-
-            if last_check is None:
-                self._last_check[node_key] = now
-                return False
-
-            if prev_time.replace(tzinfo=now.tzinfo) > last_check:
-                return True
-            return False
+            prev_time = croniter(cron_expr, now).get_prev(datetime)
         except Exception as e:
             logger.error("Invalid cron expression '%s': %s", cron_expr, e)
-            return False
+            return None
+
+        slot = prev_time.replace(tzinfo=now.tzinfo)
+        if self._last_check.get(node_key) == slot:
+            return None
+
+        lateness = (now - slot).total_seconds()
+        if lateness > settings.cron_misfire_grace_seconds:
+            if self._last_check.get(node_key) is not None:
+                logger.info(
+                    "Skipping cron slot %s for %s: %.0fs late (grace %ss)",
+                    slot.isoformat(),
+                    node_key,
+                    lateness,
+                    settings.cron_misfire_grace_seconds,
+                )
+            self.mark_slot_handled(node_key, slot)
+            return None
+
+        return slot
+
+    def mark_slot_handled(self, node_key: str, slot: datetime) -> None:
+        """Record a slot as settled for this process so later passes skip it."""
+        self._last_check[node_key] = slot
 
     async def _execute_workflow(self, db: AsyncSession, workflow: Workflow) -> None:
         logger.info("Executing workflow %s via cron trigger", workflow.id)
@@ -167,7 +196,10 @@ class CronScheduler:
                 actor_user_id=workflow.owner_id,
             )
             try:
-                result = execute_workflow(
+                # Off the event loop: a cron run can block for minutes, and this
+                # worker still has to serve HTTP and keep its leader lock alive.
+                result = await asyncio.to_thread(
+                    execute_workflow,
                     workflow_id=workflow.id,
                     nodes=workflow.nodes,
                     edges=workflow.edges,
@@ -507,6 +539,33 @@ class CronScheduler:
                     self._last_response_cache_cleanup_date = current_date
                 else:
                     logger.debug("Response cache cleanup already handled by another worker")
+
+    async def _check_cron_slot_claim_cleanup(self) -> None:
+        tz = get_configured_timezone()
+        now = datetime.now(tz)
+        current_date = now.strftime("%Y%m%d")
+
+        if now.hour == 4 and now.minute >= 30 and now.minute < 60:
+            if self._last_cron_slot_claim_cleanup_date != current_date:
+                can_cleanup = await lock_service.check_cron_execution(
+                    "cron_slot_claim_cleanup",
+                    "cleanup",
+                    current_date,
+                )
+                if can_cleanup:
+                    await self._cleanup_old_cron_slot_claims()
+                    self._last_cron_slot_claim_cleanup_date = current_date
+                else:
+                    logger.debug("Cron slot claim cleanup already handled by another worker")
+
+    async def _cleanup_old_cron_slot_claims(self) -> None:
+        async with async_session_maker() as db:
+            deleted_count = await cleanup_cron_slot_claims(db)
+            if deleted_count > 0:
+                await db.commit()
+                logger.info(
+                    "Cron slot claim cleanup completed: %d old claims deleted", deleted_count
+                )
 
     async def _cleanup_expired_response_cache(self) -> None:
         from app.services.cache_rate_limit import response_cache

--- a/backend/app/services/cron_slot_state.py
+++ b/backend/app/services/cron_slot_state.py
@@ -1,0 +1,72 @@
+"""Cross-worker bookkeeping for cron slots that have already been run.
+
+The scheduler's in-memory state is per uvicorn worker, so it cannot answer
+"did anyone already run this slot?" on its own. These helpers keep that answer
+in Postgres, where every worker (and every restart) sees the same truth.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import CronSlotClaim
+from app.db.session import async_session_maker
+
+logger = logging.getLogger("cron_scheduler")
+
+CLAIM_RETENTION_DAYS = 7
+
+
+async def claim_cron_slot(
+    *,
+    workflow_id: uuid.UUID,
+    node_id: str,
+    slot_at: datetime,
+    worker_id: str | None = None,
+) -> bool:
+    """Claim one cron slot for this worker.
+
+    Returns True only for the worker that inserted the row; everyone else - a
+    concurrent worker, or the same worker after a restart - gets False and must
+    skip the run. Fails closed: on a database error nothing is executed.
+    """
+    stmt = (
+        pg_insert(CronSlotClaim)
+        .values(
+            id=uuid.uuid4(),
+            workflow_id=workflow_id,
+            node_id=node_id,
+            slot_at=slot_at,
+            claimed_by=worker_id,
+        )
+        .on_conflict_do_nothing(constraint="uq_cron_slot_claim")
+        .returning(CronSlotClaim.id)
+    )
+    try:
+        async with async_session_maker() as db:
+            result = await db.execute(stmt)
+            claimed = result.first() is not None
+            await db.commit()
+            return claimed
+    except Exception as e:
+        logger.warning(
+            "Failed to claim cron slot for workflow %s node %s at %s: %s",
+            workflow_id,
+            node_id,
+            slot_at,
+            e,
+        )
+        return False
+
+
+async def cleanup_cron_slot_claims(
+    db: AsyncSession, *, retention_days: int = CLAIM_RETENTION_DAYS
+) -> int:
+    """Drop claims older than the retention window; they can never match again."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    result = await db.execute(delete(CronSlotClaim).where(CronSlotClaim.slot_at < cutoff))
+    return result.rowcount or 0

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -15,7 +15,16 @@ class AlembicMigrationGraphTest(unittest.TestCase):
         self.script = ScriptDirectory.from_config(config)
 
     def test_revision_graph_has_one_head(self) -> None:
-        self.assertEqual(self.script.get_heads(), ["103_add_google_drive_cred_type"])
+        self.assertEqual(self.script.get_heads(), ["104_add_cron_slot_claims"])
+
+    def test_cron_slot_claims_revision_follows_google_drive_revision(self) -> None:
+        cron_slot_revision = self.script.get_revision("104_add_cron_slot_claims")
+
+        self.assertIsNotNone(cron_slot_revision)
+        self.assertEqual(
+            cron_slot_revision.down_revision,
+            "103_add_google_drive_cred_type",
+        )
 
     def test_live_execution_snapshot_revision_follows_opencode_revision(self) -> None:
         live_execution_revision = self.script.get_revision("101_add_live_execution_snapshots")

--- a/backend/tests/test_cron_scheduler.py
+++ b/backend/tests/test_cron_scheduler.py
@@ -1,8 +1,11 @@
+import threading
 import unittest
 import uuid
 from concurrent.futures import Future
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+from zoneinfo import ZoneInfo
 
 from app.db.models import ExecutionHistory
 from app.services.cron_scheduler import CronScheduler
@@ -278,3 +281,170 @@ class CronSchedulerExecutionHistoryTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(persist_kwargs["public_base_url"], "https://app.example.com")
         self.assertEqual(added_rows, [])
         db.commit.assert_awaited_once()
+
+
+class CronDueSlotTests(unittest.TestCase):
+    """Slot selection: which scheduled slot (if any) a scheduler pass should run."""
+
+    EXPR = "0 9 * * *"
+    NODE_KEY = "wf_n1"
+    TZ = ZoneInfo("Europe/Berlin")
+
+    def _at(self, hour: int, minute: int = 0, second: int = 0) -> datetime:
+        return datetime(2026, 8, 4, hour, minute, second, tzinfo=self.TZ)
+
+    def test_returns_slot_when_pass_runs_just_after_it(self) -> None:
+        scheduler = CronScheduler()
+
+        slot = scheduler._due_slot(self.EXPR, self._at(9, 0, 12), self.NODE_KEY)
+
+        self.assertEqual(slot, self._at(9))
+
+    def test_returns_slot_on_first_pass_of_a_fresh_process(self) -> None:
+        """A restart must not silently swallow a slot that just came due."""
+        scheduler = CronScheduler()
+        self.assertEqual(scheduler._last_check, {})
+
+        slot = scheduler._due_slot(self.EXPR, self._at(9, 2), self.NODE_KEY)
+
+        self.assertEqual(slot, self._at(9))
+
+    def test_skips_slot_older_than_the_misfire_grace_window(self) -> None:
+        """The leadership-handoff case: a worker with stale state must not backfill."""
+        scheduler = CronScheduler()
+        scheduler._last_check[self.NODE_KEY] = self._at(3)
+
+        slot = scheduler._due_slot(self.EXPR, self._at(18, 14, 38), self.NODE_KEY)
+
+        self.assertIsNone(slot)
+
+    def test_skips_slot_this_process_already_handled(self) -> None:
+        scheduler = CronScheduler()
+        scheduler.mark_slot_handled(self.NODE_KEY, self._at(9))
+
+        slot = scheduler._due_slot(self.EXPR, self._at(9, 0, 42), self.NODE_KEY)
+
+        self.assertIsNone(slot)
+
+    def test_returns_none_for_invalid_expression(self) -> None:
+        scheduler = CronScheduler()
+
+        self.assertIsNone(scheduler._due_slot("not a cron", self._at(9), self.NODE_KEY))
+
+
+class CronSlotClaimTests(unittest.IsolatedAsyncioTestCase):
+    """A due slot runs at most once across all workers, whoever wins the claim."""
+
+    def _scheduler_with_one_cron_workflow(self) -> tuple[CronScheduler, SimpleNamespace]:
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Cron workflow",
+            # Every minute, so the previous slot is always freshly due.
+            nodes=[{"id": "n1", "type": "cron", "data": {"cronExpression": "* * * * *"}}],
+            edges=[],
+        )
+        scheduler = CronScheduler()
+        return scheduler, workflow
+
+    async def _run_pass(
+        self, scheduler: CronScheduler, workflow: SimpleNamespace, *, claimed: bool
+    ) -> AsyncMock:
+        execute = AsyncMock()
+        claim = AsyncMock(return_value=claimed)
+        session = AsyncMock()
+        session.__aenter__.return_value = session
+        session.__aexit__.return_value = False
+
+        with (
+            patch("app.services.cron_scheduler.async_session_maker", return_value=session),
+            patch.object(
+                CronScheduler, "_get_workflows_with_cron", AsyncMock(return_value=[workflow])
+            ),
+            patch.object(CronScheduler, "_execute_workflow", execute),
+            patch("app.services.cron_scheduler.claim_cron_slot", claim),
+        ):
+            await scheduler._check_and_execute()
+        self.claim = claim
+        return execute
+
+    async def test_executes_when_this_worker_wins_the_slot_claim(self) -> None:
+        scheduler, workflow = self._scheduler_with_one_cron_workflow()
+
+        execute = await self._run_pass(scheduler, workflow, claimed=True)
+
+        execute.assert_awaited_once()
+        claim_kwargs = self.claim.await_args.kwargs
+        self.assertEqual(claim_kwargs["workflow_id"], workflow.id)
+        self.assertEqual(claim_kwargs["node_id"], "n1")
+        slot = claim_kwargs["slot_at"]
+        self.assertEqual(slot.second, 0)
+        self.assertEqual(slot.microsecond, 0)
+        self.assertLess((datetime.now(slot.tzinfo) - slot).total_seconds(), 120)
+
+    async def test_skips_execution_when_another_worker_claimed_the_slot(self) -> None:
+        scheduler, workflow = self._scheduler_with_one_cron_workflow()
+
+        execute = await self._run_pass(scheduler, workflow, claimed=False)
+
+        execute.assert_not_awaited()
+
+    async def test_lost_claim_is_not_retried_on_the_next_pass(self) -> None:
+        """Without this, the next pass gets a fresh minute key and double-fires."""
+        scheduler, workflow = self._scheduler_with_one_cron_workflow()
+
+        await self._run_pass(scheduler, workflow, claimed=False)
+        execute = await self._run_pass(scheduler, workflow, claimed=True)
+
+        execute.assert_not_awaited()
+        self.claim.assert_not_awaited()
+
+
+class CronExecutorThreadingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_execute_workflow_runs_the_executor_off_the_event_loop(self) -> None:
+        """A blocking run must not stall the worker's event loop (leader heartbeat, HTTP)."""
+        scheduler = CronScheduler()
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            owner_id=uuid.uuid4(),
+            name="Cron workflow",
+            nodes=[],
+            edges=[],
+        )
+        db = SimpleNamespace(add=lambda row: None, commit=AsyncMock())
+        execution_result = ExecutionResult(
+            workflow_id=workflow_id,
+            status="success",
+            outputs={},
+            execution_time_ms=1.0,
+            node_results=[],
+        )
+        run_threads: list[str] = []
+
+        def fake_execute(**_kwargs: object) -> ExecutionResult:
+            run_threads.append(threading.current_thread().name)
+            return execution_result
+
+        with (
+            patch(
+                "app.services.cron_scheduler.collect_referenced_workflows",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "app.services.cron_scheduler.get_credentials_context", AsyncMock(return_value={})
+            ),
+            patch(
+                "app.services.cron_scheduler.get_global_variables_context",
+                AsyncMock(return_value={}),
+            ),
+            patch("app.services.cron_scheduler.execute_workflow", fake_execute),
+            patch("app.services.cron_scheduler.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch(
+                "app.services.cron_scheduler._persist_global_variables_from_execution", AsyncMock()
+            ),
+        ):
+            await scheduler._execute_workflow(db, workflow)
+
+        self.assertEqual(len(run_threads), 1)
+        self.assertNotEqual(run_threads[0], threading.current_thread().name)

--- a/backend/tests/test_cron_slot_state.py
+++ b/backend/tests/test_cron_slot_state.py
@@ -1,0 +1,74 @@
+import unittest
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.cron_slot_state import claim_cron_slot, cleanup_cron_slot_claims
+
+
+def _session_returning(first_row: object | None) -> AsyncMock:
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = False
+    session.execute.return_value = SimpleNamespace(first=lambda: first_row)
+    return session
+
+
+class ClaimCronSlotTests(unittest.IsolatedAsyncioTestCase):
+    SLOT = datetime(2026, 8, 4, 9, 0, tzinfo=timezone.utc)
+
+    async def test_claim_wins_when_the_row_is_inserted(self) -> None:
+        session = _session_returning((uuid.uuid4(),))
+
+        with patch("app.services.cron_slot_state.async_session_maker", return_value=session):
+            claimed = await claim_cron_slot(
+                workflow_id=uuid.uuid4(),
+                node_id="n1",
+                slot_at=self.SLOT,
+                worker_id="worker-38",
+            )
+
+        self.assertTrue(claimed)
+        session.commit.assert_awaited_once()
+
+    async def test_claim_loses_when_another_worker_already_owns_the_slot(self) -> None:
+        """on_conflict_do_nothing returns no row: the slot is someone else's."""
+        session = _session_returning(None)
+
+        with patch("app.services.cron_slot_state.async_session_maker", return_value=session):
+            claimed = await claim_cron_slot(
+                workflow_id=uuid.uuid4(), node_id="n1", slot_at=self.SLOT
+            )
+
+        self.assertFalse(claimed)
+
+    async def test_claim_fails_closed_on_database_error(self) -> None:
+        session = AsyncMock()
+        session.__aenter__.return_value = session
+        session.__aexit__.return_value = False
+        session.execute.side_effect = RuntimeError("connection is closed")
+
+        with patch("app.services.cron_slot_state.async_session_maker", return_value=session):
+            claimed = await claim_cron_slot(
+                workflow_id=uuid.uuid4(), node_id="n1", slot_at=self.SLOT
+            )
+
+        self.assertFalse(claimed)
+
+
+class CleanupCronSlotClaimsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deletes_claims_older_than_the_retention_window(self) -> None:
+        db = AsyncMock()
+        db.execute.return_value = MagicMock(rowcount=3)
+
+        deleted = await cleanup_cron_slot_claims(db, retention_days=7)
+
+        self.assertEqual(deleted, 3)
+        statement = db.execute.await_args.args[0]
+        cutoff = statement.whereclause.right.value
+        self.assertAlmostEqual(
+            cutoff.timestamp(),
+            (datetime.now(timezone.utc) - timedelta(days=7)).timestamp(),
+            delta=5,
+        )


### PR DESCRIPTION
feat: implement cron slot claiming mechanism

- Added a new CronSlotClaim model to manage cron slot executions across workers, ensuring that each slot is only executed once.
- Introduced a cron_misfire_grace_seconds setting to handle missed executions due to scheduler pauses.
- Enhanced the CronScheduler to include logic for claiming and cleaning up cron slots, preventing duplicate executions.
- Updated tests to cover new functionality for cron slot claims and their handling.