### PR TITLE
fix: explicitly release advisory lock before closing leader session

### DIFF
--- a/backend/app/services/distributed_lock.py
+++ b/backend/app/services/distributed_lock.py
@@ -127,14 +127,7 @@ class DistributedLockService:
         if not self._leader_conn:
             return False
         try:
-            await self._leader_conn.execute(
-                text("SELECT pg_advisory_lock_shared(:lock_id)"),
-                {"lock_id": self._leader_lock_id},
-            )
-            await self._leader_conn.execute(
-                text("SELECT pg_advisory_unlock_shared(:lock_id)"),
-                {"lock_id": self._leader_lock_id},
-            )
+            await self._leader_conn.execute(text("SELECT 1"))
             return True
         except Exception:
             return False

--- a/backend/app/services/distributed_lock.py
+++ b/backend/app/services/distributed_lock.py
@@ -53,6 +53,13 @@ class DistributedLockService:
     async def _release_leader_session(self) -> None:
         if self._leader_session:
             try:
+                await self._leader_session.execute(
+                    text("SELECT pg_advisory_unlock(:lock_id)"),
+                    {"lock_id": self._leader_lock_id},
+                )
+            except Exception as e:
+                logger.warning("Failed to unlock advisory lock on release: %s", e)
+            try:
                 await self._leader_session.close()
             except Exception:
                 pass

--- a/backend/app/services/distributed_lock.py
+++ b/backend/app/services/distributed_lock.py
@@ -50,7 +50,7 @@ class DistributedLockService:
         await self._release_leader_session()
         logger.info("Distributed lock service stopped")
 
-    async def _release_leader_session(self) -> None:
+    async def _release_leader_session(self, force_invalidate: bool = False) -> None:
         if self._leader_conn:
             unlock_confirmed = False
             if self._is_leader:
@@ -61,18 +61,18 @@ class DistributedLockService:
                     )
                     row = result.fetchone()
                     unlock_confirmed = bool(row[0]) if row else False
-                except Exception as e:
+                except BaseException as e:
                     logger.warning("Failed to unlock advisory lock on release: %s", e)
 
-            if self._is_leader and not unlock_confirmed:
+            if force_invalidate or (self._is_leader and not unlock_confirmed):
                 try:
                     await self._leader_conn.invalidate()
-                except Exception:
+                except BaseException:
                     pass
             else:
                 try:
                     await self._leader_conn.close()
-                except Exception:
+                except BaseException:
                     pass
 
             self._leader_conn = None
@@ -108,20 +108,37 @@ class DistributedLockService:
     async def _try_acquire_leader_lock(self) -> bool:
         try:
             conn = await engine.connect()
+        except Exception:
+            return False
+
+        try:
             self._leader_conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+        except BaseException as e:
+            logger.warning("Failed to set execution options on leader conn: %s", e)
+            await conn.close()
+            if isinstance(e, Exception):
+                return False
+            raise
+
+        uncertain = True
+        try:
             result = await self._leader_conn.execute(
                 text("SELECT pg_try_advisory_lock(:lock_id)"),
                 {"lock_id": self._leader_lock_id},
             )
             row = result.fetchone()
             acquired = bool(row[0]) if row else False
+            uncertain = False
+
             if not acquired:
                 await self._release_leader_session()
             return acquired
-        except Exception as e:
-            logger.warning("Failed to acquire leader lock: %s", e)
-            await self._release_leader_session()
-            return False
+        except BaseException as e:
+            logger.warning("Error during leader lock acquisition: %s", e)
+            await self._release_leader_session(force_invalidate=uncertain)
+            if isinstance(e, Exception):
+                return False
+            raise
 
     async def _check_leader_lock_valid(self) -> bool:
         if not self._leader_conn:

--- a/backend/app/services/distributed_lock.py
+++ b/backend/app/services/distributed_lock.py
@@ -5,9 +5,9 @@ import os
 import uuid
 
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection
 
