### PR TITLE
impl/custom-rag-embeddings

### DIFF
--- a/backend/alembic/versions/105_add_rag_credential_type.py
+++ b/backend/alembic/versions/105_add_rag_credential_type.py
@@ -1,0 +1,28 @@
+"""add rag credential type
+
+Revision ID: 105_add_rag_credential_type
+Revises: 104_add_cron_slot_claims
+Create Date: 2026-08-05 00:00:00.000000
+
+Note: alembic_version.version_num is varchar(32), so the revision id must stay
+within 32 characters.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "105_add_rag_credential_type"
+down_revision: Union[str, None] = "104_add_cron_slot_claims"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE credential_type ADD VALUE IF NOT EXISTS 'rag'")
+
+
+def downgrade() -> None:
+    # PostgreSQL does not support removing enum values; downgrade is a no-op.
+    pass

--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -38,7 +38,15 @@ from app.models.schemas import (
     TeamShareResponse,
 )
 from app.services.codex_usage_service import fetch_codex_usage
+from app.services.embedding import (
+    EMBEDDING_DIMENSIONS,
+    EmbeddingService,
+    as_bool,
+    embedding_config_from_credential,
+)
 from app.services.encryption import decrypt_config, encrypt_config, mask_api_key
+from app.services.vector_store import VECTOR_STORE_BACKENDS
+from app.services.vector_store_pg import pgvector_dimension_message
 
 router = APIRouter()
 
@@ -49,6 +57,27 @@ def merge_credential_config_for_update(
     incoming_config: dict,
 ) -> dict:
     """Merge update payload into an existing credential config when needed."""
+    if credential_type == CredentialType.rag:
+        # The dialog leaves secret inputs blank unless the user retypes them, so a
+        # blank key means "keep the stored one" rather than "clear it".
+        merged_config = dict(existing_config)
+        for key in (
+            "embedding_base_url",
+            "embedding_model",
+            "embedding_dimensions",
+            "embedding_request_dimensions",
+            "db_type",
+            "qdrant_host",
+            "qdrant_port",
+        ):
+            if key in incoming_config:
+                merged_config[key] = incoming_config[key]
+        for key in ("embedding_api_key", "qdrant_api_key"):
+            incoming_value = str(incoming_config.get(key, "") or "").strip()
+            if incoming_value:
+                merged_config[key] = incoming_value
+        return merged_config
+
     if credential_type == CredentialType.notion:
         merged_config = dict(existing_config)
         incoming_auth_mode = str(incoming_config.get("auth_mode", "") or "").strip()
@@ -201,6 +230,12 @@ def get_masked_value(credential_type: CredentialType, config: dict) -> str | Non
     elif credential_type == CredentialType.pgvector:
         openai_api_key = config.get("openai_api_key", "")
         return mask_api_key(openai_api_key)
+    elif credential_type == CredentialType.rag:
+        embedding_api_key = str(config.get("embedding_api_key", "") or "").strip()
+        if embedding_api_key:
+            return mask_api_key(embedding_api_key)
+        model = str(config.get("embedding_model", "") or "").strip()
+        return model or None
     elif credential_type == CredentialType.grist:
         api_key = config.get("api_key", "")
         return mask_api_key(api_key)
@@ -311,6 +346,18 @@ def get_public_credential_fields(
             account_id = str(config.get("account_id", "")).strip()
             fields["account_id"] = account_id or None
         return fields
+    if credential_type == CredentialType.rag:
+        return {
+            "embedding_base_url": str(config.get("embedding_base_url", "")).strip() or None,
+            "embedding_model": str(config.get("embedding_model", "")).strip() or None,
+            "embedding_dimensions": str(config.get("embedding_dimensions") or EMBEDDING_DIMENSIONS),
+            "embedding_request_dimensions": str(
+                as_bool(config.get("embedding_request_dimensions"))
+            ).lower(),
+            "db_type": str(config.get("db_type", "qdrant")).strip() or "qdrant",
+            "qdrant_host": str(config.get("qdrant_host", "") or "").strip() or None,
+            "qdrant_port": str(config.get("qdrant_port") or 6333),
+        }
     return {}
 
 
@@ -469,6 +516,7 @@ async def list_credentials(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=False,
                 shared_by=None,
@@ -491,6 +539,7 @@ async def list_credentials(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=True,
                 shared_by=owner_email,
@@ -512,6 +561,7 @@ async def list_credentials(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=True,
                 shared_by=None,
@@ -610,6 +660,7 @@ async def list_credentials_by_type(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=False,
                 shared_by=None,
@@ -632,6 +683,7 @@ async def list_credentials_by_type(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=True,
                 shared_by=owner_email,
@@ -653,6 +705,7 @@ async def list_credentials_by_type(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=True,
                 shared_by=None,
@@ -718,6 +771,7 @@ async def list_llm_credentials(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=False,
                 shared_by=None,
@@ -740,6 +794,7 @@ async def list_llm_credentials(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=True,
                 shared_by=owner_email,
@@ -761,6 +816,7 @@ async def list_llm_credentials(
                 type=cred.type,
                 masked_value=masked,
                 header_key=header_key,
+                public_fields=get_public_credential_fields(cred.type, config),
                 created_at=cred.created_at,
                 is_shared=True,
                 shared_by=None,
@@ -820,6 +876,35 @@ async def create_credential(
     )
 
 
+RAG_TEST_PROBE_TEXT = "Heym RAG credential connection test."
+
+
+async def _test_rag_embedding_endpoint(config: dict) -> CredentialTestResponse:
+    """Embed a probe string so a bad URL, key, or dimension count surfaces in the dialog."""
+    embedding_config = embedding_config_from_credential(config)
+    service = EmbeddingService(embedding_config)
+    try:
+        embedding = await run_in_threadpool(service.embed_text, RAG_TEST_PROBE_TEXT)
+    except ValueError as exc:
+        return CredentialTestResponse(success=False, message=str(exc))
+    except Exception as exc:
+        # The endpoint is user-supplied, so unreachable hosts and auth failures are
+        # expected outcomes of a test rather than server errors.
+        return CredentialTestResponse(
+            success=False,
+            message=f"Could not reach the embedding endpoint: {exc}",
+        )
+    if embedding_config.request_dimensions:
+        return CredentialTestResponse(
+            success=True,
+            message=(f"Connected. The endpoint honored the requested {len(embedding)} dimensions."),
+        )
+    return CredentialTestResponse(
+        success=True,
+        message=f"Connected. Model returned {len(embedding)} dimensions.",
+    )
+
+
 @router.post("/test", response_model=CredentialTestResponse)
 async def run_credential_connection_test(
     test_data: CredentialTestRequest,
@@ -834,6 +919,7 @@ async def run_credential_connection_test(
         CredentialType.notion,
         CredentialType.clickhouse,
         CredentialType.sentry,
+        CredentialType.rag,
     }:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -864,8 +950,17 @@ async def run_credential_connection_test(
             config = _merge_clickhouse_test_config(config, stored_config)
         elif test_data.type == CredentialType.sentry:
             config = {**stored_config, **{k: v for k, v in config.items() if v}}
+        elif test_data.type == CredentialType.rag:
+            config = {**stored_config, **{k: v for k, v in config.items() if v not in (None, "")}}
         else:
             config = _merge_notion_test_config(config, stored_config)
+
+    if test_data.type == CredentialType.rag:
+        # Only the embedding half is exercised here. Validating the vector store
+        # choice too would reject exactly the case the test exists to diagnose:
+        # a pgvector selection whose dimension count is still unknown.
+        _validate_rag_embedding_fields(config)
+        return await _test_rag_embedding_endpoint(config)
 
     validate_credential_config(test_data.type, config)
 
@@ -1353,6 +1448,60 @@ async def get_codex_usage(
     )
 
 
+def _validate_rag_embedding_fields(config: dict) -> int:
+    """Validate the embedding half of a RAG credential and return its dimension count."""
+    if not str(config.get("embedding_base_url", "") or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="RAG credential requires embedding_base_url",
+        )
+    if not str(config.get("embedding_model", "") or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="RAG credential requires embedding_model",
+        )
+
+    try:
+        dimensions = int(config.get("embedding_dimensions") or EMBEDDING_DIMENSIONS)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="RAG credential requires embedding_dimensions to be a positive integer",
+        ) from None
+    if dimensions <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="RAG credential requires embedding_dimensions to be a positive integer",
+        )
+    return dimensions
+
+
+def _validate_rag_config(config: dict) -> None:
+    """Validate a RAG credential: custom embedding endpoint plus vector store choice."""
+    dimensions = _validate_rag_embedding_fields(config)
+
+    db_type = str(config.get("db_type", "") or "").strip()
+    if db_type not in VECTOR_STORE_BACKENDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"RAG credential requires db_type to be one of: {', '.join(VECTOR_STORE_BACKENDS)}"
+            ),
+        )
+
+    if db_type == "pgvector" and dimensions != EMBEDDING_DIMENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=pgvector_dimension_message(dimensions),
+        )
+
+    if db_type == "qdrant" and not str(config.get("qdrant_host", "") or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="RAG credential requires qdrant_host when db_type is qdrant",
+        )
+
+
 def validate_credential_config(
     credential_type: CredentialType,
     config: dict,
@@ -1561,6 +1710,8 @@ def validate_credential_config(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Postgres vector credential requires openai_api_key",
             )
+    elif credential_type == CredentialType.rag:
+        _validate_rag_config(config)
     elif credential_type == CredentialType.grist:
         if "api_key" not in config or not config["api_key"]:
             raise HTTPException(

--- a/backend/app/api/vector_stores.py
+++ b/backend/app/api/vector_stores.py
@@ -40,7 +40,10 @@ from app.models.schemas import (
 from app.services.encryption import decrypt_config
 from app.services.file_processor import create_file_processor
 from app.services.upload_limits import read_upload_file_limited
-from app.services.vector_store import create_vector_store_service_for_credential
+from app.services.vector_store import (
+    create_vector_store_service_for_credential,
+    rag_credential_backend,
+)
 from app.services.vector_store_pg import VectorStoreBackendUnavailableError
 
 router = APIRouter()
@@ -89,10 +92,14 @@ async def get_credential_config(
             detail="Credential not found",
         )
 
-    if credential.type not in (CredentialType.qdrant, CredentialType.pgvector):
+    if credential.type not in (
+        CredentialType.qdrant,
+        CredentialType.pgvector,
+        CredentialType.rag,
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Credential must be a vector store credential (Qdrant or Postgres)",
+            detail="Credential must be a vector store credential (Qdrant, Postgres, or RAG)",
         )
 
     config = decrypt_config(credential.encrypted_config)
@@ -103,7 +110,17 @@ def get_vector_store_service_from_config(config: dict, credential_type: object):
     return create_vector_store_service_for_credential(credential_type, config)
 
 
-def _backend_for_credential_type(credential_type: object) -> str:
+def _backend_for_credential_type(credential_type: object, config: dict | None = None) -> str:
+    """Which vector store a credential writes into.
+
+    Legacy credentials imply their backend by type; a `rag` credential names it in
+    its config.
+    """
+    if credential_type == CredentialType.rag:
+        try:
+            return rag_credential_backend(config or {})
+        except ValueError:
+            return "qdrant"
     return "pgvector" if credential_type == CredentialType.pgvector else "qdrant"
 
 
@@ -216,9 +233,14 @@ async def list_vector_stores(
 async def _store_backend(store: VectorStore, db: AsyncSession) -> str:
     result = await db.execute(select(Credential).where(Credential.id == store.credential_id))
     credential = result.scalar_one_or_none()
-    if credential and credential.type == CredentialType.pgvector:
-        return "pgvector"
-    return "qdrant"
+    if credential is None:
+        return "qdrant"
+    config = (
+        decrypt_config(credential.encrypted_config)
+        if credential.type == CredentialType.rag
+        else None
+    )
+    return _backend_for_credential_type(credential.type, config)
 
 
 async def _get_store_stats(
@@ -324,7 +346,7 @@ async def create_vector_store(
         created_at=store.created_at,
         updated_at=store.updated_at,
         stats=None,
-        backend=_backend_for_credential_type(credential.type),
+        backend=_backend_for_credential_type(credential.type, config),
     )
 
 
@@ -506,7 +528,7 @@ async def clone_vector_store(
         created_at=new_store.created_at,
         updated_at=new_store.updated_at,
         stats=stats,
-        backend=_backend_for_credential_type(credential.type),
+        backend=_backend_for_credential_type(credential.type, config),
     )
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -59,6 +59,7 @@ class CredentialType(str, PyEnum):
     clickhouse = "clickhouse"
     opencode = "opencode"
     google_drive = "google_drive"
+    rag = "rag"
 
 
 class WorkflowAuthType(str, PyEnum):

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -539,6 +539,7 @@ class CredentialType(str, Enum):
     clickhouse = "clickhouse"
     opencode = "opencode"
     google_drive = "google_drive"
+    rag = "rag"
 
 
 class CredentialConfigOpenAI(BaseModel):
@@ -739,6 +740,7 @@ class CredentialListResponse(BaseModel):
     type: CredentialType
     masked_value: str | None = None
     header_key: str | None = None
+    public_fields: dict[str, str | None] = {}
     created_at: datetime
     is_shared: bool = False
     shared_by: str | None = None
@@ -889,6 +891,20 @@ class CredentialConfigQdrant(BaseModel):
 
 class CredentialConfigPgvector(BaseModel):
     openai_api_key: str
+
+
+class CredentialConfigRag(BaseModel):
+    """RAG credential: a custom embedding endpoint plus the vector store to write into."""
+
+    embedding_base_url: str
+    embedding_api_key: str | None = None
+    embedding_model: str
+    embedding_dimensions: int = 1536
+    embedding_request_dimensions: bool = False
+    db_type: str = "qdrant"
+    qdrant_host: str | None = None
+    qdrant_port: int = 6333
+    qdrant_api_key: str | None = None
 
 
 class CredentialConfigGrist(BaseModel):

--- a/backend/app/services/embedding.py
+++ b/backend/app/services/embedding.py
@@ -11,6 +11,9 @@ MAX_TOKENS_PER_REQUEST = 300000
 SAFETY_MARGIN = 50000
 BATCH_TOKEN_LIMIT = MAX_TOKENS_PER_REQUEST - SAFETY_MARGIN
 
+# Local embedding servers usually ignore the key but the OpenAI SDK still requires one.
+CUSTOM_ENDPOINT_API_KEY_PLACEHOLDER = "not-needed"
+
 
 @dataclass
 class EmbeddingResult:
@@ -18,13 +21,91 @@ class EmbeddingResult:
     embedding: list[float]
 
 
+def as_bool(value: object) -> bool:
+    """Read a flag that may arrive as a bool from JSON or a string from a form."""
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in ("true", "1", "yes")
+
+
+@dataclass(frozen=True)
+class EmbeddingConfig:
+    """Where embeddings come from: OpenAI by default, any compatible endpoint by URL."""
+
+    api_key: str | None = None
+    base_url: str | None = None
+    model: str = EMBEDDING_MODEL
+    dimensions: int = EMBEDDING_DIMENSIONS
+    request_dimensions: bool = False
+
+    @property
+    def is_custom_endpoint(self) -> bool:
+        return bool(self.base_url)
+
+
+def embedding_config_from_credential(config: dict) -> EmbeddingConfig:
+    """Build an embedding config from a decrypted `rag` credential config."""
+    dimensions = int(config.get("embedding_dimensions") or EMBEDDING_DIMENSIONS)
+    return EmbeddingConfig(
+        api_key=(config.get("embedding_api_key") or None),
+        base_url=(str(config.get("embedding_base_url") or "").strip() or None),
+        model=(str(config.get("embedding_model") or "").strip() or EMBEDDING_MODEL),
+        dimensions=dimensions,
+        request_dimensions=as_bool(config.get("embedding_request_dimensions")),
+    )
+
+
 class EmbeddingService:
-    def __init__(self, openai_api_key: str):
-        self.client = create_openai_client(api_key=openai_api_key)
+    def __init__(self, config: EmbeddingConfig | str):
+        if isinstance(config, str):
+            config = EmbeddingConfig(api_key=config)
+        self.config = config
+
+        client_kwargs: dict = {"api_key": config.api_key or CUSTOM_ENDPOINT_API_KEY_PLACEHOLDER}
+        if config.base_url:
+            client_kwargs["base_url"] = config.base_url
+        self.client = create_openai_client(**client_kwargs)
+
         try:
-            self.encoding = tiktoken.encoding_for_model("text-embedding-3-large")
+            self.encoding = tiktoken.encoding_for_model(config.model)
         except KeyError:
             self.encoding = tiktoken.get_encoding("cl100k_base")
+
+    def _request_kwargs(self) -> dict:
+        """Extra embedding request parameters.
+
+        OpenAI accepts a `dimensions` parameter for text-embedding-3-*, but most
+        OpenAI-compatible servers reject unknown parameters, so custom endpoints
+        only get it when the credential opts in. Otherwise they use their model's
+        native width, which `_check_dimensions` verifies against the credential.
+        """
+        if self.config.request_dimensions or not self.config.is_custom_endpoint:
+            return {"dimensions": self.config.dimensions}
+        return {}
+
+    def _check_dimensions(self, embedding: list[float]) -> list[float]:
+        if len(embedding) == self.config.dimensions:
+            return embedding
+
+        problem = (
+            f"Embedding model '{self.config.model}' returned {len(embedding)} "
+            f"dimensions, but the credential expects {self.config.dimensions}."
+        )
+        if self.config.request_dimensions:
+            # The endpoint accepted the request but ignored the requested width,
+            # which only Matryoshka-capable models honour.
+            fix = (
+                "The endpoint accepted the request but did not shorten the output, "
+                "so this model cannot produce the requested width. Use Qdrant with "
+                "the model's native dimensions instead."
+            )
+        else:
+            fix = (
+                "Set the credential's dimensions to match the model, or enable "
+                "'Ask the endpoint to return N dimensions' if the model can shorten "
+                "its output."
+            )
+        raise ValueError(f"{problem} {fix}")
 
     def _count_tokens(self, text: str) -> int:
         return len(self.encoding.encode(text))
@@ -86,11 +167,11 @@ class EmbeddingService:
             )
 
         response = self.client.embeddings.create(
-            model=EMBEDDING_MODEL,
+            model=self.config.model,
             input=text,
-            dimensions=EMBEDDING_DIMENSIONS,
+            **self._request_kwargs(),
         )
-        return response.data[0].embedding
+        return self._check_dimensions(response.data[0].embedding)
 
     def embed_texts(self, texts: list[str]) -> list[EmbeddingResult]:
         if not texts:
@@ -108,16 +189,16 @@ class EmbeddingService:
                 )
 
             response = self.client.embeddings.create(
-                model=EMBEDDING_MODEL,
+                model=self.config.model,
                 input=batch,
-                dimensions=EMBEDDING_DIMENSIONS,
+                **self._request_kwargs(),
             )
 
             for embedding_data in response.data:
                 all_results.append(
                     EmbeddingResult(
                         text=batch[embedding_data.index],
-                        embedding=embedding_data.embedding,
+                        embedding=self._check_dimensions(embedding_data.embedding),
                     )
                 )
 

--- a/backend/app/services/qdrant_pool.py
+++ b/backend/app/services/qdrant_pool.py
@@ -46,11 +46,17 @@ def warm_up_pools() -> int:
     initialized = 0
 
     with SessionLocal() as db:
-        qdrant_creds = db.query(Credential).filter(Credential.type == CredentialType.qdrant).all()
+        qdrant_creds = (
+            db.query(Credential)
+            .filter(Credential.type.in_([CredentialType.qdrant, CredentialType.rag]))
+            .all()
+        )
 
         for cred in qdrant_creds:
             try:
                 config = decrypt_config(cred.encrypted_config)
+                if cred.type == CredentialType.rag and config.get("db_type") != "qdrant":
+                    continue
                 host = config.get("qdrant_host", "localhost")
                 port = int(config.get("qdrant_port", 6333))
                 api_key = config.get("qdrant_api_key") or None

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -14,9 +14,16 @@ from qdrant_client.http.models import (
     VectorParams,
 )
 
-from app.services.embedding import EMBEDDING_DIMENSIONS, EmbeddingService
+from app.services.embedding import (
+    EmbeddingConfig,
+    EmbeddingService,
+    embedding_config_from_credential,
+)
 
 QDRANT_PAYLOAD_LIMIT_BYTES = 30 * 1024 * 1024
+
+# Vector store backends a `rag` credential can target.
+VECTOR_STORE_BACKENDS = ("qdrant", "pgvector")
 
 
 @dataclass
@@ -115,7 +122,8 @@ class QdrantVectorStoreService:
         qdrant_host: str,
         qdrant_port: int,
         qdrant_api_key: str | None,
-        openai_api_key: str,
+        openai_api_key: str | None = None,
+        embedding_config: EmbeddingConfig | None = None,
     ):
         if qdrant_api_key:
             self.client = QdrantClient(
@@ -128,13 +136,19 @@ class QdrantVectorStoreService:
                 host=qdrant_host,
                 port=qdrant_port,
             )
-        self.embedding_service = EmbeddingService(openai_api_key)
+        if embedding_config is None:
+            embedding_config = EmbeddingConfig(api_key=openai_api_key)
+        self.embedding_service = EmbeddingService(embedding_config)
+
+    @property
+    def embedding_dimensions(self) -> int:
+        return self.embedding_service.config.dimensions
 
     def create_collection(self, collection_name: str) -> bool:
         self.client.create_collection(
             collection_name=collection_name,
             vectors_config=VectorParams(
-                size=EMBEDDING_DIMENSIONS,
+                size=self.embedding_dimensions,
                 distance=Distance.COSINE,
             ),
         )
@@ -530,6 +544,14 @@ def create_vector_store_service(
     )
 
 
+def rag_credential_backend(config: dict) -> str:
+    """Vector store backend selected inside a `rag` credential."""
+    db_type = str(config.get("db_type") or "qdrant").strip()
+    if db_type not in VECTOR_STORE_BACKENDS:
+        raise ValueError(f"Unsupported vector store type: {db_type}")
+    return db_type
+
+
 def create_vector_store_service_for_credential(
     credential_type: object,
     config: dict,
@@ -547,4 +569,16 @@ def create_vector_store_service_for_credential(
         from app.services.vector_store_pg import PgVectorStoreService
 
         return PgVectorStoreService(openai_api_key=config["openai_api_key"])
+    if type_str == "rag":
+        embedding_config = embedding_config_from_credential(config)
+        if rag_credential_backend(config) == "pgvector":
+            from app.services.vector_store_pg import PgVectorStoreService
+
+            return PgVectorStoreService(embedding_config=embedding_config)
+        return QdrantVectorStoreService(
+            qdrant_host=config.get("qdrant_host", "localhost"),
+            qdrant_port=int(config.get("qdrant_port", 6333)),
+            qdrant_api_key=config.get("qdrant_api_key"),
+            embedding_config=embedding_config,
+        )
     raise ValueError(f"Unsupported vector store credential type: {type_str}")

--- a/backend/app/services/vector_store_pg.py
+++ b/backend/app/services/vector_store_pg.py
@@ -3,7 +3,7 @@ import uuid
 
 from sqlalchemy import text
 
-from app.services.embedding import EmbeddingService
+from app.services.embedding import EMBEDDING_DIMENSIONS, EmbeddingConfig, EmbeddingService
 from app.services.vector_store import (
     CollectionStats,
     ExistingFile,
@@ -22,6 +22,16 @@ BACKEND_UNAVAILABLE_MSG = (
 )
 
 
+def pgvector_dimension_message(dimensions: int) -> str:
+    """Explain why a non-1536 embedding width cannot use the pgvector backend."""
+    return (
+        f"Postgres (pgvector) stores vectors in a fixed vector({EMBEDDING_DIMENSIONS}) "
+        f"column, but this credential is configured for {dimensions} dimensions. Use an "
+        f"embedding model that returns {EMBEDDING_DIMENSIONS} dimensions, or select "
+        f"Qdrant as the vector store."
+    )
+
+
 class VectorStoreBackendUnavailableError(ValueError):
     """Raised when a pgvector operation is attempted but the backend table is missing."""
 
@@ -38,13 +48,22 @@ class PgVectorStoreService:
     ``create_collection`` is a no-op and ``collection_exists`` returns True.
     """
 