-from app.db.session import async_session_maker
+from app.db.session import async_session_maker, engine
 
 logger = logging.getLogger("distributed_lock")
 
@@ -24,7 +24,7 @@ class DistributedLockService:
         self._leader_task: asyncio.Task | None = None
         self._running = False
         self._leader_lock_id = _string_to_lock_id("heym:leader:lock")
-        self._leader_session: AsyncSession | None = None
+        self._leader_conn: AsyncConnection | None = None
 
     @property
     def worker_id(self) -> str:
@@ -51,19 +51,31 @@ class DistributedLockService:
         logger.info("Distributed lock service stopped")
 
     async def _release_leader_session(self) -> None:
-        if self._leader_session:
-            try:
-                await self._leader_session.execute(
-                    text("SELECT pg_advisory_unlock(:lock_id)"),
-                    {"lock_id": self._leader_lock_id},
-                )
-            except Exception as e:
-                logger.warning("Failed to unlock advisory lock on release: %s", e)
-            try:
-                await self._leader_session.close()
-            except Exception:
-                pass
-            self._leader_session = None
+        if self._leader_conn:
+            unlock_confirmed = False
+            if self._is_leader:
+                try:
+                    result = await self._leader_conn.execute(
+                        text("SELECT pg_advisory_unlock(:lock_id)"),
+                        {"lock_id": self._leader_lock_id},
+                    )
+                    row = result.fetchone()
+                    unlock_confirmed = bool(row[0]) if row else False
+                except Exception as e:
+                    logger.warning("Failed to unlock advisory lock on release: %s", e)
+
+            if self._is_leader and not unlock_confirmed:
+                try:
+                    await self._leader_conn.invalidate()
+                except Exception:
+                    pass
+            else:
+                try:
+                    await self._leader_conn.close()
+                except Exception:
+                    pass
+
+            self._leader_conn = None
             self._is_leader = False
 
     async def _leader_election_loop(self) -> None:
@@ -95,13 +107,14 @@ class DistributedLockService:
 
     async def _try_acquire_leader_lock(self) -> bool:
         try:
-            self._leader_session = async_session_maker()
-            result = await self._leader_session.execute(
+            conn = await engine.connect()
+            self._leader_conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+            result = await self._leader_conn.execute(
                 text("SELECT pg_try_advisory_lock(:lock_id)"),
                 {"lock_id": self._leader_lock_id},
             )
             row = result.fetchone()
-            acquired = row[0] if row else False
+            acquired = bool(row[0]) if row else False
             if not acquired:
                 await self._release_leader_session()
             return acquired
@@ -111,14 +124,14 @@ class DistributedLockService:
             return False
 
     async def _check_leader_lock_valid(self) -> bool:
-        if not self._leader_session:
+        if not self._leader_conn:
             return False
         try:
-            await self._leader_session.execute(
+            await self._leader_conn.execute(
                 text("SELECT pg_advisory_lock_shared(:lock_id)"),
                 {"lock_id": self._leader_lock_id},
             )
-            await self._leader_session.execute(
+            await self._leader_conn.execute(
                 text("SELECT pg_advisory_unlock_shared(:lock_id)"),
                 {"lock_id": self._leader_lock_id},
             )

--- a/backend/tests/test_distributed_lock.py
+++ b/backend/tests/test_distributed_lock.py
@@ -1,0 +1,193 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.services.distributed_lock import DistributedLockService
+
+
+@pytest.fixture
+def lock_service():
+    service = DistributedLockService()
+    return service
+
+
+@pytest.mark.asyncio
+async def test_successful_release(lock_service):
+    """
+    Test that a successfully acquired lock is unlocked and the connection is closed normally.
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.return_value = mock_conn
+
+    mock_acquire_result = MagicMock()
+    mock_acquire_result.fetchone.return_value = (True,)
+
+    mock_unlock_result = MagicMock()
+    mock_unlock_result.fetchone.return_value = (True,)
+
+    async def mock_execute(query, *args, **kwargs):
+        query_str = str(query)
+        if "pg_try_advisory_lock" in query_str:
+            return mock_acquire_result
+        elif "pg_advisory_unlock" in query_str:
+            return mock_unlock_result
+        return MagicMock()
+
+    mock_conn.execute.side_effect = mock_execute
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        acquired = await lock_service._try_acquire_leader_lock()
+        assert acquired is True
+        lock_service._is_leader = True
+
+        await lock_service._release_leader_session()
+
+        assert mock_conn.execute.call_count == 2
+
+        mock_conn.close.assert_awaited_once()
+        mock_conn.invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_follower_cleanup(lock_service):
+    """
+    Test that if a worker fails to acquire the lock (follower), it cleanly closes the connection.
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.return_value = mock_conn
+
+    mock_acquire_result = MagicMock()
+    mock_acquire_result.fetchone.return_value = (False,)
+    mock_conn.execute.return_value = mock_acquire_result
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        acquired = await lock_service._try_acquire_leader_lock()
+        assert acquired is False
+        assert lock_service._is_leader is False
+
+        assert mock_conn.execute.call_count == 1
+
+        mock_conn.close.assert_awaited_once()
+        mock_conn.invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_failed_unlock(lock_service):
+    """
+    Test that if the unlock query fails or throws an exception, the connection is invalidated.
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.return_value = mock_conn
+
+    mock_acquire_result = MagicMock()
+    mock_acquire_result.fetchone.return_value = (True,)
+
+    async def mock_execute(query, *args, **kwargs):
+        query_str = str(query)
+        if "pg_try_advisory_lock" in query_str:
+            return mock_acquire_result
+        elif "pg_advisory_unlock" in query_str:
+            raise RuntimeError("Database connection lost")
+        return MagicMock()
+
+    mock_conn.execute.side_effect = mock_execute
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        acquired = await lock_service._try_acquire_leader_lock()
+        assert acquired is True
+        lock_service._is_leader = True
+
+        await lock_service._release_leader_session()
+
+        mock_conn.invalidate.assert_awaited_once()
+        mock_conn.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_uncertain_acquire_cancellation(lock_service):
+    """
+    Test that if the acquire query throws an exception or is cancelled, the connection is forcibly invalidated
+    because the database might have granted the lock before the error reached Python.
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.return_value = mock_conn
+
+    mock_conn.execute.side_effect = asyncio.CancelledError("Task cancelled")
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        with pytest.raises(asyncio.CancelledError):
+            await lock_service._try_acquire_leader_lock()
+
+        assert lock_service._is_leader is False
+
+        mock_conn.invalidate.assert_awaited_once()
+        mock_conn.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_uncertain_acquire_exception(lock_service):
+    """
+    Test that a regular Exception during acquire also force-invalidates and returns False
+    (as opposed to CancelledError which re-raises).
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.return_value = mock_conn
+
+    mock_conn.execute.side_effect = RuntimeError("Connection reset by peer")
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        acquired = await lock_service._try_acquire_leader_lock()
+        assert acquired is False
+        assert lock_service._is_leader is False
+
+        # uncertain=True → force_invalidate=True → invalidate, not close
+        mock_conn.invalidate.assert_awaited_once()
+        mock_conn.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execution_options_failure(lock_service):
+    """
+    Test that if execution_options fails, the original raw connection is closed.
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.side_effect = RuntimeError("Failed to set options")
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        acquired = await lock_service._try_acquire_leader_lock()
+        assert acquired is False
+
+        mock_conn.close.assert_awaited_once()
+        mock_conn.invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execution_options_cancellation(lock_service):
+    """
+    Test that if execution_options is cancelled, the connection is closed and CancelledError is re-raised.
+    """
+    mock_conn = AsyncMock(spec=AsyncConnection)
+    mock_conn.execution_options.side_effect = asyncio.CancelledError("Task cancelled")
+
+    with patch("app.services.distributed_lock.engine") as mock_engine:
+        mock_engine.connect = AsyncMock(return_value=mock_conn)
+
+        with pytest.raises(asyncio.CancelledError):
+            await lock_service._try_acquire_leader_lock()
+
+        mock_conn.close.assert_awaited_once()
+        mock_conn.invalidate.assert_not_awaited()

--- a/backend/tests/test_distributed_lock.py
+++ b/backend/tests/test_distributed_lock.py
@@ -1,193 +1,177 @@
 import asyncio
+import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from app.services.distributed_lock import DistributedLockService
 
 
-@pytest.fixture
-def lock_service():
-    service = DistributedLockService()
-    return service
+class TestDistributedLockService(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.lock_service = DistributedLockService()
 
+    async def test_successful_release(self):
+        """
+        Test that a successfully acquired lock is unlocked and the connection is closed normally.
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.return_value = mock_conn
 
-@pytest.mark.asyncio
-async def test_successful_release(lock_service):
-    """
-    Test that a successfully acquired lock is unlocked and the connection is closed normally.
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.return_value = mock_conn
+        mock_acquire_result = MagicMock()
+        mock_acquire_result.fetchone.return_value = (True,)
 
-    mock_acquire_result = MagicMock()
-    mock_acquire_result.fetchone.return_value = (True,)
+        mock_unlock_result = MagicMock()
+        mock_unlock_result.fetchone.return_value = (True,)
 
-    mock_unlock_result = MagicMock()
-    mock_unlock_result.fetchone.return_value = (True,)
+        async def mock_execute(query, *args, **kwargs):
+            query_str = str(query)
+            if "pg_try_advisory_lock" in query_str:
+                return mock_acquire_result
+            elif "pg_advisory_unlock" in query_str:
+                return mock_unlock_result
+            return MagicMock()
 
-    async def mock_execute(query, *args, **kwargs):
-        query_str = str(query)
-        if "pg_try_advisory_lock" in query_str:
-            return mock_acquire_result
-        elif "pg_advisory_unlock" in query_str:
-            return mock_unlock_result
-        return MagicMock()
+        mock_conn.execute.side_effect = mock_execute
 
-    mock_conn.execute.side_effect = mock_execute
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
+            acquired = await self.lock_service._try_acquire_leader_lock()
+            self.assertTrue(acquired)
+            self.lock_service._is_leader = True
 
-        acquired = await lock_service._try_acquire_leader_lock()
-        assert acquired is True
-        lock_service._is_leader = True
+            await self.lock_service._release_leader_session()
 
-        await lock_service._release_leader_session()
+            self.assertEqual(mock_conn.execute.call_count, 2)
 
-        assert mock_conn.execute.call_count == 2
+            mock_conn.close.assert_awaited_once()
+            mock_conn.invalidate.assert_not_awaited()
 
-        mock_conn.close.assert_awaited_once()
-        mock_conn.invalidate.assert_not_awaited()
+    async def test_follower_cleanup(self):
+        """
+        Test that if a worker fails to acquire the lock (follower), it cleanly closes the connection.
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.return_value = mock_conn
 
+        mock_acquire_result = MagicMock()
+        mock_acquire_result.fetchone.return_value = (False,)
+        mock_conn.execute.return_value = mock_acquire_result
 
-@pytest.mark.asyncio
-async def test_follower_cleanup(lock_service):
-    """
-    Test that if a worker fails to acquire the lock (follower), it cleanly closes the connection.
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.return_value = mock_conn
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
-    mock_acquire_result = MagicMock()
-    mock_acquire_result.fetchone.return_value = (False,)
-    mock_conn.execute.return_value = mock_acquire_result
+            acquired = await self.lock_service._try_acquire_leader_lock()
+            self.assertFalse(acquired)
+            self.assertFalse(self.lock_service._is_leader)
 
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
+            self.assertEqual(mock_conn.execute.call_count, 1)
 
-        acquired = await lock_service._try_acquire_leader_lock()
-        assert acquired is False
-        assert lock_service._is_leader is False
+            mock_conn.close.assert_awaited_once()
+            mock_conn.invalidate.assert_not_awaited()
 
-        assert mock_conn.execute.call_count == 1
+    async def test_failed_unlock(self):
+        """
+        Test that if the unlock query fails or throws an exception, the connection is invalidated.
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.return_value = mock_conn
 
-        mock_conn.close.assert_awaited_once()
-        mock_conn.invalidate.assert_not_awaited()
+        mock_acquire_result = MagicMock()
+        mock_acquire_result.fetchone.return_value = (True,)
 
+        async def mock_execute(query, *args, **kwargs):
+            query_str = str(query)
+            if "pg_try_advisory_lock" in query_str:
+                return mock_acquire_result
+            elif "pg_advisory_unlock" in query_str:
+                raise RuntimeError("Database connection lost")
+            return MagicMock()
 
-@pytest.mark.asyncio
-async def test_failed_unlock(lock_service):
-    """
-    Test that if the unlock query fails or throws an exception, the connection is invalidated.
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.return_value = mock_conn
+        mock_conn.execute.side_effect = mock_execute
 
-    mock_acquire_result = MagicMock()
-    mock_acquire_result.fetchone.return_value = (True,)
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
-    async def mock_execute(query, *args, **kwargs):
-        query_str = str(query)
-        if "pg_try_advisory_lock" in query_str:
-            return mock_acquire_result
-        elif "pg_advisory_unlock" in query_str:
-            raise RuntimeError("Database connection lost")
-        return MagicMock()
+            acquired = await self.lock_service._try_acquire_leader_lock()
+            self.assertTrue(acquired)
+            self.lock_service._is_leader = True
 
-    mock_conn.execute.side_effect = mock_execute
+            await self.lock_service._release_leader_session()
 
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
+            mock_conn.invalidate.assert_awaited_once()
+            mock_conn.close.assert_not_awaited()
 
-        acquired = await lock_service._try_acquire_leader_lock()
-        assert acquired is True
-        lock_service._is_leader = True
+    async def test_uncertain_acquire_cancellation(self):
+        """
+        Test that if the acquire query throws an exception or is cancelled, the connection is forcibly invalidated
+        because the database might have granted the lock before the error reached Python.
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.return_value = mock_conn
 
-        await lock_service._release_leader_session()
+        mock_conn.execute.side_effect = asyncio.CancelledError("Task cancelled")
 
-        mock_conn.invalidate.assert_awaited_once()
-        mock_conn.close.assert_not_awaited()
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
+            with self.assertRaises(asyncio.CancelledError):
+                await self.lock_service._try_acquire_leader_lock()
 
-@pytest.mark.asyncio
-async def test_uncertain_acquire_cancellation(lock_service):
-    """
-    Test that if the acquire query throws an exception or is cancelled, the connection is forcibly invalidated
-    because the database might have granted the lock before the error reached Python.
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.return_value = mock_conn
+            self.assertFalse(self.lock_service._is_leader)
 
-    mock_conn.execute.side_effect = asyncio.CancelledError("Task cancelled")
+            mock_conn.invalidate.assert_awaited_once()
+            mock_conn.close.assert_not_awaited()
 
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
+    async def test_uncertain_acquire_exception(self):
+        """
+        Test that a regular Exception during acquire also force-invalidates and returns False
+        (as opposed to CancelledError which re-raises).
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.return_value = mock_conn
 
-        with pytest.raises(asyncio.CancelledError):
-            await lock_service._try_acquire_leader_lock()
+        mock_conn.execute.side_effect = RuntimeError("Connection reset by peer")
 
-        assert lock_service._is_leader is False
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
-        mock_conn.invalidate.assert_awaited_once()
-        mock_conn.close.assert_not_awaited()
+            acquired = await self.lock_service._try_acquire_leader_lock()
+            self.assertFalse(acquired)
+            self.assertFalse(self.lock_service._is_leader)
 
+            mock_conn.invalidate.assert_awaited_once()
+            mock_conn.close.assert_not_awaited()
 
-@pytest.mark.asyncio
-async def test_uncertain_acquire_exception(lock_service):
-    """
-    Test that a regular Exception during acquire also force-invalidates and returns False
-    (as opposed to CancelledError which re-raises).
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.return_value = mock_conn
+    async def test_execution_options_failure(self):
+        """
+        Test that if execution_options fails, the original raw connection is closed.
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.side_effect = RuntimeError("Failed to set options")
 
-    mock_conn.execute.side_effect = RuntimeError("Connection reset by peer")
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
+            acquired = await self.lock_service._try_acquire_leader_lock()
+            self.assertFalse(acquired)
 
-        acquired = await lock_service._try_acquire_leader_lock()
-        assert acquired is False
-        assert lock_service._is_leader is False
+            mock_conn.close.assert_awaited_once()
+            mock_conn.invalidate.assert_not_awaited()
 
-        # uncertain=True → force_invalidate=True → invalidate, not close
-        mock_conn.invalidate.assert_awaited_once()
-        mock_conn.close.assert_not_awaited()
+    async def test_execution_options_cancellation(self):
+        """
+        Test that if execution_options is cancelled, the connection is closed and CancelledError is re-raised.
+        """
+        mock_conn = AsyncMock(spec=AsyncConnection)
+        mock_conn.execution_options.side_effect = asyncio.CancelledError("Task cancelled")
 
+        with patch("app.services.distributed_lock.engine") as mock_engine:
+            mock_engine.connect = AsyncMock(return_value=mock_conn)
 
-@pytest.mark.asyncio
-async def test_execution_options_failure(lock_service):
-    """
-    Test that if execution_options fails, the original raw connection is closed.
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.side_effect = RuntimeError("Failed to set options")
+            with self.assertRaises(asyncio.CancelledError):
+                await self.lock_service._try_acquire_leader_lock()
 
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
-
-        acquired = await lock_service._try_acquire_leader_lock()
-        assert acquired is False
-
-        mock_conn.close.assert_awaited_once()
-        mock_conn.invalidate.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_execution_options_cancellation(lock_service):
-    """
-    Test that if execution_options is cancelled, the connection is closed and CancelledError is re-raised.
-    """
-    mock_conn = AsyncMock(spec=AsyncConnection)
-    mock_conn.execution_options.side_effect = asyncio.CancelledError("Task cancelled")
-
-    with patch("app.services.distributed_lock.engine") as mock_engine:
-        mock_engine.connect = AsyncMock(return_value=mock_conn)
-
-        with pytest.raises(asyncio.CancelledError):
-            await lock_service._try_acquire_leader_lock()
-
-        mock_conn.close.assert_awaited_once()
-        mock_conn.invalidate.assert_not_awaited()
+            mock_conn.close.assert_awaited_once()
+            mock_conn.invalidate.assert_not_awaited()


### PR DESCRIPTION
_release_leader_session() previously only closed the SQLAlchemy session, returning the underlying connection to the pool with the pg_advisory_lock still held. This caused:

1. Self-lockout on error recovery: when the election loop hit an exception, the lock leaked onto the pooled connection and subsequent acquire attempts on a different pooled connection would fail permanently.

```Python
# Line 83-85
except Exception as e:
    logger.exception("Error in leader election loop: %s", e)
    await self._release_leader_session()  # ← lock leaks onto pooled connection
# Loop continues running, process stays alive
```
Here the process doesn't exit. The lock is stuck on a pooled connection, and when _try_acquire_leader_lock runs again 5 seconds later, it creates a new session which may get a different pooled connection. That new connection tries pg_try_advisory_lock and:

If it gets the same physical connection → succeeds (PG counts it as a re-acquire by the same session)
If it gets a different physical connection → fails, because the old connection in the pool still holds the lock

2. Delayed leader handoff on graceful shutdown: the lock persisted until process exit rather than releasing immediately on stop().

Now explicitly calls pg_advisory_unlock before session.close() so the lock is released deterministically.