-    def __init__(self, openai_api_key: str, engine=None):
+    def __init__(
+        self,
+        openai_api_key: str | None = None,
+        engine=None,
+        embedding_config: EmbeddingConfig | None = None,
+    ):
         if engine is None:
             from app.db.session import sync_engine
 
             engine = sync_engine
         self.engine = engine
-        self.embedding_service = EmbeddingService(openai_api_key)
+        if embedding_config is None:
+            embedding_config = EmbeddingConfig(api_key=openai_api_key)
+        if embedding_config.dimensions != EMBEDDING_DIMENSIONS:
+            raise ValueError(pgvector_dimension_message(embedding_config.dimensions))
+        self.embedding_service = EmbeddingService(embedding_config)
 
     def _table_exists(self) -> bool:
         with self.engine.connect() as conn:

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -1936,7 +1936,7 @@ The last node in the iteration body MUST connect BACK to the loop node's `loop` 
   - `searchLimit`: Maximum number of results to return (only for "search" operation, default: 3)
   - `metadataFilters`: JSON object with metadata filters for search (only for "search" operation)
 
-**SETUP**: Requires a Vector Store created in the Vector Stores tab with either a "RAG: Qdrant + OpenAI" credential (external Qdrant server) or a "RAG: Psql + OpenAI" credential (vectors stored in Heym's own Postgres database via pgvector — no external service). The same RAG operations, metadata filters, and reranking work identically with both backends.
+**SETUP**: Requires a Vector Store created in the Vector Stores tab with a "RAG: Qdrant + OpenAI" credential (external Qdrant server), a "RAG: Psql + OpenAI" credential (vectors stored in Heym's own Postgres database via pgvector — no external service), or a "RAG: Custom Embeddings" credential (any OpenAI-compatible embedding endpoint by URL, targeting either backend). The same RAG operations, metadata filters, and reranking work identically with every backend.
 
 **RAG Operations**:
 

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -15,7 +15,13 @@ class AlembicMigrationGraphTest(unittest.TestCase):
         self.script = ScriptDirectory.from_config(config)
 
     def test_revision_graph_has_one_head(self) -> None:
-        self.assertEqual(self.script.get_heads(), ["104_add_cron_slot_claims"])
+        self.assertEqual(self.script.get_heads(), ["105_add_rag_credential_type"])
+
+    def test_rag_credential_revision_follows_cron_slot_revision(self) -> None:
+        rag_revision = self.script.get_revision("105_add_rag_credential_type")
+
+        self.assertIsNotNone(rag_revision)
+        self.assertEqual(rag_revision.down_revision, "104_add_cron_slot_claims")
 
     def test_cron_slot_claims_revision_follows_google_drive_revision(self) -> None:
         cron_slot_revision = self.script.get_revision("104_add_cron_slot_claims")

--- a/backend/tests/test_rag_credential.py
+++ b/backend/tests/test_rag_credential.py
@@ -1,0 +1,413 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+from app.api.credentials import (
+    get_masked_value,
+    get_public_credential_fields,
+    merge_credential_config_for_update,
+    validate_credential_config,
+)
+from app.db.models import CredentialType
+from app.services.embedding import (
+    EMBEDDING_DIMENSIONS,
+    EmbeddingConfig,
+    EmbeddingService,
+    embedding_config_from_credential,
+)
+from app.services.vector_store import (
+    QdrantVectorStoreService,
+    create_vector_store_service_for_credential,
+    rag_credential_backend,
+)
+
+
+def _qdrant_config(**overrides: object) -> dict:
+    config: dict = {
+        "embedding_base_url": "http://localhost:11434/v1",
+        "embedding_api_key": "",
+        "embedding_model": "nomic-embed-text",
+        "embedding_dimensions": 768,
+        "db_type": "qdrant",
+        "qdrant_host": "localhost",
+        "qdrant_port": 6333,
+        "qdrant_api_key": "",
+    }
+    config.update(overrides)
+    return config
+
+
+def _pgvector_config(**overrides: object) -> dict:
+    config: dict = {
+        "embedding_base_url": "https://api.openai.com/v1",
+        "embedding_api_key": "sk-test",
+        "embedding_model": "text-embedding-3-large",
+        "embedding_dimensions": EMBEDDING_DIMENSIONS,
+        "db_type": "pgvector",
+    }
+    config.update(overrides)
+    return config
+
+
+class TestRagCredentialValidation(unittest.TestCase):
+    def test_valid_qdrant_config_passes(self):
+        validate_credential_config(CredentialType.rag, _qdrant_config())
+
+    def test_valid_pgvector_config_passes(self):
+        validate_credential_config(CredentialType.rag, _pgvector_config())
+
+    def test_missing_base_url_rejected(self):
+        with self.assertRaises(HTTPException) as ctx:
+            validate_credential_config(CredentialType.rag, _qdrant_config(embedding_base_url=""))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("embedding_base_url", ctx.exception.detail)
+
+    def test_missing_model_rejected(self):
+        with self.assertRaises(HTTPException) as ctx:
+            validate_credential_config(CredentialType.rag, _qdrant_config(embedding_model=""))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("embedding_model", ctx.exception.detail)
+
+    def test_non_positive_dimensions_rejected(self):
+        with self.assertRaises(HTTPException) as ctx:
+            validate_credential_config(CredentialType.rag, _qdrant_config(embedding_dimensions=-1))
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_unknown_db_type_rejected(self):
+        with self.assertRaises(HTTPException) as ctx:
+            validate_credential_config(CredentialType.rag, _qdrant_config(db_type="milvus"))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("db_type", ctx.exception.detail)
+
+    def test_qdrant_requires_host(self):
+        with self.assertRaises(HTTPException) as ctx:
+            validate_credential_config(CredentialType.rag, _qdrant_config(qdrant_host=""))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("qdrant_host", ctx.exception.detail)
+
+    def test_pgvector_rejects_non_default_dimensions(self):
+        """pgvector's column is a fixed vector(1536), so other widths cannot be stored."""
+        with self.assertRaises(HTTPException) as ctx:
+            validate_credential_config(
+                CredentialType.rag, _pgvector_config(embedding_dimensions=768)
+            )
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("768", ctx.exception.detail)
+        self.assertIn(str(EMBEDDING_DIMENSIONS), ctx.exception.detail)
+
+    def test_qdrant_allows_non_default_dimensions(self):
+        validate_credential_config(CredentialType.rag, _qdrant_config(embedding_dimensions=1024))
+
+
+class TestRagCredentialFields(unittest.TestCase):
+    def test_masked_value_masks_api_key(self):
+        masked = get_masked_value(CredentialType.rag, _pgvector_config())
+        self.assertIsNotNone(masked)
+        self.assertNotIn("sk-test", str(masked))
+
+    def test_masked_value_falls_back_to_model_without_key(self):
+        masked = get_masked_value(CredentialType.rag, _qdrant_config())
+        self.assertEqual(masked, "nomic-embed-text")
+
+    def test_public_fields_expose_non_secret_config(self):
+        fields = get_public_credential_fields(CredentialType.rag, _qdrant_config())
+        self.assertEqual(fields["embedding_base_url"], "http://localhost:11434/v1")
+        self.assertEqual(fields["embedding_model"], "nomic-embed-text")
+        self.assertEqual(fields["embedding_dimensions"], "768")
+        self.assertEqual(fields["db_type"], "qdrant")
+        self.assertEqual(fields["qdrant_host"], "localhost")
+        self.assertEqual(fields["embedding_request_dimensions"], "false")
+        self.assertNotIn("embedding_api_key", fields)
+
+    def test_public_fields_round_trip_the_request_dimensions_flag(self):
+        fields = get_public_credential_fields(
+            CredentialType.rag, _pgvector_config(embedding_request_dimensions=True)
+        )
+        self.assertEqual(fields["embedding_request_dimensions"], "true")
+
+    def test_update_keeps_stored_secrets_when_inputs_are_blank(self):
+        existing = _qdrant_config(embedding_api_key="stored-key", qdrant_api_key="stored-qdrant")
+        incoming = _qdrant_config(embedding_api_key="", qdrant_api_key="")
+        merged = merge_credential_config_for_update(CredentialType.rag, existing, incoming)
+        self.assertEqual(merged["embedding_api_key"], "stored-key")
+        self.assertEqual(merged["qdrant_api_key"], "stored-qdrant")
+
+    def test_update_carries_the_request_dimensions_flag(self):
+        """A cleared checkbox must survive the merge, not fall back to the stored value."""
+        existing = _pgvector_config(embedding_request_dimensions=True)
+        incoming = _pgvector_config(embedding_request_dimensions=False)
+        merged = merge_credential_config_for_update(CredentialType.rag, existing, incoming)
+        self.assertIs(merged["embedding_request_dimensions"], False)
+
+    def test_update_applies_new_secrets_and_fields(self):
+        existing = _qdrant_config(embedding_api_key="stored-key")
+        incoming = _qdrant_config(embedding_api_key="fresh-key", embedding_model="bge-m3")
+        merged = merge_credential_config_for_update(CredentialType.rag, existing, incoming)
+        self.assertEqual(merged["embedding_api_key"], "fresh-key")
+        self.assertEqual(merged["embedding_model"], "bge-m3")
+
+
+class TestCredentialTypeEnumsInSync(unittest.TestCase):
+    def test_schema_and_model_enums_both_carry_rag(self):
+        from app.db.models import CredentialType as ModelType
+        from app.models.schemas import CredentialType as SchemaType
+
+        self.assertIn("rag", {e.value for e in SchemaType})
+        self.assertIn("rag", {e.value for e in ModelType})
+
+    def test_create_credential_accepts_rag(self):
+        from app.models.schemas import CredentialCreate
+
+        cred = CredentialCreate(name="RAG Custom", type="rag", config=_qdrant_config())
+        self.assertEqual(cred.type.value, "rag")
+
+
+class TestEmbeddingConfigFromCredential(unittest.TestCase):
+    def test_reads_custom_endpoint_fields(self):
+        config = embedding_config_from_credential(_qdrant_config())
+        self.assertEqual(config.base_url, "http://localhost:11434/v1")
+        self.assertEqual(config.model, "nomic-embed-text")
+        self.assertEqual(config.dimensions, 768)
+        self.assertIsNone(config.api_key)
+        self.assertTrue(config.is_custom_endpoint)
+
+    def test_falls_back_to_defaults_for_empty_fields(self):
+        config = embedding_config_from_credential({})
+        self.assertIsNone(config.base_url)
+        self.assertEqual(config.dimensions, EMBEDDING_DIMENSIONS)
+        self.assertFalse(config.is_custom_endpoint)
+        self.assertFalse(config.request_dimensions)
+
+    def test_request_dimensions_flag_accepts_bool_and_string(self):
+        """The flag arrives as a bool from JSON but as a string from public_fields."""
+        for raw in (True, "true", "True", "1"):
+            config = embedding_config_from_credential(
+                _pgvector_config(embedding_request_dimensions=raw)
+            )
+            self.assertTrue(config.request_dimensions, raw)
+        for raw in (False, "false", "", None):
+            config = embedding_config_from_credential(
+                _pgvector_config(embedding_request_dimensions=raw)
+            )
+            self.assertFalse(config.request_dimensions, raw)
+
+
+class TestEmbeddingServiceCustomEndpoint(unittest.TestCase):
+    def _service(self, config: EmbeddingConfig) -> tuple[EmbeddingService, MagicMock]:
+        with patch("app.services.embedding.create_openai_client") as make_client:
+            client = MagicMock()
+            make_client.return_value = client
+            service = EmbeddingService(config)
+        return service, client
+
+    def _response(self, embedding: list[float]) -> MagicMock:
+        response = MagicMock()
+        item = MagicMock()
+        item.embedding = embedding
+        item.index = 0
+        response.data = [item]
+        return response
+
+    def test_custom_endpoint_omits_dimensions_parameter(self):
+        """Most OpenAI-compatible servers reject unknown request parameters."""
+        config = EmbeddingConfig(base_url="http://localhost:11434/v1", model="m", dimensions=3)
+        service, client = self._service(config)
+        client.embeddings.create.return_value = self._response([0.1, 0.2, 0.3])
+
+        service.embed_text("hello")
+
+        kwargs = client.embeddings.create.call_args.kwargs
+        self.assertNotIn("dimensions", kwargs)
+        self.assertEqual(kwargs["model"], "m")
+
+    def test_custom_endpoint_sends_dimensions_when_requested(self):
+        """Opting in asks a Matryoshka-capable model to shorten its output."""
+        config = EmbeddingConfig(
+            base_url="http://localhost:11434/v1",
+            model="m",
+            dimensions=1536,
+            request_dimensions=True,
+        )
+        service, client = self._service(config)
+        client.embeddings.create.return_value = self._response([0.0] * 1536)
+
+        service.embed_text("hello")
+
+        self.assertEqual(client.embeddings.create.call_args.kwargs["dimensions"], 1536)
+
+    def test_ignored_dimensions_request_explains_the_failure(self):
+        """An endpoint may accept the parameter yet return its native width."""
+        config = EmbeddingConfig(
+            base_url="http://localhost:11434/v1",
+            model="m",
+            dimensions=1536,
+            request_dimensions=True,
+        )
+        service, client = self._service(config)
+        client.embeddings.create.return_value = self._response([0.0] * 2560)
+
+        with self.assertRaises(ValueError) as ctx:
+            service.embed_text("hello")
+        message = str(ctx.exception)
+        self.assertIn("2560", message)
+        self.assertIn("did not shorten", message)
+        self.assertIn("Qdrant", message)
+
+    def test_openai_path_still_sends_dimensions(self):
+        config = EmbeddingConfig(api_key="sk-test", dimensions=EMBEDDING_DIMENSIONS)
+        service, client = self._service(config)
+        client.embeddings.create.return_value = self._response([0.0] * EMBEDDING_DIMENSIONS)
+
+        service.embed_text("hello")
+
+        kwargs = client.embeddings.create.call_args.kwargs
+        self.assertEqual(kwargs["dimensions"], EMBEDDING_DIMENSIONS)
+
+    def test_dimension_mismatch_raises_with_both_values(self):
+        config = EmbeddingConfig(base_url="http://localhost:11434/v1", model="m", dimensions=1024)
+        service, client = self._service(config)
+        client.embeddings.create.return_value = self._response([0.1, 0.2, 0.3])
+
+        with self.assertRaises(ValueError) as ctx:
+            service.embed_text("hello")
+        self.assertIn("3 dimensions", str(ctx.exception))
+        self.assertIn("1024", str(ctx.exception))
+
+    def test_batch_embedding_checks_dimensions(self):
+        config = EmbeddingConfig(base_url="http://localhost:11434/v1", model="m", dimensions=2)
+        service, client = self._service(config)
+        client.embeddings.create.return_value = self._response([0.1, 0.2, 0.3])
+
+        with self.assertRaises(ValueError):
+            service.embed_texts(["hello"])
+
+    def test_blank_api_key_uses_placeholder(self):
+        config = EmbeddingConfig(base_url="http://localhost:11434/v1", model="m")
+        with patch("app.services.embedding.create_openai_client") as make_client:
+            EmbeddingService(config)
+        kwargs = make_client.call_args.kwargs
+        self.assertTrue(kwargs["api_key"])
+        self.assertEqual(kwargs["base_url"], "http://localhost:11434/v1")
+
+
+class TestRagVectorStoreFactory(unittest.TestCase):
+    def test_backend_selection_reads_db_type(self):
+        self.assertEqual(rag_credential_backend({"db_type": "pgvector"}), "pgvector")
+        self.assertEqual(rag_credential_backend({"db_type": "qdrant"}), "qdrant")
+        self.assertEqual(rag_credential_backend({}), "qdrant")
+
+    def test_unknown_db_type_raises(self):
+        with self.assertRaises(ValueError):
+            rag_credential_backend({"db_type": "milvus"})
+
+    def test_rag_qdrant_credential_returns_qdrant_service(self):
+        with patch("app.services.vector_store.QdrantClient"):
+            service = create_vector_store_service_for_credential("rag", _qdrant_config())
+        self.assertIsInstance(service, QdrantVectorStoreService)
+        self.assertEqual(service.embedding_dimensions, 768)
+
+    def test_rag_pgvector_credential_returns_pg_service(self):
+        from app.services.vector_store_pg import PgVectorStoreService
+
+        service = create_vector_store_service_for_credential("rag", _pgvector_config())
+        self.assertIsInstance(service, PgVectorStoreService)
+
+    def test_pg_service_rejects_non_default_dimensions(self):
+        """Defence in depth: the factory must not build an unusable pgvector service."""
+        with self.assertRaises(ValueError) as ctx:
+            create_vector_store_service_for_credential(
+                "rag", dict(_pgvector_config(), embedding_dimensions=768)
+            )
+        self.assertIn("768", str(ctx.exception))
+
+    def test_qdrant_collection_uses_credential_dimensions(self):
+        with patch("app.services.vector_store.QdrantClient") as client_cls:
+            client = MagicMock()
+            client_cls.return_value = client
+            service = create_vector_store_service_for_credential(
+                "rag", _qdrant_config(embedding_dimensions=1024)
+            )
+            service.create_collection("heym_vs_test")
+
+        vectors_config = client.create_collection.call_args.kwargs["vectors_config"]
+        self.assertEqual(vectors_config.size, 1024)
+
+    def test_legacy_qdrant_credential_keeps_default_dimensions(self):
+        with patch("app.services.vector_store.QdrantClient"):
+            service = create_vector_store_service_for_credential(
+                "qdrant",
+                {"qdrant_host": "localhost", "qdrant_port": 6333, "openai_api_key": "sk-test"},
+            )
+        self.assertEqual(service.embedding_dimensions, EMBEDDING_DIMENSIONS)
+
+
+class TestVectorStoreBackendDerivation(unittest.TestCase):
+    def test_rag_credential_backend_comes_from_config(self):
+        from app.api.vector_stores import _backend_for_credential_type
+
+        self.assertEqual(
+            _backend_for_credential_type(CredentialType.rag, _pgvector_config()),
+            "pgvector",
+        )
+        self.assertEqual(
+            _backend_for_credential_type(CredentialType.rag, _qdrant_config()),
+            "qdrant",
+        )
+
+    def test_legacy_credential_backend_comes_from_type(self):
+        from app.api.vector_stores import _backend_for_credential_type
+
+        self.assertEqual(_backend_for_credential_type(CredentialType.pgvector), "pgvector")
+        self.assertEqual(_backend_for_credential_type(CredentialType.qdrant), "qdrant")
+
+
+class TestRagConnectionTest(unittest.IsolatedAsyncioTestCase):
+    async def test_reports_dimension_count_on_success(self):
+        from app.api.credentials import _test_rag_embedding_endpoint
+
+        with patch("app.api.credentials.EmbeddingService") as service_cls:
+            service_cls.return_value.embed_text.return_value = [0.0] * 768
+            result = await _test_rag_embedding_endpoint(_qdrant_config())
+
+        self.assertTrue(result.success)
+        self.assertIn("768", result.message)
+
+    async def test_reports_that_the_endpoint_honored_the_request(self):
+        from app.api.credentials import _test_rag_embedding_endpoint
+
+        with patch("app.api.credentials.EmbeddingService") as service_cls:
+            service_cls.return_value.embed_text.return_value = [0.0] * 1536
+            result = await _test_rag_embedding_endpoint(
+                _pgvector_config(embedding_request_dimensions=True)
+            )
+
+        self.assertTrue(result.success)
+        self.assertIn("honored", result.message)
+        self.assertIn("1536", result.message)
+
+    async def test_reports_dimension_mismatch_as_failure(self):
+        from app.api.credentials import _test_rag_embedding_endpoint
+
+        with patch("app.api.credentials.EmbeddingService") as service_cls:
+            service_cls.return_value.embed_text.side_effect = ValueError(
+                "returned 768 dimensions, but the credential expects 1024"
+            )
+            result = await _test_rag_embedding_endpoint(_qdrant_config(embedding_dimensions=1024))
+
+        self.assertFalse(result.success)
+        self.assertIn("768", result.message)
+
+    async def test_unreachable_endpoint_is_a_failure_not_an_error(self):
+        from app.api.credentials import _test_rag_embedding_endpoint
+
+        with patch("app.api.credentials.EmbeddingService") as service_cls:
+            service_cls.return_value.embed_text.side_effect = ConnectionError("refused")
+            result = await _test_rag_embedding_endpoint(_qdrant_config())
+
+        self.assertFalse(result.success)
+        self.assertIn("refused", result.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/superpowers/specs/2026-08-05-rag-credential-type-design.md
+++ b/docs/superpowers/specs/2026-08-05-rag-credential-type-design.md
@@ -1,0 +1,215 @@
+# RAG Credential Type — Design
+
+**Date:** 2026-08-05
+**Status:** Approved, implementation local-only (no commit)
+
+## Problem
+
+Heym has two vector-store credential types, `qdrant` ("RAG: Qdrant + OpenAI") and
+`pgvector` ("RAG: Psql + OpenAI"). Both hardcode the embedding provider: the config
+carries only an `openai_api_key`, and `EmbeddingService` always calls OpenAI's
+`text-embedding-3-large` at 1536 dimensions. Users who run their own embedding
+endpoint (Ollama, TEI, vLLM, LM Studio, Together, Voyage, any OpenAI-compatible
+server) cannot use RAG at all.
+
+We need a credential that points at an arbitrary embedding endpoint by URL, with an
+optional API key, and that also picks which of the two existing vector-store backends
+to write into.
+
+## Goals
+
+- New `rag` credential type: custom embedding base URL, optional API key, model name,
+  embedding dimensions.
+- Single-select vector store DB type inside the same credential dialog, limited to the
+  two backends that exist today: Qdrant and Postgres (pgvector).
+- Works everywhere RAG already works: the RAG node, the Vector Stores panel, agent RAG
+  tooling, file upload/indexing.
+- Existing `qdrant` and `pgvector` credentials keep working untouched.
+
+## Non-goals
+
+- Making the pgvector column dimension-flexible. The `pgvector_store_items.embedding`
+  column is `vector(1536)` (migration `5ba5b9aaf6ba`) and stays that way.
+- Migrating existing `qdrant`/`pgvector` credentials to the new type.
+- Reranker changes. Reranking stays on the separate `cohere` credential.
+- Frontend UI tests (repo convention: backend pytest only).
+
+## Key decisions
+
+### Dimensions: configurable, with a hard pgvector constraint
+
+Qdrant sizes its vectors per collection, so it can hold any dimension as long as
+`create_collection` is told the number. Postgres cannot, without a schema migration we
+explicitly ruled out.
+
+So: the credential carries `embedding_dimensions` (default 1536). Qdrant honors it.
+Choosing `pgvector` with anything other than 1536 is rejected at credential-save time
+with a clear message, and the dialog warns *before* the user gets there.
+
+### Coexistence, not replacement
+
+`rag` is added as a third type. `qdrant` and `pgvector` remain in the credential type
+dropdown and keep functioning. No data migration, no deprecation. Zero regression risk
+for existing stores; the cost is three similar-looking entries in the dropdown.
+
+### `dimensions=` is not sent to custom endpoints
+
+OpenAI accepts a `dimensions` request parameter for `text-embedding-3-*`. Most
+OpenAI-compatible servers reject unknown parameters. The parameter is therefore sent
+only on the legacy OpenAI path (no custom base URL); for a `rag` credential the model's
+native output width is used and validated instead.
+
+### Returned vector width is always validated
+
+Every embedding response is checked against the configured `embedding_dimensions`. A
+mismatch raises `ValueError("... model returned 768 dimensions, credential expects
+1024")` rather than surfacing as an opaque Qdrant/Postgres write failure.
+
+### Connection test in the dialog
+
+Dimension mismatch is the dominant failure mode and would otherwise only appear during
+a workflow run. `POST /credentials/test` accepts `rag`, embeds a short probe string, and
+reports the real dimension count back into the dialog.
+
+## Architecture
+
+### Backend
+
+**Enum and schema** — `backend/app/models/schemas.py`, `backend/app/db/models.py`
+
+Add `rag = "rag"` to both `CredentialType` enums, plus an Alembic migration doing
+`ALTER TYPE ... ADD VALUE 'rag'` (follows `081_add_notion_credential_type.py`).
+
+```python
+class CredentialConfigRag(BaseModel):
+    embedding_base_url: str
+    embedding_api_key: str | None = None
+    embedding_model: str
+    embedding_dimensions: int = 1536
+    db_type: str                      # "qdrant" | "pgvector"
+    qdrant_host: str | None = None    # required when db_type == "qdrant"
+    qdrant_port: int = 6333
+    qdrant_api_key: str | None = None
+```
+
+**Validation** — `validate_credential_config` in `backend/app/api/credentials.py`
+
+- `embedding_base_url`, `embedding_model` required and non-empty.
+- `db_type` must be `qdrant` or `pgvector`.
+- `db_type == "pgvector"` and `embedding_dimensions != 1536` → HTTP 400 naming both the
+  configured value and the requirement.
+- `db_type == "qdrant"` → `qdrant_host` required.
+- `embedding_dimensions` must be a positive int.
+
+**Masking** — the secret-preview branch in `credentials.py` masks `embedding_api_key`.
+
+**Embedding layer** — `backend/app/services/embedding.py`
+
+Introduce an `EmbeddingConfig` dataclass (`base_url`, `api_key`, `model`, `dimensions`)
+and let `EmbeddingService` be constructed from it. The existing positional
+`EmbeddingService(openai_api_key)` signature is preserved so the two legacy call sites
+(`vector_store.py:131`, `vector_store_pg.py:47`) keep compiling; that path defaults to
+the current OpenAI model/dimensions and keeps sending `dimensions=`.
+
+- `tiktoken.encoding_for_model(model)` with `cl100k_base` fallback for unknown names.
+  Token batching stays approximate for non-OpenAI models, which is acceptable — it only
+  drives request chunking.
+- Both `embed_text` and `embed_texts` verify `len(embedding) == config.dimensions`.
+
+**Vector store factory** — `backend/app/services/vector_store.py:533`
+
+`create_vector_store_service_for_credential` gains a `rag` branch that reads
+`config["db_type"]` and builds `QdrantVectorStoreService` or `PgVectorStoreService` with
+an `EmbeddingConfig` derived from the credential. Only two call sites exist
+(`api/vector_stores.py:103`, `node_execution/nodes/rag_node.py:45`), so this stays the
+single dispatch point.
+
+`QdrantVectorStoreService` takes the dimension count and uses it in `create_collection`
+instead of the module-level `EMBEDDING_DIMENSIONS` constant.
+`PgVectorStoreService` continues to assume 1536 (guarded by the validation above).
+
+**Backend derivation** — `backend/app/api/vector_stores.py`
+
+- The credential-type guard at line 92 accepts `CredentialType.rag`.
+- `_backend_for_credential_type` and `_store_backend` return `config["db_type"]` for
+  `rag` credentials. `_store_backend` already loads the credential row, so it only needs
+  to decrypt the config.
+
+**Pool warm-up** — `backend/app/services/qdrant_pool.py`
+
+`warm_up_pools` also collects `rag` credentials whose `db_type` is `qdrant`.
+
+**Connection test** — `backend/app/api/credentials.py:823`
+
+Add `CredentialType.rag` to the permitted set. The handler builds an `EmbeddingService`
+from the (possibly merged, possibly stored) config, embeds a short probe string in a
+threadpool, and returns either
+`"Connected. Model returned N dimensions."` or a failure naming both N and the
+configured value.
+
+### Frontend
+
+**Types** — `frontend/src/types/credential.ts`
+
+Add `"rag"` to the `CredentialType` union, a `RagCredentialConfig` interface, a label
+(`"RAG"`), and a description covering custom embedding endpoints.
+
+**Dialog** — `frontend/src/components/Credentials/CredentialDialog.vue`
+
+A new type block following the existing per-type pattern: base URL, API key (optional),
+model, dimensions, then a single-select vector DB control. Selecting Qdrant reveals
+host/port/API key. Selecting Postgres shows an inline notice above the fields:
+
+> Postgres (pgvector) stores vectors in a fixed `vector(1536)` column. Your embedding
+> model must return 1536 dimensions.
+
+Wire the type into: reset-on-open, load-for-edit, `canSave` validation, the save
+payload, and the secret-dirty check. Add the `Test connection` button for this type.
+
+**Vector Stores panel** — `frontend/src/components/VectorStores/VectorStoresPanel.vue`
+
+Add `credentialsApi.listByType("rag")` to the credential fetch, and filter the
+credential options by the selected backend — a `rag` credential matches the chosen
+backend when its `db_type` equals it.
+
+**RAG node** — no change. `node.data.dbType` is only a list filter; rag-backed stores
+report the correct `backend` value, so filtering keeps working.
+
+## Testing
+
+Backend pytest (`backend/tests/`):
+
+- `validate_credential_config` accepts a well-formed rag config; rejects missing base
+  URL, missing model, bad `db_type`, missing `qdrant_host` under Qdrant, and
+  `pgvector` + non-1536 dimensions.
+- `create_vector_store_service_for_credential` dispatches a rag credential to the Qdrant
+  or the pgvector service according to `db_type`, and raises on an unknown `db_type`.
+- Qdrant `create_collection` uses the credential's dimension count.
+- `EmbeddingService` raises on a width mismatch, and omits `dimensions=` when a custom
+  base URL is configured (assert on the mocked client call kwargs).
+- `POST /credentials/test` with `type=rag` returns success with the reported dimension,
+  and failure text on mismatch.
+- `_store_backend` / `_backend_for_credential_type` return `db_type` for rag
+  credentials.
+- Credential secret masking covers `embedding_api_key`.
+
+No frontend UI tests. Verification is `bun run lint` + `bun run typecheck`.
+
+## Documentation
+
+Per the repository feature-documentation policy this is a medium feature, so update via
+the `heym-documentation` skill:
+
+- `frontend/src/docs/content/tabs/credentials-tab.md`
+- `frontend/src/docs/content/tabs/vectorstores-tab.md`
+- `frontend/src/docs/content/nodes/rag-node.md`
+- `frontend/src/docs/content/reference/credentials.md`
+- `frontend/src/docs/content/reference/credentials-sharing.md`
+- `frontend/src/docs/content/reference/integrations.md`
+- the RAG node SETUP paragraph in
+  `backend/app/services/workflow_dsl_prompt.py` (~line 1939)
+
+## Delivery
+
+Work happens on `main` in the working tree. **Nothing is committed** — the user will
+review the local diff. `./check.sh` is run for verification only.

--- a/frontend/src/components/Credentials/CredentialDialog.vue
+++ b/frontend/src/components/Credentials/CredentialDialog.vue
@@ -6,6 +6,7 @@ import type {
   Credential,
   CredentialConfig,
   CredentialType,
+  VectorStoreBackend,
 } from "@/types/credential";
 
 import Button from "@/components/ui/Button.vue";
@@ -107,6 +108,18 @@ const qdrantPort = ref("6333");
 const qdrantApiKey = ref("");
 const qdrantOpenaiApiKey = ref("");
 const pgvectorOpenaiApiKey = ref("");
+const ragEmbeddingBaseUrl = ref("");
+const ragEmbeddingApiKey = ref("");
+const ragEmbeddingModel = ref("");
+const ragEmbeddingDimensions = ref("1536");
+const ragRequestDimensions = ref(false);
+const ragDbType = ref<VectorStoreBackend>("qdrant");
+const ragQdrantHost = ref("");
+const ragQdrantPort = ref("6333");
+const ragQdrantApiKey = ref("");
+const ragTesting = ref(false);
+const ragTestSuccess = ref<boolean | null>(null);
+const ragTestMessage = ref("");
 const gristApiKey = ref("");
 const gristServerUrl = ref("");
 const rabbitmqHost = ref("");
@@ -236,6 +249,7 @@ const typeOptions = [
   { value: "redis", label: CREDENTIAL_TYPE_LABELS.redis },
   { value: "qdrant", label: CREDENTIAL_TYPE_LABELS.qdrant },
   { value: "pgvector", label: CREDENTIAL_TYPE_LABELS.pgvector },
+  { value: "rag", label: CREDENTIAL_TYPE_LABELS.rag },
   { value: "grist", label: CREDENTIAL_TYPE_LABELS.grist },
   { value: "rabbitmq", label: CREDENTIAL_TYPE_LABELS.rabbitmq },
   { value: "cohere", label: CREDENTIAL_TYPE_LABELS.cohere },
@@ -253,6 +267,42 @@ const typeOptions = [
 function isTrustedOAuthMessage(evt: MessageEvent, popup: Window | null): boolean {
   return evt.origin === window.location.origin && evt.source === popup;
 }
+
+function applyRagPublicFields(credential: Credential | null | undefined): void {
+  const fields = credential?.type === "rag" ? credential.public_fields : undefined;
+  ragEmbeddingBaseUrl.value = fields?.embedding_base_url ?? "";
+  ragEmbeddingApiKey.value = "";
+  ragEmbeddingModel.value = fields?.embedding_model ?? "";
+  ragEmbeddingDimensions.value = fields?.embedding_dimensions ?? "1536";
+  ragDbType.value = fields?.db_type === "pgvector" ? "pgvector" : "qdrant";
+  ragRequestDimensions.value =
+    ragDbType.value === "pgvector" && fields?.embedding_request_dimensions === "true";
+  ragQdrantHost.value = fields?.qdrant_host ?? "";
+  ragQdrantPort.value = fields?.qdrant_port ?? "6333";
+  ragQdrantApiKey.value = "";
+  ragTesting.value = false;
+  ragTestSuccess.value = null;
+  ragTestMessage.value = "";
+}
+
+const ragDbTypeOptions: { value: VectorStoreBackend; label: string }[] = [
+  { value: "qdrant", label: "Qdrant" },
+  { value: "pgvector", label: "Postgres (pgvector)" },
+];
+
+const PGVECTOR_FIXED_DIMENSIONS = "1536";
+
+// pgvector's column is a fixed vector(1536), so the field is pinned rather than
+// left editable with an error the user can only resolve one way. The shorten option
+// is meaningless for Qdrant, which sizes each collection freely — this watcher is the
+// single place that clears it, so what the checkbox shows is always what gets saved.
+watch(ragDbType, (dbType) => {
+  if (dbType === "pgvector") {
+    ragEmbeddingDimensions.value = PGVECTOR_FIXED_DIMENSIONS;
+  } else {
+    ragRequestDimensions.value = false;
+  }
+});
 
 watch(
   () => props.open,
@@ -320,6 +370,7 @@ watch(
         qdrantApiKey.value = "";
         qdrantOpenaiApiKey.value = "";
         pgvectorOpenaiApiKey.value = "";
+        applyRagPublicFields(props.credential);
         gristApiKey.value = "";
         gristServerUrl.value = "";
         rabbitmqHost.value = "";
@@ -434,6 +485,7 @@ watch(
         qdrantApiKey.value = "";
         qdrantOpenaiApiKey.value = "";
         pgvectorOpenaiApiKey.value = "";
+        applyRagPublicFields(null);
         gristApiKey.value = "";
         gristServerUrl.value = "";
         rabbitmqHost.value = "";
@@ -580,6 +632,13 @@ const isValid = computed(() => {
     ) || isEditing.value;
   } else if (type.value === "pgvector") {
     return !!pgvectorOpenaiApiKey.value.trim() || isEditing.value;
+  } else if (type.value === "rag") {
+    return (
+      !!ragEmbeddingBaseUrl.value.trim() &&
+      !!ragEmbeddingModel.value.trim() &&
+      Number(ragEmbeddingDimensions.value) > 0 &&
+      (ragDbType.value !== "qdrant" || !!ragQdrantHost.value.trim())
+    );
   } else if (type.value === "grist") {
     return (
       !!gristApiKey.value.trim() &&
@@ -821,6 +880,18 @@ function buildConfig(): CredentialConfig {
       qdrant_port: qdrantPort.value,
       qdrant_api_key: qdrantApiKey.value,
       openai_api_key: qdrantOpenaiApiKey.value,
+    };
+  } else if (type.value === "rag") {
+    return {
+      embedding_base_url: ragEmbeddingBaseUrl.value.trim(),
+      embedding_api_key: ragEmbeddingApiKey.value.trim(),
+      embedding_model: ragEmbeddingModel.value.trim(),
+      embedding_dimensions: ragEmbeddingDimensions.value.trim(),
+      embedding_request_dimensions: ragRequestDimensions.value,
+      db_type: ragDbType.value,
+      qdrant_host: ragDbType.value === "qdrant" ? ragQdrantHost.value.trim() : "",
+      qdrant_port: ragDbType.value === "qdrant" ? ragQdrantPort.value.trim() : "6333",
+      qdrant_api_key: ragDbType.value === "qdrant" ? ragQdrantApiKey.value.trim() : "",
     };
   } else if (type.value === "pgvector") {
     return {
@@ -1283,6 +1354,42 @@ async function testNotionConnection(): Promise<void> {
   }
 }
 
+async function testRagConnection(): Promise<void> {
+  if (!ragEmbeddingBaseUrl.value.trim() || !ragEmbeddingModel.value.trim()) {
+    ragTestSuccess.value = false;
+    ragTestMessage.value =
+      "Enter an embedding base URL and model to test the connection.";
+    return;
+  }
+  ragTesting.value = true;
+  ragTestSuccess.value = null;
+  ragTestMessage.value = "";
+  error.value = "";
+  try {
+    const result = await credentialsApi.testConnection({
+      type: "rag",
+      config: {
+        embedding_base_url: ragEmbeddingBaseUrl.value.trim(),
+        embedding_api_key: ragEmbeddingApiKey.value.trim(),
+        embedding_model: ragEmbeddingModel.value.trim(),
+        embedding_dimensions: ragEmbeddingDimensions.value.trim(),
+        embedding_request_dimensions: ragRequestDimensions.value,
+      },
+      credential_id: isEditing.value ? props.credential?.id : undefined,
+    });
+    // The result is shown inline next to the button, so it is deliberately not
+    // mirrored into `error`, which is reserved for save failures.
+    ragTestSuccess.value = result.success;
+    ragTestMessage.value = result.message;
+  } catch (err) {
+    ragTestSuccess.value = false;
+    ragTestMessage.value =
+      err instanceof Error ? err.message : "Connection test failed";
+  } finally {
+    ragTesting.value = false;
+  }
+}
+
 async function testSentryConnection(): Promise<void> {
   if (!apiKey.value.trim() && !isEditing.value) {
     error.value = "Enter a Sentry auth token to test the connection.";
@@ -1550,6 +1657,9 @@ async function handleSave(): Promise<void> {
           qdrantApiKey.value.trim() ||
           qdrantOpenaiApiKey.value.trim() ||
           pgvectorOpenaiApiKey.value.trim() ||
+          // RAG fields are prefilled from public_fields, so the config is always
+          // resent; the backend keeps stored secrets when their inputs are blank.
+          type.value === "rag" ||
           gristApiKey.value.trim() ||
           gristServerUrl.value.trim() ||
           rabbitmqHost.value.trim() ||
@@ -2795,6 +2905,188 @@ async function handleSave(): Promise<void> {
           <p class="text-xs text-muted-foreground">
             OpenAI API key for text-embedding-3-large embeddings. Vectors are stored
             in Heym's own Postgres database — no external service required.
+          </p>
+        </div>
+      </template>
+
+      <template v-if="type === 'rag'">
+        <div class="space-y-2">
+          <Label for="cred-rag-base-url">Embedding Base URL</Label>
+          <Input
+            id="cred-rag-base-url"
+            v-model="ragEmbeddingBaseUrl"
+            placeholder="http://localhost:11434/v1"
+            :disabled="saving"
+          />
+          <p class="text-xs text-muted-foreground">
+            Any OpenAI-compatible embeddings endpoint, including the /v1 path
+            (Ollama, vLLM, TEI, LM Studio, Together, or api.openai.com/v1).
+          </p>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cred-rag-api-key">API Key (optional)</Label>
+          <div class="relative">
+            <Input
+              id="cred-rag-api-key"
+              v-model="ragEmbeddingApiKey"
+              :type="showApiKey ? 'text' : 'password'"
+              :placeholder="isEditing ? '••••••• (re-enter to update)' : 'Leave empty for open endpoints'"
+              :disabled="saving"
+              class="pr-10"
+            />
+            <button
+              type="button"
+              class="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              @click="showApiKey = !showApiKey"
+            >
+              <EyeOff
+                v-if="showApiKey"
+                class="w-4 h-4"
+              />
+              <Eye
+                v-else
+                class="w-4 h-4"
+              />
+            </button>
+          </div>
+          <p class="text-xs text-muted-foreground">
+            Local servers usually need no key. Leave blank to keep the stored one.
+          </p>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cred-rag-model">Embedding Model</Label>
+          <Input
+            id="cred-rag-model"
+            v-model="ragEmbeddingModel"
+            placeholder="text-embedding-3-large"
+            :disabled="saving"
+          />
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cred-rag-dimensions">Dimensions</Label>
+          <Input
+            id="cred-rag-dimensions"
+            v-model="ragEmbeddingDimensions"
+            type="number"
+            placeholder="1536"
+            :disabled="saving || ragDbType === 'pgvector'"
+          />
+          <p class="text-xs text-muted-foreground">
+            {{
+              ragDbType === "pgvector"
+                ? "Fixed at 1536 by the Postgres (pgvector) column. Switch to Qdrant for any other width."
+                : "Vector width the model returns. Use Test Connection to confirm it."
+            }}
+          </p>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cred-rag-db-type">Vector Store</Label>
+          <Select
+            id="cred-rag-db-type"
+            :model-value="ragDbType"
+            :options="ragDbTypeOptions"
+            :disabled="saving"
+            @update:model-value="ragDbType = $event as VectorStoreBackend"
+          />
+          <p
+            v-if="ragDbType === 'pgvector'"
+            class="text-xs text-muted-foreground"
+          >
+            Postgres (pgvector) stores vectors in a fixed vector(1536) column, so
+            the embedding model must return 1536 dimensions. Choose Qdrant for any
+            other width.
+          </p>
+          <label
+            v-if="ragDbType === 'pgvector'"
+            class="flex items-start gap-2 text-sm text-muted-foreground"
+          >
+            <input
+              type="checkbox"
+              class="mt-1 rounded border-input"
+              :checked="ragRequestDimensions"
+              :disabled="saving"
+              @change="ragRequestDimensions = ($event.target as HTMLInputElement).checked"
+            >
+            <span>
+              Ask the endpoint to return 1536 dimensions
+              <span class="block text-xs">
+                For models that can shorten their output (OpenAI text-embedding-3,
+                nomic-embed-text-v1.5, jina-v3 and similar). Sends the
+                <code>dimensions</code> parameter, which some endpoints reject —
+                use Test Connection to confirm before saving.
+              </span>
+            </span>
+          </label>
+          <p
+            v-else
+            class="text-xs text-muted-foreground"
+          >
+            Qdrant sizes each collection to this credential's dimensions, so any
+            width works.
+          </p>
+        </div>
+
+        <template v-if="ragDbType === 'qdrant'">
+          <div class="space-y-2">
+            <Label for="cred-rag-qdrant-host">QDrant Host</Label>
+            <Input
+              id="cred-rag-qdrant-host"
+              v-model="ragQdrantHost"
+              placeholder="localhost"
+              :disabled="saving"
+            />
+          </div>
+
+          <div class="space-y-2">
+            <Label for="cred-rag-qdrant-port">QDrant Port</Label>
+            <Input
+              id="cred-rag-qdrant-port"
+              v-model="ragQdrantPort"
+              type="number"
+              placeholder="6333"
+              :disabled="saving"
+            />
+          </div>
+
+          <div class="space-y-2">
+            <Label for="cred-rag-qdrant-api-key">QDrant API Key (optional)</Label>
+            <Input
+              id="cred-rag-qdrant-api-key"
+              v-model="ragQdrantApiKey"
+              :type="showApiKey ? 'text' : 'password'"
+              :placeholder="isEditing ? '••••••• (re-enter to update)' : 'Leave empty for local Qdrant'"
+              :disabled="saving"
+            />
+          </div>
+        </template>
+
+        <div class="space-y-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            data-testid="rag-test-connection-button"
+            :loading="ragTesting"
+            :disabled="
+              saving ||
+                ragTesting ||
+                !ragEmbeddingBaseUrl.trim() ||
+                !ragEmbeddingModel.trim()
+            "
+            @click="testRagConnection"
+          >
+            Test Connection
+          </Button>
+          <p
+            v-if="ragTestMessage"
+            class="text-xs"
+            :class="ragTestSuccess ? 'text-emerald-600' : 'text-destructive'"
+          >
+            {{ ragTestMessage }}
           </p>
         </div>
       </template>

--- a/frontend/src/components/VectorStores/VectorStoresPanel.vue
+++ b/frontend/src/components/VectorStores/VectorStoresPanel.vue
@@ -83,8 +83,18 @@ const expandedSources = ref<Set<string>>(new Set());
 const deletingSource = ref<string | null>(null);
 const deletingItem = ref<string | null>(null);
 
+function credentialBackend(credential: CredentialListItem): string {
+  // Legacy credentials imply their backend by type; a RAG credential names it.
+  if (credential.type === "rag") {
+    return credential.public_fields?.db_type === "pgvector" ? "pgvector" : "qdrant";
+  }
+  return credential.type;
+}
+
 const filteredCredentials = computed(() =>
-  vectorCredentials.value.filter((c) => c.type === newStoreDbType.value),
+  vectorCredentials.value.filter(
+    (c) => credentialBackend(c) === newStoreDbType.value,
+  ),
 );
 
 const credentialOptions = computed(() => {
@@ -92,7 +102,7 @@ const credentialOptions = computed(() => {
     { value: "", label: "Select a credential" },
     ...filteredCredentials.value.map((c) => ({
       value: c.id,
-      label: c.name,
+      label: c.type === "rag" ? `${c.name} (custom embeddings)` : c.name,
     })),
   ];
 });
@@ -124,11 +134,12 @@ async function loadVectorStores(): Promise<void> {
 }
 
 async function loadCredentials(): Promise<void> {
-  const [qdrant, pgvector] = await Promise.all([
+  const [qdrant, pgvector, rag] = await Promise.all([
     credentialsApi.listByType("qdrant").catch(() => []),
     credentialsApi.listByType("pgvector").catch(() => []),
+    credentialsApi.listByType("rag").catch(() => []),
   ]);
-  vectorCredentials.value = [...qdrant, ...pgvector];
+  vectorCredentials.value = [...qdrant, ...pgvector, ...rag];
 }
 
 function openCreateDialog(): void {

--- a/frontend/src/docs/content/nodes/rag-node.md
+++ b/frontend/src/docs/content/nodes/rag-node.md
@@ -9,6 +9,11 @@ The node has a **Database** dropdown that selects the backend:
 
 The default is **Qdrant** for backward compatibility. Changing the Database filters the **Vector Store** list to stores backed by that database. Both backends support the same operations, metadata filtering, and Cohere reranking.
 
+Either backend can also be reached through a *RAG: Custom Embeddings* credential, which
+replaces OpenAI with any OpenAI-compatible embedding endpoint and names its own vector
+store. A store created from such a credential appears under whichever Database it
+targets. See [Custom Embeddings](../reference/integrations.md#custom-embeddings-rag).
+
 ## Overview
 
 | Property | Value |

--- a/frontend/src/docs/content/reference/credentials-sharing.md
+++ b/frontend/src/docs/content/reference/credentials-sharing.md
@@ -71,7 +71,7 @@ Some nodes store `credentialId` (UUID) in `node.data`:
 | [ClickHouse](../nodes/clickhouse-node.md) | `credentialId` | ClickHouse connection details (host, port, auth, database) |
 | [Telegram Trigger](../nodes/telegram-trigger-node.md), [Telegram](../nodes/telegram-node.md) | `credentialId` | Telegram bot credential |
 | [Discord Trigger](../nodes/discord-trigger-node.md), [Discord](../nodes/discord-node.md) | `credentialId` | Discord public key or webhook credential |
-| Vector Store | `credential_id` | Qdrant or Postgres (pgvector) vector DB |
+| Vector Store | `credential_id` | Qdrant or Postgres (pgvector) vector DB, via a Qdrant, Psql, or Custom Embeddings RAG credential |
 | Evals | `credential_id`, `judge_credential_id` | Model credentials |
 | [Playwright](../nodes/playwright-node.md) AI step | `credentialId` | LLM/Vision model (for AI step and [Auto Heal](../nodes/playwright-node.md#ai-auto-heal)) |
 

--- a/frontend/src/docs/content/reference/credentials.md
+++ b/frontend/src/docs/content/reference/credentials.md
@@ -22,7 +22,7 @@ Credentials store API keys and secrets used by workflow nodes. You add them in t
 | [Telegram](../nodes/telegram-node.md), [Telegram Trigger](../nodes/telegram-trigger-node.md) | Telegram | Bot token and optional webhook secret |
 | [Discord](../nodes/discord-node.md) | Discord | Incoming webhook URL |
 | [Discord Trigger](../nodes/discord-trigger-node.md) | Discord Trigger (Public Key) | Application public key for signature verification |
-| [RAG](../nodes/rag-node.md) | RAG: Qdrant + OpenAI, RAG: Psql + OpenAI | Vector store connection (external Qdrant, or Heym's own Postgres via pgvector) |
+| [RAG](../nodes/rag-node.md) | RAG: Qdrant + OpenAI, RAG: Psql + OpenAI, RAG: Custom Embeddings | Vector store connection (external Qdrant, or Heym's own Postgres via pgvector), with OpenAI or any OpenAI-compatible embedding endpoint |
 | [Slack](../nodes/slack-node.md) | Slack | Webhook or API token |
 | [IMAP Trigger](../nodes/imap-trigger-node.md) | IMAP | Inbound mailbox connection |
 | [Send Email](../nodes/send-email-node.md) | SMTP | Mail server |

--- a/frontend/src/docs/content/reference/integrations.md
+++ b/frontend/src/docs/content/reference/integrations.md
@@ -22,6 +22,7 @@ Some integration nodes do **not** require credentials. [WebSocket Trigger](../no
 | **Cohere** | Embeddings | `api_key` |
 | **RAG: Qdrant + OpenAI** | [RAG](../nodes/rag-node.md), Vectorstores | `qdrant_host`, `openai_api_key` |
 | **RAG: Psql + OpenAI** | [RAG](../nodes/rag-node.md), Vectorstores | `openai_api_key` (vectors stored in Heym's own Postgres via pgvector) |
+| **RAG: Custom Embeddings** | [RAG](../nodes/rag-node.md), Vectorstores | `embedding_base_url`, `embedding_model`, `embedding_dimensions`, `db_type`, optional `embedding_api_key`, plus `qdrant_host` when `db_type` is `qdrant` |
 | **Grist** | [Grist node](../nodes/grist-node.md) | `api_key`, `server_url` |
 | **Google Sheets** | [Google Sheets node](../nodes/google-sheets-node.md) | `client_id`, `client_secret` + OAuth2 consent |
 | **Google Drive** | [Google Drive node](../nodes/google-drive-node.md) | `client_id`, `client_secret` + OAuth2 consent (full Drive scope) |
@@ -268,6 +269,54 @@ The Sentry credential stores an auth token for the [Sentry node](../nodes/sentry
 - The [RAG node](../nodes/rag-node.md) uses a vector store (which references a Qdrant credential) — it does not reference the credential directly.
 - If your Qdrant instance requires an API key, include it in the `qdrant_host` value or configure Qdrant accordingly; the current integration does not have a separate Qdrant API key field.
 - Self-hosted Qdrant: use the [official Docker image](https://hub.docker.com/r/qdrant/qdrant) and expose port `6333`.
+
+### Used By
+
+- [RAG node](../nodes/rag-node.md) (via vector store)
+- [Vectorstores Tab](../tabs/vectorstores-tab.md)
+
+## Custom Embeddings (RAG)
+
+By default RAG embeddings come from OpenAI. A **RAG: Custom Embeddings** credential
+points at any OpenAI-compatible embeddings endpoint instead — Ollama, vLLM, Text
+Embeddings Inference, LM Studio, Together, or a hosted gateway — and names the vector
+store it writes into.
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `embedding_base_url` | Endpoint URL including the `/v1` path, e.g. `http://localhost:11434/v1` |
+| `embedding_api_key` | Optional. Local servers usually need no key |
+| `embedding_model` | Model name as the endpoint expects it, e.g. `nomic-embed-text` |
+| `embedding_dimensions` | Vector width the model returns (default `1536`) |
+| `embedding_request_dimensions` | Optional. Ask the endpoint to return `embedding_dimensions` instead of the model's native width |
+| `db_type` | `qdrant` or `pgvector` |
+| `qdrant_host`, `qdrant_port`, `qdrant_api_key` | Qdrant connection, required when `db_type` is `qdrant` |
+
+### Notes
+
+- **Qdrant accepts any dimension count.** Each collection is created at the width this
+  credential declares, so the Dimensions field is freely editable.
+- **Postgres (pgvector) requires exactly 1536 dimensions.** Its column is a fixed
+  `vector(1536)`, so the Dimensions field is pinned to 1536 and a credential declaring
+  any other width is rejected at save time.
+- **Shortening for pgvector.** When the store is Postgres, the dialog offers *Ask the
+  endpoint to return 1536 dimensions*. This sends the `dimensions` request parameter,
+  which models trained with Matryoshka representations (OpenAI `text-embedding-3-*`,
+  `nomic-embed-text-v1.5`, `jina-v3` and similar) honour by returning a shortened,
+  still-meaningful vector. Endpoints that do not support the parameter reject the
+  request, and endpoints that accept but ignore it produce a clear error naming the
+  width actually returned. Heym never truncates vectors itself, because slicing the
+  output of a non-Matryoshka model degrades retrieval quality silently. The option is
+  not offered for Qdrant, which can size a collection to any width.
+- Use **Test Connection** in the credential dialog to embed a probe string and see the
+  width the model actually returns before you create a store.
+- The `dimensions` request parameter is only sent to OpenAI itself, since most
+  OpenAI-compatible servers reject unknown parameters. The model's native width is
+  validated against the credential instead.
+- The existing **RAG: Qdrant + OpenAI** and **RAG: Psql + OpenAI** credentials are
+  unchanged and keep working.
 
 ### Used By
 

--- a/frontend/src/docs/content/tabs/credentials-tab.md
+++ b/frontend/src/docs/content/tabs/credentials-tab.md
@@ -26,6 +26,7 @@ The **Credentials** tab manages API keys and secrets used by nodes. Add credenti
 | **Redis** | Redis connection |
 | **RAG: Qdrant + OpenAI** | Vector store for RAG nodes, backed by an external Qdrant server |
 | **RAG: Psql + OpenAI** | Vector store for RAG nodes, backed by Heym's own Postgres database (pgvector) — no external service |
+| **RAG: Custom Embeddings** | Vector store for RAG nodes using any OpenAI-compatible embedding endpoint, with Qdrant or Postgres (pgvector) as the store |
 | **Cohere** | Cohere API for embeddings |
 
 ## Adding Credentials

--- a/frontend/src/docs/content/tabs/vectorstores-tab.md
+++ b/frontend/src/docs/content/tabs/vectorstores-tab.md
@@ -9,7 +9,7 @@ The **Vectorstores** tab manages vector stores used by [RAG](../nodes/rag-node.m
 
 1. Click **New Vector Store**
 2. Enter a name and optional description
-3. Select a vector store **credential** – either *RAG: Qdrant + OpenAI* (external Qdrant server) or *RAG: Psql + OpenAI* (Heym's own Postgres database via pgvector). The credential determines the store's backend.
+3. Select a vector store **credential** – *RAG: Qdrant + OpenAI* (external Qdrant server), *RAG: Psql + OpenAI* (Heym's own Postgres database via pgvector), or *RAG: Custom Embeddings* (any OpenAI-compatible embedding endpoint, targeting either backend). The credential determines the store's backend.
 4. Optionally set a custom collection name (defaults to auto-generated)
 5. Save
 
@@ -39,7 +39,7 @@ In a [RAG node](../nodes/rag-node.md), select the vector store by name. The node
 
 ## Related
 
-- [Credentials Tab](./credentials-tab.md) – Vector store credential setup (Qdrant or Postgres)
+- [Credentials Tab](./credentials-tab.md) – Vector store credential setup (Qdrant, Postgres, or custom embeddings)
 - [RAG Node](../nodes/rag-node.md) – Node reference
 - [Workflows Tab](./workflows-tab.md) – Create workflows that use RAG
 - [Contextual Showcase](../reference/contextual-showcase.md) – Compact page guide for dashboard surfaces

--- a/frontend/src/types/credential.ts
+++ b/frontend/src/types/credential.ts
@@ -31,7 +31,8 @@ export type CredentialType =
   | "sentry"
   | "s3"
   | "elevenlabs"
-  | "clickhouse";
+  | "clickhouse"
+  | "rag";
 
 export interface Credential {
   id: string;
@@ -50,6 +51,7 @@ export interface CredentialListItem {
   type: CredentialType;
   masked_value: string | null;
   header_key: string | null;
+  public_fields?: Record<string, string | null>;
   created_at: string;
   is_shared?: boolean;
   shared_by?: string | null;
@@ -219,6 +221,25 @@ export interface CredentialConfigPgvector {
   openai_api_key: string;
 }
 
+export type VectorStoreBackend = "qdrant" | "pgvector";
+
+/** The embedding half of a RAG credential — also the payload the test endpoint takes. */
+export interface CredentialConfigRagEmbedding {
+  embedding_base_url: string;
+  embedding_api_key: string;
+  embedding_model: string;
+  embedding_dimensions: string;
+  /** Ask the endpoint to return `embedding_dimensions` instead of the model's native width. */
+  embedding_request_dimensions: boolean;
+}
+
+export interface CredentialConfigRag extends CredentialConfigRagEmbedding {
+  db_type: VectorStoreBackend;
+  qdrant_host: string;
+  qdrant_port: string;
+  qdrant_api_key: string;
+}
+
 export interface CredentialConfigGrist {
   api_key: string;
   server_url: string;
@@ -305,6 +326,8 @@ export type CredentialConfig =
   | CredentialConfigRedis
   | CredentialConfigQdrant
   | CredentialConfigPgvector
+  | CredentialConfigRag
+  | CredentialConfigRagEmbedding
   | CredentialConfigGrist
   | CredentialConfigRabbitmq
   | CredentialConfigCohere
@@ -406,6 +429,7 @@ export const CREDENTIAL_TYPE_LABELS: Record<CredentialType, string> = {
   redis: "Redis",
   qdrant: "RAG: Qdrant + OpenAI",
   pgvector: "RAG: Psql + OpenAI",
+  rag: "RAG: Custom Embeddings",
   grist: "Grist",
   rabbitmq: "RabbitMQ",
   cohere: "Cohere Reranker",
@@ -443,6 +467,7 @@ export const CREDENTIAL_TYPE_DESCRIPTIONS: Record<CredentialType, string> = {
   qdrant: "Connect to QDrant for vector storage with OpenAI embeddings",
   pgvector:
     "Vector storage inside Heym's own Postgres database with OpenAI embeddings (no external DB)",
+  rag: "Use any OpenAI-compatible embedding endpoint by URL, and pick Qdrant or Postgres (pgvector) as the vector store",
   grist: "Connect to Grist spreadsheet for data operations",
   rabbitmq: "Connect to RabbitMQ for message queue operations",
   cohere: "Connect to Cohere API for reranking search results",


### PR DESCRIPTION
feat: add RAG credential support for custom embeddings

- Introduced a new CredentialType for RAG, allowing integration with custom embedding endpoints.
- Updated credential management to handle RAG-specific configurations, including embedding base URL, model, and dimensions.
- Enhanced vector store services to support RAG credentials, enabling selection between Qdrant and pgvector backends.
- Implemented connection testing for RAG credentials to validate embedding endpoint configurations.
- Updated frontend components to accommodate RAG credential fields and validation.
- Expanded documentation to include details on RAG credential setup and usage.