### PR TITLE
feat: dashboard chat composer

### DIFF
--- a/docs/superpowers/plans/2026-08-07-dashboard-chat-composer.md
+++ b/docs/superpowers/plans/2026-08-07-dashboard-chat-composer.md
@@ -1,0 +1,913 @@
+# Dashboard Chat Composer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a horizontal chat composer to the top of the dashboard Workflows tab that greets the user, takes a prompt plus an optional file, lets them pick an LLM credential and model, then creates a conversation and opens it in the chat tab with the reply already streaming.
+
+**Architecture:** A new self-contained `DashboardChatComposer.vue` sends through the existing `useChatStore` (`createConversation` then `sendMessage`) and navigates to `/chats/:id`. The credential and model bootstrap that lives inline in `ChatConversation.vue` today is extracted into a shared `useChatModelSelection` composable so both surfaces use one implementation. No backend change.
+
+**Tech Stack:** Vue 3 `<script setup>` + TypeScript strict, Pinia, Vue Router, Tailwind, existing `SearchableSelect` and `useFileAttachment`.
+
+**Spec:** `docs/superpowers/specs/2026-08-07-dashboard-chat-composer-design.md`
+
+---
+
+## Testing policy for this plan
+
+This repo's owner does not want frontend or UI tests written for heymrun (verification is lint, typecheck, and manual checks). This feature is frontend only and touches no backend code, so there are no pytest additions either. That is why the tasks below do not follow the usual red/green TDD loop. Every task still ends with a mechanical verification command whose expected output is stated, plus a manual check where behavior changes.
+
+Run all frontend commands from `frontend/`:
+
+- `bun run lint`
+- `bun run typecheck`
+
+Run `./check.sh` from the repo root once at the end (it applies `ruff format`, then lint and backend tests). If your shell does not export `SECRET_KEY`, use:
+`SECRET_KEY=test-secret-key-for-tests-only-32-bytes HEYM_OTEL_ENABLED=false ./check.sh`
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `frontend/src/composables/useChatModelSelection.ts` (create) | Loads LLM credentials and models, resolves defaults through `useAiDefaults`, owns `selectedCredentialId` / `selectedModel` and their loading and failure flags |
+| `frontend/src/components/Chat/DashboardChatComposer.vue` (create) | The dashboard composer UI and its submit flow |
+| `frontend/src/components/Chat/ChatConversation.vue` (modify) | Drops its inline credential and model state in favor of the composable |
+| `frontend/src/views/DashboardView.vue` (modify) | Renders the composer on the Workflows tab, owns the dismissed flag and the `Ask AI` restore button |
+
+---
+
+### Task 1: Extract the credential and model selection composable
+
+**Files:**
+- Create: `frontend/src/composables/useChatModelSelection.ts`
+
+Background for someone new to this codebase: `credentialsApi.listLLM()` returns the user's LLM credentials, `credentialsApi.getModels(credentialId)` returns the models for one credential, and `useAiDefaults()` resolves the user's preferred credential and model (`preferred_credential_id`, `preferred_model` on the user record). The resolution order copied below is the behavior that ships today in `ChatConversation.vue`; do not change it.
+
+`onModelsSettled` exists because `ChatConversation.vue` runs two side effects in the `finally` block of its current `loadModels`: it refocuses the chat textarea and it loads the context summary. The composable stays unaware of those by taking a callback.
+
+- [ ] **Step 1: Create the composable**
+
+```typescript
+import { computed, ref } from "vue";
+import type { ComputedRef, Ref } from "vue";
+
+import type { CredentialListItem, LLMModel } from "@/types/credential";
+
+import { useAiDefaults } from "@/composables/useAiDefaults";
+import { credentialsApi } from "@/services/api";
+
+export interface ChatSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SavedChatSelection {
+  credentialId?: string | null;
+  model?: string | null;
+}
+
+export interface UseChatModelSelectionOptions {
+  /** Runs after every model load attempt, success or failure. */
+  onModelsSettled?: () => void;
+}
+
+export interface UseChatModelSelectionResult {
+  credentials: Ref<CredentialListItem[]>;
+  models: Ref<LLMModel[]>;
+  selectedCredentialId: Ref<string>;
+  selectedModel: Ref<string>;
+  credentialOptions: ComputedRef<ChatSelectOption[]>;
+  modelOptions: ComputedRef<ChatSelectOption[]>;
+  isLoadingModels: Ref<boolean>;
+  modelsLoadFailed: Ref<boolean>;
+  credentialError: Ref<string>;
+  credentialsLoaded: Ref<boolean>;
+  hasCredentials: ComputedRef<boolean>;
+  isReady: ComputedRef<boolean>;
+  modelPlaceholder: ComputedRef<string>;
+  loadCredentials: () => Promise<void>;
+  loadModels: (credentialId: string, preferredModelId?: string) => Promise<void>;
+  applySavedSelection: (saved?: SavedChatSelection) => Promise<void>;
+  selectCredential: (value: string | undefined) => Promise<void>;
+  bootstrap: (saved?: SavedChatSelection) => Promise<void>;
+}
+
+/**
+ * Shared LLM credential and model selection for chat surfaces.
+ *
+ * Resolution order matches the chat composer: a saved selection wins, then the
+ * user's preferred credential and model, then the first credential and the last
+ * model in the list.
+ */
+export function useChatModelSelection(
+  options: UseChatModelSelectionOptions = {},
+): UseChatModelSelectionResult {
+  const aiDefaults = useAiDefaults();
+
+  const credentials = ref<CredentialListItem[]>([]);
+  const models = ref<LLMModel[]>([]);
+  const selectedCredentialId = ref("");
+  const selectedModel = ref("");
+  const isLoadingModels = ref(false);
+  const modelsLoadFailed = ref(false);
+  const credentialError = ref("");
+  const credentialsLoaded = ref(false);
+
+  const credentialOptions = computed<ChatSelectOption[]>(() =>
+    credentials.value.map((credential) => ({
+      value: credential.id,
+      label: credential.name,
+    })),
+  );
+
+  const modelOptions = computed<ChatSelectOption[]>(() =>
+    models.value.map((model) => ({
+      value: model.id,
+      label: model.name,
+    })),
+  );
+
+  const hasCredentials = computed<boolean>(() => credentials.value.length > 0);
+
+  const isReady = computed<boolean>(
+    () =>
+      Boolean(selectedCredentialId.value) &&
+      Boolean(selectedModel.value) &&
+      !modelsLoadFailed.value,
+  );
+
+  const modelPlaceholder = computed<string>(() => {
+    if (isLoadingModels.value) return "Loading...";
+    if (modelsLoadFailed.value) return "Failed to load";
+    return "Select...";
+  });
+
+  async function loadModels(credentialId: string, preferredModelId?: string): Promise<void> {
+    if (!credentialId) return;
+    isLoadingModels.value = true;
+    modelsLoadFailed.value = false;
+    models.value = [];
+    selectedModel.value = "";
+    try {
+      models.value = await credentialsApi.getModels(credentialId);
+      if (models.value.length > 0) {
+        const match = preferredModelId
+          ? models.value.find((model) => model.id === preferredModelId)
+          : null;
+        const preferredModel = aiDefaults.resolveModel(credentialId, models.value, {
+          savedModel: preferredModelId ?? null,
+        });
+        selectedModel.value =
+          preferredModel ?? (match ? match.id : models.value[models.value.length - 1].id);
+      }
+    } catch {
+      modelsLoadFailed.value = true;
+    } finally {
+      isLoadingModels.value = false;
+      options.onModelsSettled?.();
+    }
+  }
+
+  async function loadCredentials(): Promise<void> {
+    try {
+      credentials.value = await credentialsApi.listLLM();
+      credentialsLoaded.value = true;
+    } catch {
+      credentialError.value = "Failed to load credentials";
+    }
+  }
+
+  async function applySavedSelection(saved: SavedChatSelection = {}): Promise<void> {
+    if (credentials.value.length === 0) return;
+    const savedCredentialId = saved.credentialId ?? null;
+    if (savedCredentialId && credentials.value.some((c) => c.id === savedCredentialId)) {
+      selectedCredentialId.value = savedCredentialId;
+      await loadModels(savedCredentialId, saved.model ?? undefined);
+      return;
+    }
+    if (selectedCredentialId.value) return;
+    const resolved = aiDefaults.resolveCredentialId(credentials.value, {});
+    if (!resolved) return;
+    selectedCredentialId.value = resolved;
+    await loadModels(resolved);
+  }
+
+  async function selectCredential(value: string | undefined): Promise<void> {
+    selectedCredentialId.value = value ?? "";
+    if (!selectedCredentialId.value) {
+      models.value = [];
+      selectedModel.value = "";
+      return;
+    }
+    await loadModels(selectedCredentialId.value);
+  }
+
+  async function bootstrap(saved: SavedChatSelection = {}): Promise<void> {
+    await loadCredentials();
+    await applySavedSelection(saved);
+  }
+
+  return {
+    credentials,
+    models,
+    selectedCredentialId,
+    selectedModel,
+    credentialOptions,
+    modelOptions,
+    isLoadingModels,
+    modelsLoadFailed,
+    credentialError,
+    credentialsLoaded,
+    hasCredentials,
+    isReady,
+    modelPlaceholder,
+    loadCredentials,
+    loadModels,
+    applySavedSelection,
+    selectCredential,
+    bootstrap,
+  };
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run from `frontend/`: `bun run typecheck`
+Expected: PASS, no output errors. The composable is not imported anywhere yet, and `noUnusedLocals` only flags unused locals inside a module, not unused exports, so this is clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/composables/useChatModelSelection.ts
+git commit -m "refactor: add shared useChatModelSelection composable"
+```
+
+---
+
+### Task 2: Move ChatConversation onto the composable
+
+**Files:**
+- Modify: `frontend/src/components/Chat/ChatConversation.vue`
+
+This task must be behavior preserving. The chat view is the primary chat surface and a regression here is worse than the whole feature.
+
+- [ ] **Step 1: Replace the imports**
+
+In the import block, delete the `CredentialListItem, LLMModel` type import and the `useAiDefaults` import, and add the composable. Concretely:
+
+Remove these two lines:
+
+```typescript
+import type { CredentialListItem, LLMModel } from "@/types/credential";
+```
+
+```typescript
+import { useAiDefaults } from "@/composables/useAiDefaults";
+```
+
+Add next to the other composable imports:
+
+```typescript
+import { useChatModelSelection } from "@/composables/useChatModelSelection";
+```
+
+Also change the API import from:
+
+```typescript
+import { aiApi, credentialsApi } from "@/services/api";
+```
+
+to:
+
+```typescript
+import { aiApi } from "@/services/api";
+```
+
+- [ ] **Step 2: Replace the local state block**
+
+Delete these declarations (they currently sit just after `const fileInputRef = ...`):
+
+```typescript
+const credentials = ref<CredentialListItem[]>([]);
+const models = ref<LLMModel[]>([]);
+const selectedCredentialId = ref("");
+const selectedModel = ref("");
+const isLoadingModels = ref(false);
+const credentialError = ref("");
+const modelsLoadFailed = ref(false);
+```
+
+Delete the `credentialOptions`, `modelOptions`, and `modelSelectPlaceholder` computed blocks, and delete the local `interface SelectOption { value: string; label: string; }` near the top of the script. Those two computeds are its only consumers, so nothing else breaks.
+
+Do not destructure `models` or `loadModels` from the composable. After this refactor nothing in `ChatConversation.vue` references them directly, and `noUnusedLocals` would fail the typecheck.
+
+Delete `const aiDefaults = useAiDefaults();`.
+
+In their place, add:
+
+```typescript
+const {
+  credentials,
+  selectedCredentialId,
+  selectedModel,
+  credentialOptions,
+  modelOptions,
+  isLoadingModels,
+  modelsLoadFailed,
+  credentialError,
+  modelPlaceholder: modelSelectPlaceholder,
+  loadCredentials: loadCredentialList,
+  applySavedSelection,
+  selectCredential,
+} = useChatModelSelection({
+  onModelsSettled: () => {
+    focusInputWhenReady();
+    void _maybeLoadContextSummary();
+  },
+});
+```
+
+Note: `focusInputWhenReady` and `_maybeLoadContextSummary` are function declarations later in the file, so they are hoisted and safe to reference from this callback.
+
+- [ ] **Step 3: Rewrite the three functions that used the deleted state**
+
+Replace the existing `_applyConversationSession`, `loadCredentials`, and `loadModels` function bodies with these. The old `loadModels` and the old `onCredentialChange` are deleted entirely; `loadModels` now comes from the composable.
+
+```typescript
+function _applyConversationSession(): void {
+  const conv = chatStore.activeConversation;
+  if (!conv || !credentials.value.length) return;
+  void applySavedSelection({
+    credentialId: conv.last_credential_id,
+    model: conv.last_model,
+  });
+}
+
+async function loadCredentials(): Promise<void> {
+  await loadCredentialList();
+  _credentialsReady = true;
+  if (credentials.value.length === 0) return;
+  if (chatStore.activeConversation) {
+    _applyConversationSession();
+    return;
+  }
+  await applySavedSelection();
+}
+
+function onCredentialSelect(value: string | undefined): void {
+  void selectCredential(value);
+}
+```
+
+Delete the old `async function onCredentialChange()` since `selectCredential` covers it. Search the file for `onCredentialChange` first and make sure the template does not reference it (today only `onCredentialSelect` is bound).
+
+- [ ] **Step 4: Confirm nothing else referenced the removed symbols**
+
+Run from `frontend/`:
+
+```bash
+grep -n "aiDefaults\|credentialsApi\|onCredentialChange\|LLMModel" src/components/Chat/ChatConversation.vue
+```
+
+Expected: no matches. If `credentialsApi` still matches, some other call site uses it; keep the import and only drop the unused symbols.
+
+- [ ] **Step 5: Lint and typecheck**
+
+Run from `frontend/`: `bun run lint && bun run typecheck`
+Expected: both PASS with no errors.
+
+- [ ] **Step 6: Manual smoke test of the chat view**
+
+Start the stack from the repo root with `./run.sh`, open `http://localhost:4017/chats`, then check:
+
+1. Opening an existing conversation preselects that conversation's credential and model.
+2. Creating a new chat preselects your preferred credential and model.
+3. Switching the credential dropdown reloads the model list.
+4. Sending a message still works and streams.
+
+Expected: identical to `main` before this change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/Chat/ChatConversation.vue
+git commit -m "refactor: use shared model selection composable in ChatConversation"
+```
+
+---
+
+### Task 3: Build the DashboardChatComposer component
+
+**Files:**
+- Create: `frontend/src/components/Chat/DashboardChatComposer.vue`
+
+The component is not mounted anywhere in this task, so it can be reviewed on its own before it touches the dashboard.
+
+- [ ] **Step 1: Create the component**
+
+```vue
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { Loader2, Paperclip, Send, X } from "lucide-vue-next";
+
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
+import { useChatModelSelection } from "@/composables/useChatModelSelection";
+import { useFileAttachment } from "@/composables/useFileAttachment";
+import { useAuthStore } from "@/stores/auth";
+import { useChatStore } from "@/stores/chat";
+
+const emit = defineEmits<{
+  (event: "dismiss"): void;
+  (event: "open-credentials"): void;
+}>();
+
+const ATTACHMENT_ACCEPT =
+  ".txt,.csv,.json,.md,.py,.ts,.js,.html,.xml,.yaml,.yml,.log,.jpg,.jpeg,.png,.gif,.webp,.pdf";
+const MAX_INPUT_HEIGHT_PX = 140;
+
+const router = useRouter();
+const authStore = useAuthStore();
+const chatStore = useChatStore();
+
+const {
+  credentialOptions,
+  modelOptions,
+  selectedCredentialId,
+  selectedModel,
+  isLoadingModels,
+  modelsLoadFailed,
+  credentialsLoaded,
+  hasCredentials,
+  isReady,
+  modelPlaceholder,
+  bootstrap,
+  selectCredential,
+} = useChatModelSelection();
+
+const { attachedFile, attachmentError, attachmentLoading, processFile, clearAttachment } =
+  useFileAttachment();
+
+const input = ref("");
+const inputRef = ref<HTMLTextAreaElement | null>(null);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const isSubmitting = ref(false);
+const submitError = ref("");
+
+const greeting = computed<string>(() => {
+  const name = authStore.user?.name?.trim();
+  return name ? `Welcome ${name},` : "Welcome,";
+});
+
+const showNoCredentialsHint = computed<boolean>(
+  () => credentialsLoaded.value && !hasCredentials.value,
+);
+
+const canSubmit = computed<boolean>(
+  () =>
+    input.value.trim().length > 0 &&
+    isReady.value &&
+    !attachmentLoading.value &&
+    attachmentError.value === null &&
+    !isSubmitting.value,
+);
+
+function resizeInput(): void {
+  const element = inputRef.value;
+  if (!element) return;
+  element.style.height = "auto";
+  element.style.height = `${Math.min(element.scrollHeight, MAX_INPUT_HEIGHT_PX)}px`;
+}
+
+function onInput(): void {
+  resizeInput();
+}
+
+function openFilePicker(): void {
+  fileInputRef.value?.click();
+}
+
+async function handleFileInputChange(event: Event): Promise<void> {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) return;
+  await processFile(file);
+  // Allow re-picking the same file after removing it.
+  target.value = "";
+}
+
+function onCredentialSelect(value: string | undefined): void {
+  void selectCredential(value);
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    void submit();
+  }
+}
+
+async function submit(): Promise<void> {
+  const text = input.value.trim();
+  if (!canSubmit.value || !text) return;
+
+  isSubmitting.value = true;
+  submitError.value = "";
+  const payload = attachedFile.value;
+
+  try {
+    const conversation = await chatStore.createConversation();
+    // sendMessage swallows its own transport errors and clears stream state,
+    // so a failure here still leaves a real conversation to navigate to.
+    await chatStore.sendMessage(
+      conversation.id,
+      text,
+      selectedCredentialId.value,
+      selectedModel.value,
+      payload ? { name: payload.name, kind: payload.kind, content: payload.content } : null,
+    );
+    input.value = "";
+    clearAttachment();
+    void nextTick(resizeInput);
+    await router.push(`/chats/${conversation.id}`);
+  } catch {
+    submitError.value = "Could not start chat. Try again.";
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+onMounted(() => {
+  void bootstrap();
+});
+</script>
+
+<template>
+  <section
+    data-testid="dashboard-chat-composer"
+    class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 py-4 shadow-sm sm:px-5"
+  >
+    <button
+      type="button"
+      class="absolute right-3 top-3 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      aria-label="Hide chat box"
+      title="Hide"
+      @click="emit('dismiss')"
+    >
+      <X class="h-4 w-4" />
+    </button>
+
+    <h2 class="text-lg font-bold tracking-tight sm:text-xl">
+      {{ greeting }}
+    </h2>
+    <p class="mt-0.5 text-sm text-muted-foreground">
+      What do you want to automate?
+    </p>
+
+    <input
+      ref="fileInputRef"
+      type="file"
+      :accept="ATTACHMENT_ACCEPT"
+      class="hidden"
+      @change="handleFileInputChange"
+    >
+
+    <form
+      class="mt-3 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2 py-2 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-center sm:px-3"
+      @submit.prevent="submit"
+    >
+      <button
+        type="button"
+        class="hidden h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
+        :disabled="attachmentLoading"
+        title="Attach file"
+        aria-label="Attach file"
+        @click="openFilePicker"
+      >
+        <Paperclip class="h-4 w-4" />
+      </button>
+
+      <textarea
+        ref="inputRef"
+        v-model="input"
+        rows="1"
+        data-testid="dashboard-chat-input"
+        placeholder="Ask anything, or describe a workflow to build"
+        class="min-h-[36px] w-full flex-1 resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        @input="onInput"
+        @keydown="onKeydown"
+      />
+
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:hidden"
+          :disabled="attachmentLoading"
+          title="Attach file"
+          aria-label="Attach file"
+          @click="openFilePicker"
+        >
+          <Paperclip class="h-4 w-4" />
+        </button>
+
+        <div
+          class="min-w-0 flex-1 sm:w-[160px] sm:flex-none"
+          data-testid="dashboard-chat-credential-selector"
+        >
+          <SearchableSelect
+            id="dashboard-chat-credential-select"
+            :model-value="selectedCredentialId"
+            :options="credentialOptions"
+            placeholder="Select..."
+            search-placeholder="Search credentials..."
+            empty-text="No credentials found."
+            :disabled="!hasCredentials"
+            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            content-class="z-[60]"
+            @update:model-value="onCredentialSelect"
+          />
+        </div>
+
+        <div
+          class="min-w-0 flex-1 sm:w-[160px] sm:flex-none"
+          data-testid="dashboard-chat-model-selector"
+        >
+          <SearchableSelect
+            id="dashboard-chat-model-select"
+            :model-value="selectedModel"
+            :options="modelOptions"
+            :placeholder="modelPlaceholder"
+            search-placeholder="Search models..."
+            empty-text="No models found."
+            :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
+            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            content-class="z-[60]"
+            @update:model-value="selectedModel = $event ?? ''"
+          />
+        </div>
+
+        <button
+          type="submit"
+          data-testid="dashboard-chat-send"
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          :disabled="!canSubmit"
+          title="Start chat"
+          aria-label="Start chat"
+        >
+          <Loader2
+            v-if="isSubmitting"
+            class="h-4 w-4 animate-spin"
+          />
+          <Send
+            v-else
+            class="h-4 w-4"
+          />
+        </button>
+      </div>
+    </form>
+
+    <div
+      v-if="attachedFile || attachmentError || modelsLoadFailed || showNoCredentialsHint || submitError"
+      class="mt-2 flex flex-wrap items-center gap-2"
+    >
+      <div
+        v-if="attachedFile"
+        class="flex max-w-xs items-center gap-1.5 rounded-lg border border-border/40 bg-muted/60 px-2.5 py-1 text-xs text-foreground"
+      >
+        <Paperclip class="h-3 w-3 shrink-0 text-muted-foreground" />
+        <span class="truncate">{{ attachedFile.name }}</span>
+        <span class="shrink-0 text-muted-foreground">· {{ attachedFile.sizeKb }} KB</span>
+        <button
+          type="button"
+          class="ml-0.5 shrink-0 rounded p-0.5 hover:bg-muted/80"
+          aria-label="Remove attachment"
+          @click="clearAttachment"
+        >
+          <X class="h-3 w-3" />
+        </button>
+      </div>
+
+      <p
+        v-if="attachmentError"
+        class="text-xs text-destructive"
+      >
+        {{ attachmentError }}
+      </p>
+
+      <p
+        v-if="modelsLoadFailed"
+        class="text-xs text-amber-600 dark:text-amber-400"
+      >
+        This credential's model list could not be loaded.
+      </p>
+
+      <button
+        v-if="showNoCredentialsHint"
+        type="button"
+        class="text-xs font-medium text-primary underline-offset-2 hover:underline"
+        @click="emit('open-credentials')"
+      >
+        Add an LLM credential to start chatting
+      </button>
+
+      <p
+        v-if="submitError"
+        class="text-xs text-destructive"
+      >
+        {{ submitError }}
+      </p>
+    </div>
+  </section>
+</template>
+```
+
+- [ ] **Step 2: Check the SearchableSelect props actually exist**
+
+Run from `frontend/`:
+
+```bash
+grep -n "defineProps\|withDefaults" -A 20 src/components/ui/SearchableSelect.vue | head -40
+```
+
+Expected: props include `modelValue`, `options`, `placeholder`, `searchPlaceholder`, `emptyText`, `disabled`, `selectClass`, `contentClass`, and it emits `update:modelValue`. If any prop name differs, adjust the two `SearchableSelect` usages above to match, and mirror whatever `ChatConversation.vue` already passes.
+
+- [ ] **Step 3: Lint and typecheck**
+
+Run from `frontend/`: `bun run lint && bun run typecheck`
+Expected: both PASS. If lint complains that `ATTACHMENT_ACCEPT` or `MAX_INPUT_HEIGHT_PX` are unused, you dropped a template binding; re-add it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/Chat/DashboardChatComposer.vue
+git commit -m "feat: add dashboard chat composer component"
+```
+
+---
+
+### Task 4: Mount the composer on the dashboard Workflows tab
+
+**Files:**
+- Modify: `frontend/src/views/DashboardView.vue`
+
+- [ ] **Step 1: Add the imports**
+
+Add `Sparkles` to the existing `lucide-vue-next` import list (keep it alphabetical, so between `Settings` and `Trash2`):
+
+```typescript
+  Settings,
+  Sparkles,
+  Trash2,
+```
+
+Add the component import next to the other `@/components` imports (after the `CredentialsPanel` line reads well alphabetically, but any spot in that block is fine):
+
+```typescript
+import DashboardChatComposer from "@/components/Chat/DashboardChatComposer.vue";
+```
+
+- [ ] **Step 2: Add the dismiss state**
+
+Add this near the other top-level state in `<script setup>`, for example right after `const activeTab = ref<TabKey>(initialTab);`:
+
+```typescript
+const CHAT_COMPOSER_DISMISSED_KEY = "heym-dashboard-chat-composer-dismissed";
+
+function readChatComposerDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CHAT_COMPOSER_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+const chatComposerDismissed = ref(readChatComposerDismissed());
+
+function dismissChatComposer(): void {
+  chatComposerDismissed.value = true;
+  try {
+    window.localStorage.setItem(CHAT_COMPOSER_DISMISSED_KEY, "1");
+  } catch {
+    // Ignore storage failures; the composer still hides for this session.
+  }
+}
+
+function restoreChatComposer(): void {
+  chatComposerDismissed.value = false;
+  try {
+    window.localStorage.removeItem(CHAT_COMPOSER_DISMISSED_KEY);
+  } catch {
+    // Ignore storage failures; the composer still shows for this session.
+  }
+}
+
+function openCredentialsTab(): void {
+  activeTab.value = "credentials";
+}
+```
+
+- [ ] **Step 3: Render the composer above the Workflows heading**
+
+In the template, find this exact closing of the drag overlay `Transition` followed by the header row (around line 1471):
+
+```html
+            </Transition>
+
+            <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-5">
+```
+
+Change it to:
+
+```html
+            </Transition>
+
+            <DashboardChatComposer
+              v-if="!chatComposerDismissed"
+              @dismiss="dismissChatComposer"
+              @open-credentials="openCredentialsTab"
+            />
+
+            <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-5">
+```
+
+- [ ] **Step 4: Add the `Ask AI` restore button**
+
+Inside that same header row, the right-hand action group starts with:
+
+```html
+              <div class="flex flex-wrap items-center justify-end gap-1.5 sm:flex-nowrap">
+```
+
+Insert the restore button as its first child:
+
+```html
+              <div class="flex flex-wrap items-center justify-end gap-1.5 sm:flex-nowrap">
+                <Button
+                  v-if="chatComposerDismissed"
+                  variant="ghost"
+                  size="sm"
+                  class="gap-1.5"
+                  data-testid="dashboard-chat-composer-restore"
+                  @click="restoreChatComposer"
+                >
+                  <Sparkles class="w-4 h-4" />
+                  Ask AI
+                </Button>
+```
+
+- [ ] **Step 5: Lint and typecheck**
+
+Run from `frontend/`: `bun run lint && bun run typecheck`
+Expected: both PASS.
+
+- [ ] **Step 6: Manual verification**
+
+With `./run.sh` running, open `http://localhost:4017/`:
+
+1. The composer sits above the Workflows heading with `Welcome <your name>,` and preselected credential and model.
+2. Type a prompt and press Enter. You land on `/chats/<id>`, your message is there, and the reply streams without a duplicate assistant bubble.
+3. Go back to the dashboard. The composer is empty again.
+4. Attach a `.txt`, `.png`, and `.pdf` in three separate sends. Each arrives with the file name on the user message.
+5. Attach an unsupported file (for example `.zip`). The composer shows `Unsupported file type` and the send button stays disabled.
+6. Switch to the Credentials tab and back. The composer does not appear on other tabs.
+7. Click the `x`. The composer hides and `Ask AI` appears next to the heading. Reload the page: still hidden. Click `Ask AI`: it comes back and survives a reload.
+8. Double click the send button quickly. Only one conversation is created.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/views/DashboardView.vue
+git commit -m "feat: show chat composer on dashboard workflows tab"
+```
+
+---
+
+### Task 5: Documentation and full check
+
+**Files:**
+- Modify: docs chosen by the `heym-documentation` skill (expect `frontend/src/docs/content/` pages covering the dashboard or the chat assistant)
+
+- [ ] **Step 1: Update the docs**
+
+Invoke the `heym-documentation` skill and ask it to document the dashboard chat composer: where it lives (Workflows tab), what it does (start an assistant chat with an optional file and a chosen credential and model), that submitting opens the conversation in the Chats tab, and that it can be hidden and restored with `Ask AI`. Keep the copy short and plain, no em dashes.
+
+- [ ] **Step 2: Run the full check**
+
+Run from the repo root:
+
+```bash
+SECRET_KEY=test-secret-key-for-tests-only-32-bytes HEYM_OTEL_ENABLED=false ./check.sh
+```
+
+Expected: frontend lint and typecheck PASS, backend Ruff PASS, backend tests PASS. `HEYM_OTEL_ENABLED=false` is required because a stale `.env` value plus no collector makes the suite hang.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "docs: document the dashboard chat composer"
+```
+
+- [ ] **Step 4: Report, do not push**
+
+Summarize what shipped and leave the commits local. Pushing requires explicit approval.

--- a/docs/superpowers/specs/2026-08-07-dashboard-chat-composer-design.md
+++ b/docs/superpowers/specs/2026-08-07-dashboard-chat-composer-design.md
@@ -1,0 +1,145 @@
+# Dashboard Chat Composer
+
+Date: 2026-08-07
+Status: Approved, ready for implementation plan
+
+## Summary
+
+Add a horizontal chat composer to the top of the dashboard Workflows tab. It greets the
+user by name, asks what they want to automate, accepts a file attachment, and lets them
+pick an LLM credential and model. Submitting creates a conversation, sends the first
+message, and navigates to `/chats/:id` where the response streams in.
+
+## Goals
+
+- Let a user start an assistant chat from the dashboard without first opening the Chats tab.
+- Carry the same capabilities the chat composer already has: file attachment, credential
+  selection, model selection.
+- Reuse existing store and composable contracts instead of adding backend surface.
+
+## Non-goals
+
+- Multiple file attachments. The chat API takes one attachment per message.
+- Voice input, quick prompts, or queued messages on the dashboard. Those stay in the chat view.
+- Any backend change. No new endpoint, model, or migration.
+
+## User-visible behavior
+
+Placement: dashboard Workflows tab only, directly above the `Workflows` heading block,
+below `DashboardNav`. Other tabs (credentials, drive, mcp, and so on) do not render it.
+
+Copy (short, natural English, no em dashes):
+
+- Heading: `Welcome {name},` when `authStore.user.name` is set, otherwise `Welcome,`
+- Subheading: `What do you want to automate?`
+- Textarea placeholder: `Ask anything, or describe a workflow to build`
+- No credentials: `Add an LLM credential to start chatting`
+- Model list failure: `This credential's model list could not be loaded.`
+- Create failure: `Could not start chat. Try again.`
+
+Layout: one row on desktop (attach button, textarea, credential select, model select, send
+button), stacked on mobile. The attachment chip and any error text sit under the row.
+
+Dismiss: an `x` in the top right hides the composer and persists that in
+`localStorage["heym-dashboard-chat-composer-dismissed"]`. When dismissed, a small
+`Ask AI` button appears next to the `Workflows` heading and restores the composer.
+
+Keyboard: Enter sends, Shift+Enter inserts a newline. The textarea auto-resizes.
+
+## Architecture
+
+### New: `frontend/src/components/Chat/DashboardChatComposer.vue`
+
+Self-contained component, roughly 200 lines. Emits `dismiss`. Owns its draft text,
+attachment state, and submit state. Uses `SearchableSelect` for both dropdowns, matching
+the chat composer.
+
+### New: `frontend/src/composables/useChatModelSelection.ts`
+
+Extracts the credential and model bootstrap that currently lives inline in
+`ChatConversation.vue`.
+
+Exposed contract:
+
+- State: `credentials`, `models`, `selectedCredentialId`, `selectedModel`,
+  `credentialOptions`, `modelOptions`, `isLoadingModels`, `modelsLoadFailed`,
+  `credentialError`, `hasCredentials`, `isReady`
+- Actions: `bootstrap()`, `selectCredential(id)`,
+  `applySavedSelection({ credentialId, model })`
+
+Resolution rules are the ones in place today: `useAiDefaults.resolveCredentialId` picks the
+saved credential, then the user's `preferred_credential_id`, then the first credential;
+`useAiDefaults.resolveModel` picks the saved model, then `preferred_model`, then the last
+model in the list. `applySavedSelection` covers the chat view's need to restore a
+conversation's `last_credential_id` and `last_model`.
+
+### Edited: `frontend/src/views/DashboardView.vue`
+
+Around 15 lines. Renders `<DashboardChatComposer>` in the Workflows tab, holds the
+dismissed flag, and renders the `Ask AI` restore button.
+
+### Edited: `frontend/src/components/Chat/ChatConversation.vue`
+
+Replaces its local credential and model state with `useChatModelSelection`. Behavior is
+unchanged, including the conversation session restore path (`_applyConversationSession`)
+and the disabled states around `modelsLoadFailed`.
+
+## Data flow
+
+1. Composer mounts and calls `bootstrap()`: `credentialsApi.listLLM()`, resolve credential,
+   `credentialsApi.getModels(credId)`, resolve model.
+2. User types, optionally attaches a file through `useFileAttachment.processFile`.
+3. Submit calls `chatStore.createConversation()`.
+4. Submit then calls
+   `chatStore.sendMessage(conv.id, text, selectedCredentialId, selectedModel, attachedFile)`.
+5. Submit navigates to `/chats/${conv.id}`.
+6. `ChatsView` mounts `ChatConversation`, which calls `chatStore.loadConversation(id)`.
+   Since `activeConversation.id` already matches, the store keeps the optimistic user
+   message, and `foregroundSubscribedConvIds` prevents a second stream subscription. The
+   user lands mid-stream.
+7. The composer clears its text and attachment after a successful submit.
+
+Double submit is blocked by an `isSubmitting` flag. Send is disabled when any of these
+hold: empty trimmed text, no selected model, `modelsLoadFailed`, `attachmentLoading`,
+`attachmentError`, `isSubmitting`.
+
+## Error handling
+
+| Case | Behavior |
+| --- | --- |
+| No LLM credentials | Selects and send disabled, `Add an LLM credential to start chatting` link switches the dashboard to the Credentials tab |
+| `getModels` fails | `modelsLoadFailed` true, model select disabled, warning text shown, send disabled |
+| `createConversation` fails | No navigation. User stays on the dashboard, sees `Could not start chat. Try again.`, and keeps their text and attachment |
+| `sendMessage` fails | `chatStore.sendMessage` already swallows its own errors and clears the stream state, so the composer does not special case it. The conversation exists, so still navigate to `/chats/:id` and let the chat view surface the state |
+| Unsupported or oversized file | `useFileAttachment` error text, send stays disabled until cleared |
+
+## Testing and verification
+
+No backend change, so no new pytest coverage. Per project preference, no frontend UI tests
+are written for this repo.
+
+Automated: `bun run lint`, `bun run typecheck`, and `./check.sh` from the repo root.
+
+Manual checks:
+
+1. Composer opens with the user's preferred credential and model preselected.
+2. Sending with a text file, an image, and a PDF each reaches the chat view with the
+   attachment name on the user message.
+3. An account with no LLM credential shows the CTA and cannot send.
+4. Dismiss hides the composer, survives a reload, and `Ask AI` restores it.
+5. The stream started on the dashboard continues without interruption in the chat tab, and
+   no duplicate assistant message appears.
+
+## Documentation
+
+This is a medium-sized UI addition, so the docs update runs through the
+`heym-documentation` skill: a short section on the dashboard composer in the chat or
+dashboard docs page.
+
+## Risks
+
+- `ChatConversation.vue` is large and its credential and model bootstrap is entangled with
+  focus handling and context summary loading. The composable extraction must keep
+  `focusInputWhenReady` and `_maybeLoadContextSummary` firing at the same points.
+- Navigation timing: `router.push` must happen after `sendMessage` has set the streaming
+  state, otherwise the chat view may briefly render an empty conversation.

--- a/frontend/src/components/Chat/ChatConversation.vue
+++ b/frontend/src/components/Chat/ChatConversation.vue
@@ -22,7 +22,6 @@ import {
 } from "lucide-vue-next";
 
 import type { Message, QueuedMessage, WorkflowPreview } from "@/types/chat";
-import type { CredentialListItem, LLMModel } from "@/types/credential";
 import ChatToolCall from "@/components/Chat/ChatToolCall.vue";
 import ChatContextBadge from "@/components/Chat/ChatContextBadge.vue";
 import ReadonlyCanvasPreview from "@/components/Canvas/ReadonlyCanvasPreview.vue";
@@ -39,8 +38,8 @@ import {
 } from "@/utils/parseClarify";
 import { estimateTokens } from "@/lib/contextEstimator";
 import { markdownToPlainText, renderMarkdown } from "@/lib/markdown";
-import { aiApi, credentialsApi } from "@/services/api";
-import { useAiDefaults } from "@/composables/useAiDefaults";
+import { aiApi } from "@/services/api";
+import { useChatModelSelection } from "@/composables/useChatModelSelection";
 import { useFileAttachment } from "@/composables/useFileAttachment";
 import type { AttachedFile } from "@/composables/useFileAttachment";
 import { useQuickPrompts } from "@/composables/useQuickPrompts";
@@ -58,11 +57,6 @@ interface Props {
   conversationId: string;
 }
 
-interface SelectOption {
-  value: string;
-  label: string;
-}
-
 const props = defineProps<Props>();
 
 const UUID_PATTERN =
@@ -71,7 +65,6 @@ const CHAT_SCROLLBAR_VERTICAL_INSET_PX = 12;
 
 const chatStore = useChatStore();
 const authStore = useAuthStore();
-const aiDefaults = useAiDefaults();
 const router = useRouter();
 
 const input = ref("");
@@ -81,37 +74,27 @@ const messagesScrollRef = ref<HTMLDivElement | null>(null);
 const chatScrollbarTrackRef = ref<HTMLDivElement | null>(null);
 const messagesEndRef = ref<HTMLElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
-const credentials = ref<CredentialListItem[]>([]);
-const models = ref<LLMModel[]>([]);
-const selectedCredentialId = ref("");
-const selectedModel = ref("");
-const isLoadingModels = ref(false);
-const credentialError = ref("");
-const modelsLoadFailed = ref(false);
 
-const credentialOptions = computed<SelectOption[]>(() =>
-  credentials.value.map((credential) => ({
-    value: credential.id,
-    label: credential.name,
-  })),
-);
-
-const modelOptions = computed<SelectOption[]>(() =>
-  models.value.map((model) => ({
-    value: model.id,
-    label: model.name,
-  })),
-);
-
-const modelSelectPlaceholder = computed<string>(() => {
-  if (isLoadingModels.value) {
-    return "Loading...";
-  }
-  if (modelsLoadFailed.value) {
-    return "Failed to load";
-  }
-  return "Select...";
+const {
+  credentials,
+  selectedCredentialId,
+  selectedModel,
+  credentialOptions,
+  modelOptions,
+  isLoadingModels,
+  modelsLoadFailed,
+  credentialError,
+  modelPlaceholder: modelSelectPlaceholder,
+  loadCredentials: loadCredentialList,
+  applySavedSelection,
+  selectCredential,
+} = useChatModelSelection({
+  onModelsSettled: () => {
+    focusInputWhenReady();
+    void _maybeLoadContextSummary();
+  },
 });
+
 const copiedMessageId = ref<string | null>(null);
 const queueEditingId = ref<string | null>(null);
 const queueEditingValue = ref("");
@@ -743,70 +726,21 @@ function toggleSpeechInput(): void {
 function _applyConversationSession(): void {
   const conv = chatStore.activeConversation;
   if (!conv || !credentials.value.length) return;
-  const savedCredId = conv.last_credential_id;
-  const savedModel = conv.last_model;
-  if (savedCredId) {
-    const credMatch = credentials.value.find((c) => c.id === savedCredId);
-    if (credMatch) {
-      selectedCredentialId.value = credMatch.id;
-      void loadModels(credMatch.id, savedModel ?? undefined);
-      return;
-    }
-  }
-  if (!selectedCredentialId.value) {
-    const resolved = aiDefaults.resolveCredentialId(credentials.value, {});
-    if (resolved) {
-      selectedCredentialId.value = resolved;
-      void loadModels(resolved);
-    }
-  }
+  void applySavedSelection({
+    credentialId: conv.last_credential_id,
+    model: conv.last_model,
+  });
 }
 
 async function loadCredentials(): Promise<void> {
-  try {
-    credentials.value = await credentialsApi.listLLM();
-    _credentialsReady = true;
-    if (credentials.value.length > 0) {
-      if (chatStore.activeConversation) {
-        _applyConversationSession();
-      } else if (!selectedCredentialId.value) {
-        const resolved = aiDefaults.resolveCredentialId(credentials.value, {});
-        if (resolved) {
-          selectedCredentialId.value = resolved;
-          await loadModels(resolved);
-        }
-      }
-    }
-  } catch {
-    credentialError.value = "Failed to load credentials";
+  await loadCredentialList();
+  _credentialsReady = true;
+  if (credentials.value.length === 0) return;
+  if (chatStore.activeConversation) {
+    _applyConversationSession();
+    return;
   }
-}
-
-async function loadModels(credId: string, preferredModelId?: string): Promise<void> {
-  if (!credId) return;
-  isLoadingModels.value = true;
-  modelsLoadFailed.value = false;
-  models.value = [];
-  selectedModel.value = "";
-  try {
-    models.value = await credentialsApi.getModels(credId);
-    if (models.value.length > 0) {
-      const match = preferredModelId
-        ? models.value.find((m) => m.id === preferredModelId)
-        : null;
-      const preferredModel = aiDefaults.resolveModel(credId, models.value, {
-        savedModel: preferredModelId ?? null,
-      });
-      selectedModel.value =
-        preferredModel ?? (match ? match.id : models.value[models.value.length - 1].id);
-    }
-  } catch {
-    modelsLoadFailed.value = true;
-  } finally {
-    isLoadingModels.value = false;
-    focusInputWhenReady();
-    void _maybeLoadContextSummary();
-  }
+  await applySavedSelection();
 }
 
 async function _maybeLoadContextSummary(): Promise<void> {
@@ -818,18 +752,8 @@ async function _maybeLoadContextSummary(): Promise<void> {
   );
 }
 
-async function onCredentialChange(): Promise<void> {
-  await loadModels(selectedCredentialId.value);
-}
-
 function onCredentialSelect(value: string | undefined): void {
-  selectedCredentialId.value = value ?? "";
-  if (!selectedCredentialId.value) {
-    models.value = [];
-    selectedModel.value = "";
-    return;
-  }
-  void onCredentialChange();
+  void selectCredential(value);
 }
 
 function sendQuickPrompt(text: string): void {

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
+import { useMediaQuery } from "@vueuse/core";
 import { Loader2, Paperclip, Send, X } from "lucide-vue-next";
 
 import SearchableSelect from "@/components/ui/SearchableSelect.vue";
@@ -45,6 +46,13 @@ const inputRef = ref<HTMLTextAreaElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 const isSubmitting = ref(false);
 const submitError = ref("");
+
+const isNarrowViewport = useMediaQuery("(max-width: 639px)");
+
+// The long prompt wraps and clips inside the one-line box on small screens.
+const inputPlaceholder = computed<string>(() =>
+  isNarrowViewport.value ? "Ask anything" : "Ask anything, or describe a workflow to build",
+);
 
 const greeting = computed<string>(() => {
   const name = authStore.user?.name?.trim();
@@ -172,7 +180,7 @@ onMounted(() => {
             search-placeholder="Search credentials..."
             empty-text="No credentials found."
             :disabled="!hasCredentials"
-            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            select-class="h-8 rounded-lg border-input bg-background shadow-none"
             content-class="z-[60]"
             @update:model-value="onCredentialSelect"
           />
@@ -190,7 +198,7 @@ onMounted(() => {
             search-placeholder="Search models..."
             empty-text="No models found."
             :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
-            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            select-class="h-8 rounded-lg border-input bg-background shadow-none"
             content-class="z-[60]"
             @update:model-value="selectedModel = $event ?? ''"
           />
@@ -212,7 +220,7 @@ onMounted(() => {
     >
       <button
         type="button"
-        class="flex h-[52px] w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+        class="flex h-11 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground sm:h-[52px] sm:w-10 transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
         :disabled="attachmentLoading"
         title="Attach file"
         aria-label="Attach file"
@@ -226,17 +234,17 @@ onMounted(() => {
         v-model="input"
         rows="1"
         data-testid="dashboard-chat-input"
-        placeholder="Ask anything, or describe a workflow to build"
-        class="min-h-[52px] w-full flex-1 resize-none bg-transparent px-2 py-3 text-sm leading-7 text-foreground outline-none placeholder:text-muted-foreground sm:text-[15px]"
+        :placeholder="inputPlaceholder"
+        class="min-h-[44px] w-full flex-1 resize-none bg-transparent px-1.5 py-2 text-sm leading-7 sm:min-h-[52px] sm:px-2 sm:py-3 text-foreground outline-none placeholder:text-muted-foreground sm:text-[15px]"
         @input="onInput"
         @keydown="onKeydown"
       />
 
-      <div class="flex h-[52px] shrink-0 items-center">
+      <div class="flex h-11 shrink-0 items-center sm:h-[52px]">
         <button
           type="submit"
           data-testid="dashboard-chat-send"
-          class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary sm:h-10 sm:w-10 text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
           :disabled="!canSubmit"
           title="Start chat"
           aria-label="Start chat"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -327,9 +327,9 @@ onUnmounted(() => {
           </button>
         </div>
 
-        <div class="order-1 flex min-w-0 items-center gap-1 sm:order-2 sm:ml-auto sm:max-w-full sm:justify-end">
+        <div class="order-1 flex max-w-full flex-wrap items-center gap-1 sm:order-2 sm:ml-auto sm:flex-nowrap sm:justify-end">
           <div
-            class="min-w-0 flex-1 sm:max-w-full sm:flex-none sm:shrink-0"
+            class="max-w-full shrink-0"
             data-testid="dashboard-chat-credential-selector"
           >
             <SearchableSelect
@@ -348,7 +348,7 @@ onUnmounted(() => {
           </div>
 
           <div
-            class="min-w-0 flex-1 sm:max-w-full sm:flex-none sm:shrink-0"
+            class="max-w-full shrink-0"
             data-testid="dashboard-chat-model-selector"
           >
             <SearchableSelect

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -20,10 +20,12 @@ const MAX_INPUT_HEIGHT_PX = 180;
 const PLACEHOLDER_ROTATION_MS = 5000;
 const PROMPT_SUGGESTIONS: string[] = [
   "Ask anything, or describe a workflow to build",
-  "Summarize my unread emails every morning",
+  "Run my daily report workflow",
+  "Which scheduled workflows run this week?",
+  "Add a task to my Kanban board",
+  "What is stored in my global variables?",
+  "Which workflow templates are available?",
   "Turn a CSV into a clean JSON report",
-  "Read new invoices with OCR and file them",
-  "Post today's GitHub issues to Slack",
 ];
 
 const router = useRouter();
@@ -54,6 +56,7 @@ const fileInputRef = ref<HTMLInputElement | null>(null);
 const isSubmitting = ref(false);
 const submitError = ref("");
 const placeholderIndex = ref(0);
+const isInputFocused = ref(false);
 const isDraggingFile = ref(false);
 let placeholderTimer: ReturnType<typeof setInterval> | null = null;
 let dragCounter = 0;
@@ -187,9 +190,9 @@ async function submit(): Promise<void> {
 onMounted(() => {
   void bootstrap();
   placeholderTimer = setInterval(() => {
-    // The suggestion is hidden while typing, so pause instead of rotating
-    // behind the draft and jumping on clear.
-    if (input.value.length > 0) return;
+    // Hold still while the box is in use, so the line never moves under the
+    // caret and never jumps when a draft is cleared.
+    if (input.value.length > 0 || isInputFocused.value) return;
     placeholderIndex.value = (placeholderIndex.value + 1) % PROMPT_SUGGESTIONS.length;
   }, PLACEHOLDER_ROTATION_MS);
 });
@@ -223,7 +226,7 @@ onUnmounted(() => {
 
     <button
       type="button"
-      class="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
+      class="absolute right-6 top-4 flex h-9 w-9 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
       aria-label="Hide chat box"
       title="Hide"
       @click="emit('dismiss')"
@@ -231,7 +234,7 @@ onUnmounted(() => {
       <X class="h-5 w-5" />
     </button>
 
-    <div class="pr-8">
+    <div class="pr-16">
       <h2 class="text-lg font-bold tracking-tight sm:text-xl">
         {{ greeting }}
       </h2>
@@ -262,6 +265,8 @@ onUnmounted(() => {
           class="min-h-[28px] w-full resize-none bg-transparent px-2.5 py-0 text-[15px] leading-7 text-foreground outline-none sm:text-base"
           @input="onInput"
           @keydown="onKeydown"
+          @focus="isInputFocused = true"
+          @blur="isInputFocused = false"
         />
 
         <Transition
@@ -278,7 +283,7 @@ onUnmounted(() => {
         </Transition>
       </div>
 
-      <div class="mt-1 flex flex-wrap items-center gap-2">
+      <div class="mt-0.5 flex flex-wrap items-center gap-2">
         <button
           type="button"
           class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 
 const ATTACHMENT_ACCEPT =
   ".txt,.csv,.json,.md,.py,.ts,.js,.html,.xml,.yaml,.yml,.log,.jpg,.jpeg,.png,.gif,.webp,.pdf";
-const MAX_INPUT_HEIGHT_PX = 140;
+const MAX_INPUT_HEIGHT_PX = 180;
 
 const router = useRouter();
 const authStore = useAuthStore();
@@ -137,7 +137,7 @@ onMounted(() => {
 <template>
   <section
     data-testid="dashboard-chat-composer"
-    class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 py-4 shadow-sm sm:px-5"
+    class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 py-5 shadow-sm sm:px-6 sm:py-6"
   >
     <button
       type="button"
@@ -165,12 +165,12 @@ onMounted(() => {
     >
 
     <form
-      class="mt-3 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2 py-2 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-center sm:px-3"
+      class="mt-4 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-center sm:gap-2.5 sm:px-3.5 sm:py-3"
       @submit.prevent="submit"
     >
       <button
         type="button"
-        class="hidden h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
+        class="hidden h-10 w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
         :disabled="attachmentLoading"
         title="Attach file"
         aria-label="Attach file"
@@ -185,7 +185,7 @@ onMounted(() => {
         rows="1"
         data-testid="dashboard-chat-input"
         placeholder="Ask anything, or describe a workflow to build"
-        class="min-h-[36px] w-full flex-1 resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        class="min-h-[52px] w-full flex-1 resize-none bg-transparent px-2 py-3 text-sm text-foreground outline-none placeholder:text-muted-foreground sm:text-[15px]"
         @input="onInput"
         @keydown="onKeydown"
       />
@@ -193,7 +193,7 @@ onMounted(() => {
       <div class="flex items-center gap-2">
         <button
           type="button"
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:hidden"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:hidden"
           :disabled="attachmentLoading"
           title="Attach file"
           aria-label="Attach file"
@@ -203,7 +203,7 @@ onMounted(() => {
         </button>
 
         <div
-          class="min-w-0 flex-1 sm:w-[160px] sm:flex-none"
+          class="min-w-0 flex-1 sm:w-[170px] sm:flex-none"
           data-testid="dashboard-chat-credential-selector"
         >
           <SearchableSelect
@@ -214,14 +214,14 @@ onMounted(() => {
             search-placeholder="Search credentials..."
             empty-text="No credentials found."
             :disabled="!hasCredentials"
-            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            select-class="h-10 rounded-lg border-input bg-background shadow-none"
             content-class="z-[60]"
             @update:model-value="onCredentialSelect"
           />
         </div>
 
         <div
-          class="min-w-0 flex-1 sm:w-[160px] sm:flex-none"
+          class="min-w-0 flex-1 sm:w-[170px] sm:flex-none"
           data-testid="dashboard-chat-model-selector"
         >
           <SearchableSelect
@@ -232,7 +232,7 @@ onMounted(() => {
             search-placeholder="Search models..."
             empty-text="No models found."
             :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
-            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            select-class="h-10 rounded-lg border-input bg-background shadow-none"
             content-class="z-[60]"
             @update:model-value="selectedModel = $event ?? ''"
           />
@@ -241,7 +241,7 @@ onMounted(() => {
         <button
           type="submit"
           data-testid="dashboard-chat-send"
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
           :disabled="!canSubmit"
           title="Start chat"
           aria-label="Start chat"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -165,12 +165,12 @@ onMounted(() => {
     >
 
     <form
-      class="mt-4 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-center sm:gap-2.5 sm:px-3.5 sm:py-3"
+      class="mt-4 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-start sm:gap-2.5 sm:px-3.5 sm:py-3"
       @submit.prevent="submit"
     >
       <button
         type="button"
-        class="hidden h-10 w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
+        class="hidden h-[52px] w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
         :disabled="attachmentLoading"
         title="Attach file"
         aria-label="Attach file"
@@ -185,12 +185,12 @@ onMounted(() => {
         rows="1"
         data-testid="dashboard-chat-input"
         placeholder="Ask anything, or describe a workflow to build"
-        class="min-h-[52px] w-full flex-1 resize-none bg-transparent px-2 py-3 text-sm text-foreground outline-none placeholder:text-muted-foreground sm:text-[15px]"
+        class="min-h-[52px] w-full flex-1 resize-none bg-transparent px-2 py-3 text-sm leading-7 text-foreground outline-none placeholder:text-muted-foreground sm:text-[15px]"
         @input="onInput"
         @keydown="onKeydown"
       />
 
-      <div class="flex items-center gap-2">
+      <div class="flex w-full items-center gap-2 sm:mt-1 sm:w-auto">
         <button
           type="button"
           class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:hidden"
@@ -203,7 +203,7 @@ onMounted(() => {
         </button>
 
         <div
-          class="min-w-0 flex-1 sm:w-[170px] sm:flex-none"
+          class="min-w-0 flex-1 sm:w-[190px] sm:flex-none"
           data-testid="dashboard-chat-credential-selector"
         >
           <SearchableSelect
@@ -221,7 +221,7 @@ onMounted(() => {
         </div>
 
         <div
-          class="min-w-0 flex-1 sm:w-[170px] sm:flex-none"
+          class="min-w-0 flex-1 sm:w-[190px] sm:flex-none"
           data-testid="dashboard-chat-model-selector"
         >
           <SearchableSelect

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -187,6 +187,9 @@ async function submit(): Promise<void> {
 onMounted(() => {
   void bootstrap();
   placeholderTimer = setInterval(() => {
+    // The suggestion is hidden while typing, so pause instead of rotating
+    // behind the draft and jumping on clear.
+    if (input.value.length > 0) return;
     placeholderIndex.value = (placeholderIndex.value + 1) % PROMPT_SUGGESTIONS.length;
   }, PLACEHOLDER_ROTATION_MS);
 });
@@ -220,12 +223,12 @@ onUnmounted(() => {
 
     <button
       type="button"
-      class="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
+      class="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
       aria-label="Hide chat box"
       title="Hide"
       @click="emit('dismiss')"
     >
-      <X class="h-[18px] w-[18px]" />
+      <X class="h-5 w-5" />
     </button>
 
     <div class="pr-8">
@@ -256,7 +259,7 @@ onUnmounted(() => {
           rows="1"
           data-testid="dashboard-chat-input"
           aria-label="Message"
-          class="min-h-[36px] w-full resize-none bg-transparent px-2.5 py-1 text-[15px] leading-7 text-foreground outline-none sm:text-base"
+          class="min-h-[28px] w-full resize-none bg-transparent px-2.5 py-0 text-[15px] leading-7 text-foreground outline-none sm:text-base"
           @input="onInput"
           @keydown="onKeydown"
         />
@@ -268,14 +271,14 @@ onUnmounted(() => {
           <p
             v-if="!input"
             :key="placeholderIndex"
-            class="pointer-events-none absolute left-2.5 right-2.5 top-1 truncate text-[15px] leading-7 text-muted-foreground sm:text-base"
+            class="pointer-events-none absolute left-2.5 right-2.5 top-0 truncate text-[15px] leading-7 text-muted-foreground sm:text-base"
           >
             {{ currentPlaceholder }}
           </p>
         </Transition>
       </div>
 
-      <div class="mt-2 flex flex-wrap items-center gap-2">
+      <div class="mt-1 flex flex-wrap items-center gap-2">
         <button
           type="button"
           class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -149,12 +149,54 @@ onMounted(() => {
       <X class="h-4 w-4" />
     </button>
 
-    <h2 class="text-lg font-bold tracking-tight sm:text-xl">
-      {{ greeting }}
-    </h2>
-    <p class="mt-0.5 text-sm text-muted-foreground">
-      What do you want to automate?
-    </p>
+    <div class="flex flex-col gap-3 pr-8 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div class="min-w-0">
+        <h2 class="text-lg font-bold tracking-tight sm:text-xl">
+          {{ greeting }}
+        </h2>
+        <p class="mt-0.5 text-sm text-muted-foreground">
+          What do you want to automate?
+        </p>
+      </div>
+
+      <div class="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0">
+        <div
+          class="min-w-0 sm:w-[190px]"
+          data-testid="dashboard-chat-credential-selector"
+        >
+          <SearchableSelect
+            id="dashboard-chat-credential-select"
+            :model-value="selectedCredentialId"
+            :options="credentialOptions"
+            placeholder="Select..."
+            search-placeholder="Search credentials..."
+            empty-text="No credentials found."
+            :disabled="!hasCredentials"
+            select-class="h-10 rounded-lg border-input bg-background shadow-none"
+            content-class="z-[60]"
+            @update:model-value="onCredentialSelect"
+          />
+        </div>
+
+        <div
+          class="min-w-0 sm:w-[190px]"
+          data-testid="dashboard-chat-model-selector"
+        >
+          <SearchableSelect
+            id="dashboard-chat-model-select"
+            :model-value="selectedModel"
+            :options="modelOptions"
+            :placeholder="modelPlaceholder"
+            search-placeholder="Search models..."
+            empty-text="No models found."
+            :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
+            select-class="h-10 rounded-lg border-input bg-background shadow-none"
+            content-class="z-[60]"
+            @update:model-value="selectedModel = $event ?? ''"
+          />
+        </div>
+      </div>
+    </div>
 
     <input
       ref="fileInputRef"
@@ -165,12 +207,12 @@ onMounted(() => {
     >
 
     <form
-      class="mt-4 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-start sm:gap-2.5 sm:px-3.5 sm:py-3"
+      class="mt-4 flex items-start gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:gap-2.5 sm:px-3.5 sm:py-3"
       @submit.prevent="submit"
     >
       <button
         type="button"
-        class="hidden h-[52px] w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
+        class="flex h-[52px] w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
         :disabled="attachmentLoading"
         title="Attach file"
         aria-label="Attach file"
@@ -190,58 +232,11 @@ onMounted(() => {
         @keydown="onKeydown"
       />
 
-      <div class="flex w-full items-center gap-2 sm:mt-1 sm:w-auto">
-        <button
-          type="button"
-          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:hidden"
-          :disabled="attachmentLoading"
-          title="Attach file"
-          aria-label="Attach file"
-          @click="openFilePicker"
-        >
-          <Paperclip class="h-4 w-4" />
-        </button>
-
-        <div
-          class="min-w-0 flex-1 sm:w-[190px] sm:flex-none"
-          data-testid="dashboard-chat-credential-selector"
-        >
-          <SearchableSelect
-            id="dashboard-chat-credential-select"
-            :model-value="selectedCredentialId"
-            :options="credentialOptions"
-            placeholder="Select..."
-            search-placeholder="Search credentials..."
-            empty-text="No credentials found."
-            :disabled="!hasCredentials"
-            select-class="h-10 rounded-lg border-input bg-background shadow-none"
-            content-class="z-[60]"
-            @update:model-value="onCredentialSelect"
-          />
-        </div>
-
-        <div
-          class="min-w-0 flex-1 sm:w-[190px] sm:flex-none"
-          data-testid="dashboard-chat-model-selector"
-        >
-          <SearchableSelect
-            id="dashboard-chat-model-select"
-            :model-value="selectedModel"
-            :options="modelOptions"
-            :placeholder="modelPlaceholder"
-            search-placeholder="Search models..."
-            empty-text="No models found."
-            :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
-            select-class="h-10 rounded-lg border-input bg-background shadow-none"
-            content-class="z-[60]"
-            @update:model-value="selectedModel = $event ?? ''"
-          />
-        </div>
-
+      <div class="flex h-[52px] shrink-0 items-center">
         <button
           type="submit"
           data-testid="dashboard-chat-send"
-          class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
           :disabled="!canSubmit"
           title="Start chat"
           aria-label="Start chat"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -256,7 +256,7 @@ onUnmounted(() => {
           rows="1"
           data-testid="dashboard-chat-input"
           aria-label="Message"
-          class="min-h-[36px] w-full resize-none bg-transparent px-1 py-1 text-sm leading-7 text-foreground outline-none sm:text-[15px]"
+          class="min-h-[36px] w-full resize-none bg-transparent px-2.5 py-1 text-[15px] leading-7 text-foreground outline-none sm:text-base"
           @input="onInput"
           @keydown="onKeydown"
         />
@@ -268,7 +268,7 @@ onUnmounted(() => {
           <p
             v-if="!input"
             :key="placeholderIndex"
-            class="pointer-events-none absolute left-1 right-1 top-1 truncate text-sm leading-7 text-muted-foreground sm:text-[15px]"
+            class="pointer-events-none absolute left-2.5 right-2.5 top-1 truncate text-[15px] leading-7 text-muted-foreground sm:text-base"
           >
             {{ currentPlaceholder }}
           </p>
@@ -289,7 +289,7 @@ onUnmounted(() => {
 
         <div class="ml-auto flex max-w-full flex-wrap items-center justify-end gap-1">
           <div
-            class="max-w-full"
+            class="max-w-full shrink-0"
             data-testid="dashboard-chat-credential-selector"
           >
             <SearchableSelect
@@ -308,7 +308,7 @@ onUnmounted(() => {
           </div>
 
           <div
-            class="max-w-full"
+            class="max-w-full shrink-0"
             data-testid="dashboard-chat-model-selector"
           >
             <SearchableSelect
@@ -329,7 +329,7 @@ onUnmounted(() => {
           <button
             type="submit"
             data-testid="dashboard-chat-send"
-            class="ml-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+            class="ml-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
             :disabled="!canSubmit"
             title="Start chat"
             aria-label="Start chat"
@@ -345,59 +345,58 @@ onUnmounted(() => {
           </button>
         </div>
       </div>
-    </form>
-
-    <div
-      v-if="attachedFile || attachmentError || modelsLoadFailed || showNoCredentialsHint || submitError"
-      class="mt-2 flex flex-wrap items-center gap-2"
-    >
       <div
-        v-if="attachedFile"
-        class="flex max-w-xs items-center gap-1.5 rounded-lg border border-border/40 bg-muted/60 px-2.5 py-1 text-xs text-foreground"
+        v-if="attachedFile || attachmentError || modelsLoadFailed || showNoCredentialsHint || submitError"
+        class="mt-2 flex flex-wrap items-center gap-2 px-1"
       >
-        <Paperclip class="h-3 w-3 shrink-0 text-muted-foreground" />
-        <span class="truncate">{{ attachedFile.name }}</span>
-        <span class="shrink-0 text-muted-foreground">· {{ attachedFile.sizeKb }} KB</span>
-        <button
-          type="button"
-          class="ml-0.5 shrink-0 rounded p-0.5 hover:bg-muted/80"
-          aria-label="Remove attachment"
-          @click="clearAttachment"
+        <div
+          v-if="attachedFile"
+          class="flex max-w-xs items-center gap-1.5 rounded-lg border border-border/40 bg-muted/60 px-2.5 py-1 text-xs text-foreground"
         >
-          <X class="h-3 w-3" />
+          <Paperclip class="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span class="truncate">{{ attachedFile.name }}</span>
+          <span class="shrink-0 text-muted-foreground">· {{ attachedFile.sizeKb }} KB</span>
+          <button
+            type="button"
+            class="ml-0.5 shrink-0 rounded p-0.5 hover:bg-muted/80"
+            aria-label="Remove attachment"
+            @click="clearAttachment"
+          >
+            <X class="h-3 w-3" />
+          </button>
+        </div>
+
+        <p
+          v-if="attachmentError"
+          class="text-xs text-destructive"
+        >
+          {{ attachmentError }}
+        </p>
+
+        <p
+          v-if="modelsLoadFailed"
+          class="text-xs text-amber-600 dark:text-amber-400"
+        >
+          This credential's model list could not be loaded.
+        </p>
+
+        <button
+          v-if="showNoCredentialsHint"
+          type="button"
+          class="text-xs font-medium text-primary underline-offset-2 hover:underline"
+          @click="emit('open-credentials')"
+        >
+          Add an LLM credential to start chatting
         </button>
+
+        <p
+          v-if="submitError"
+          class="text-xs text-destructive"
+        >
+          {{ submitError }}
+        </p>
       </div>
-
-      <p
-        v-if="attachmentError"
-        class="text-xs text-destructive"
-      >
-        {{ attachmentError }}
-      </p>
-
-      <p
-        v-if="modelsLoadFailed"
-        class="text-xs text-amber-600 dark:text-amber-400"
-      >
-        This credential's model list could not be loaded.
-      </p>
-
-      <button
-        v-if="showNoCredentialsHint"
-        type="button"
-        class="text-xs font-medium text-primary underline-offset-2 hover:underline"
-        @click="emit('open-credentials')"
-      >
-        Add an LLM credential to start chatting
-      </button>
-
-      <p
-        v-if="submitError"
-        class="text-xs text-destructive"
-      >
-        {{ submitError }}
-      </p>
-    </div>
+    </form>
   </section>
 </template>
 

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { Loader2, Paperclip, Send, X } from "lucide-vue-next";
+
+import SearchableSelect from "@/components/ui/SearchableSelect.vue";
+import { useChatModelSelection } from "@/composables/useChatModelSelection";
+import { useFileAttachment } from "@/composables/useFileAttachment";
+import { useAuthStore } from "@/stores/auth";
+import { useChatStore } from "@/stores/chat";
+
+const emit = defineEmits<{
+  (event: "dismiss"): void;
+  (event: "open-credentials"): void;
+}>();
+
+const ATTACHMENT_ACCEPT =
+  ".txt,.csv,.json,.md,.py,.ts,.js,.html,.xml,.yaml,.yml,.log,.jpg,.jpeg,.png,.gif,.webp,.pdf";
+const MAX_INPUT_HEIGHT_PX = 140;
+
+const router = useRouter();
+const authStore = useAuthStore();
+const chatStore = useChatStore();
+
+const {
+  credentialOptions,
+  modelOptions,
+  selectedCredentialId,
+  selectedModel,
+  isLoadingModels,
+  modelsLoadFailed,
+  credentialsLoaded,
+  hasCredentials,
+  isReady,
+  modelPlaceholder,
+  bootstrap,
+  selectCredential,
+} = useChatModelSelection();
+
+const { attachedFile, attachmentError, attachmentLoading, processFile, clearAttachment } =
+  useFileAttachment();
+
+const input = ref("");
+const inputRef = ref<HTMLTextAreaElement | null>(null);
+const fileInputRef = ref<HTMLInputElement | null>(null);
+const isSubmitting = ref(false);
+const submitError = ref("");
+
+const greeting = computed<string>(() => {
+  const name = authStore.user?.name?.trim();
+  return name ? `Welcome ${name},` : "Welcome,";
+});
+
+const showNoCredentialsHint = computed<boolean>(
+  () => credentialsLoaded.value && !hasCredentials.value,
+);
+
+const canSubmit = computed<boolean>(
+  () =>
+    input.value.trim().length > 0 &&
+    isReady.value &&
+    !attachmentLoading.value &&
+    attachmentError.value === null &&
+    !isSubmitting.value,
+);
+
+function resizeInput(): void {
+  const element = inputRef.value;
+  if (!element) return;
+  element.style.height = "auto";
+  element.style.height = `${Math.min(element.scrollHeight, MAX_INPUT_HEIGHT_PX)}px`;
+}
+
+function onInput(): void {
+  resizeInput();
+}
+
+function openFilePicker(): void {
+  fileInputRef.value?.click();
+}
+
+async function handleFileInputChange(event: Event): Promise<void> {
+  const target = event.target as HTMLInputElement;
+  const file = target.files?.[0];
+  if (!file) return;
+  await processFile(file);
+  // Allow re-picking the same file after removing it.
+  target.value = "";
+}
+
+function onCredentialSelect(value: string | undefined): void {
+  void selectCredential(value);
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === "Enter" && !event.shiftKey) {
+    event.preventDefault();
+    void submit();
+  }
+}
+
+async function submit(): Promise<void> {
+  const text = input.value.trim();
+  if (!canSubmit.value || !text) return;
+
+  isSubmitting.value = true;
+  submitError.value = "";
+  const payload = attachedFile.value;
+
+  try {
+    const conversation = await chatStore.createConversation();
+    // sendMessage swallows its own transport errors and clears stream state,
+    // so a failure here still leaves a real conversation to navigate to.
+    await chatStore.sendMessage(
+      conversation.id,
+      text,
+      selectedCredentialId.value,
+      selectedModel.value,
+      payload ? { name: payload.name, kind: payload.kind, content: payload.content } : null,
+    );
+    input.value = "";
+    clearAttachment();
+    void nextTick(resizeInput);
+    await router.push(`/chats/${conversation.id}`);
+  } catch {
+    submitError.value = "Could not start chat. Try again.";
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+onMounted(() => {
+  void bootstrap();
+});
+</script>
+
+<template>
+  <section
+    data-testid="dashboard-chat-composer"
+    class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 py-4 shadow-sm sm:px-5"
+  >
+    <button
+      type="button"
+      class="absolute right-3 top-3 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      aria-label="Hide chat box"
+      title="Hide"
+      @click="emit('dismiss')"
+    >
+      <X class="h-4 w-4" />
+    </button>
+
+    <h2 class="text-lg font-bold tracking-tight sm:text-xl">
+      {{ greeting }}
+    </h2>
+    <p class="mt-0.5 text-sm text-muted-foreground">
+      What do you want to automate?
+    </p>
+
+    <input
+      ref="fileInputRef"
+      type="file"
+      :accept="ATTACHMENT_ACCEPT"
+      class="hidden"
+      @change="handleFileInputChange"
+    >
+
+    <form
+      class="mt-3 flex flex-col gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2 py-2 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:flex-row sm:items-center sm:px-3"
+      @submit.prevent="submit"
+    >
+      <button
+        type="button"
+        class="hidden h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:flex"
+        :disabled="attachmentLoading"
+        title="Attach file"
+        aria-label="Attach file"
+        @click="openFilePicker"
+      >
+        <Paperclip class="h-4 w-4" />
+      </button>
+
+      <textarea
+        ref="inputRef"
+        v-model="input"
+        rows="1"
+        data-testid="dashboard-chat-input"
+        placeholder="Ask anything, or describe a workflow to build"
+        class="min-h-[36px] w-full flex-1 resize-none bg-transparent px-2 py-1.5 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        @input="onInput"
+        @keydown="onKeydown"
+      />
+
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:hidden"
+          :disabled="attachmentLoading"
+          title="Attach file"
+          aria-label="Attach file"
+          @click="openFilePicker"
+        >
+          <Paperclip class="h-4 w-4" />
+        </button>
+
+        <div
+          class="min-w-0 flex-1 sm:w-[160px] sm:flex-none"
+          data-testid="dashboard-chat-credential-selector"
+        >
+          <SearchableSelect
+            id="dashboard-chat-credential-select"
+            :model-value="selectedCredentialId"
+            :options="credentialOptions"
+            placeholder="Select..."
+            search-placeholder="Search credentials..."
+            empty-text="No credentials found."
+            :disabled="!hasCredentials"
+            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            content-class="z-[60]"
+            @update:model-value="onCredentialSelect"
+          />
+        </div>
+
+        <div
+          class="min-w-0 flex-1 sm:w-[160px] sm:flex-none"
+          data-testid="dashboard-chat-model-selector"
+        >
+          <SearchableSelect
+            id="dashboard-chat-model-select"
+            :model-value="selectedModel"
+            :options="modelOptions"
+            :placeholder="modelPlaceholder"
+            search-placeholder="Search models..."
+            empty-text="No models found."
+            :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
+            select-class="h-9 rounded-lg border-input bg-background shadow-none"
+            content-class="z-[60]"
+            @update:model-value="selectedModel = $event ?? ''"
+          />
+        </div>
+
+        <button
+          type="submit"
+          data-testid="dashboard-chat-send"
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          :disabled="!canSubmit"
+          title="Start chat"
+          aria-label="Start chat"
+        >
+          <Loader2
+            v-if="isSubmitting"
+            class="h-4 w-4 animate-spin"
+          />
+          <Send
+            v-else
+            class="h-4 w-4"
+          />
+        </button>
+      </div>
+    </form>
+
+    <div
+      v-if="attachedFile || attachmentError || modelsLoadFailed || showNoCredentialsHint || submitError"
+      class="mt-2 flex flex-wrap items-center gap-2"
+    >
+      <div
+        v-if="attachedFile"
+        class="flex max-w-xs items-center gap-1.5 rounded-lg border border-border/40 bg-muted/60 px-2.5 py-1 text-xs text-foreground"
+      >
+        <Paperclip class="h-3 w-3 shrink-0 text-muted-foreground" />
+        <span class="truncate">{{ attachedFile.name }}</span>
+        <span class="shrink-0 text-muted-foreground">· {{ attachedFile.sizeKb }} KB</span>
+        <button
+          type="button"
+          class="ml-0.5 shrink-0 rounded p-0.5 hover:bg-muted/80"
+          aria-label="Remove attachment"
+          @click="clearAttachment"
+        >
+          <X class="h-3 w-3" />
+        </button>
+      </div>
+
+      <p
+        v-if="attachmentError"
+        class="text-xs text-destructive"
+      >
+        {{ attachmentError }}
+      </p>
+
+      <p
+        v-if="modelsLoadFailed"
+        class="text-xs text-amber-600 dark:text-amber-400"
+      >
+        This credential's model list could not be loaded.
+      </p>
+
+      <button
+        v-if="showNoCredentialsHint"
+        type="button"
+        class="text-xs font-medium text-primary underline-offset-2 hover:underline"
+        @click="emit('open-credentials')"
+      >
+        Add an LLM credential to start chatting
+      </button>
+
+      <p
+        v-if="submitError"
+        class="text-xs text-destructive"
+      >
+        {{ submitError }}
+      </p>
+    </div>
+  </section>
+</template>

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -327,7 +327,7 @@ onUnmounted(() => {
           </button>
         </div>
 
-        <div class="order-1 flex max-w-full flex-wrap items-center gap-1 sm:order-2 sm:ml-auto sm:flex-nowrap sm:justify-end">
+        <div class="order-1 flex w-full max-w-full flex-wrap items-center justify-between gap-1 sm:order-2 sm:ml-auto sm:w-auto sm:flex-nowrap sm:justify-end">
           <div
             class="max-w-full shrink-0"
             data-testid="dashboard-chat-credential-selector"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -25,7 +25,19 @@ const PROMPT_SUGGESTIONS: string[] = [
   "Add a task to my Kanban board",
   "What is stored in my global variables?",
   "Which workflow templates are available?",
-  "Turn a CSV into a clean JSON report",
+  // Titles from the beginner templates collection on heym.run.
+  "Daily sales snapshot to Slack",
+  "Save Slack requests to Google Sheets",
+  "New leads sheet to Slack",
+  "Log Slack messages in BigQuery",
+  "BigQuery report to Google Sheets",
+  "Google Sheets to BigQuery sync",
+  "Save Slack feedback and notify product",
+  "Daily low-stock alert to Slack",
+  "Weekly cloud spend to Google Sheets",
+  "Log Slack partner leads in BigQuery",
+  "Daily Google Sheets lead digest by email",
+  "Email new Slack feedback",
 ];
 
 const router = useRouter();
@@ -283,21 +295,41 @@ onUnmounted(() => {
         </Transition>
       </div>
 
-      <div class="mt-0 flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-          :disabled="attachmentLoading"
-          title="Attach file"
-          aria-label="Attach file"
-          @click="openFilePicker"
-        >
-          <Paperclip class="h-4 w-4" />
-        </button>
+      <div class="mt-0 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+        <div class="flex items-center justify-between gap-2 sm:contents">
+          <button
+            type="button"
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:order-1"
+            :disabled="attachmentLoading"
+            title="Attach file"
+            aria-label="Attach file"
+            @click="openFilePicker"
+          >
+            <Paperclip class="h-4 w-4" />
+          </button>
 
-        <div class="ml-auto flex max-w-full flex-wrap items-center justify-end gap-1">
+          <button
+            type="submit"
+            data-testid="dashboard-chat-send"
+            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50 sm:order-3 sm:ml-1"
+            :disabled="!canSubmit"
+            title="Start chat"
+            aria-label="Start chat"
+          >
+            <Loader2
+              v-if="isSubmitting"
+              class="h-4 w-4 animate-spin"
+            />
+            <Send
+              v-else
+              class="h-4 w-4"
+            />
+          </button>
+        </div>
+
+        <div class="flex min-w-0 items-center gap-1 sm:order-2 sm:ml-auto sm:max-w-full sm:justify-end">
           <div
-            class="max-w-full shrink-0"
+            class="min-w-0 flex-1 sm:max-w-full sm:flex-none sm:shrink-0"
             data-testid="dashboard-chat-credential-selector"
           >
             <SearchableSelect
@@ -316,7 +348,7 @@ onUnmounted(() => {
           </div>
 
           <div
-            class="max-w-full shrink-0"
+            class="min-w-0 flex-1 sm:max-w-full sm:flex-none sm:shrink-0"
             data-testid="dashboard-chat-model-selector"
           >
             <SearchableSelect
@@ -333,24 +365,6 @@ onUnmounted(() => {
               @update:model-value="selectedModel = $event ?? ''"
             />
           </div>
-
-          <button
-            type="submit"
-            data-testid="dashboard-chat-send"
-            class="ml-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-            :disabled="!canSubmit"
-            title="Start chat"
-            aria-label="Start chat"
-          >
-            <Loader2
-              v-if="isSubmitting"
-              class="h-4 w-4 animate-spin"
-            />
-            <Send
-              v-else
-              class="h-4 w-4"
-            />
-          </button>
         </div>
       </div>
       <div

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -296,7 +296,7 @@ onUnmounted(() => {
       </div>
 
       <div class="mt-0 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
-        <div class="flex items-center justify-between gap-2 sm:contents">
+        <div class="order-2 flex items-center justify-between gap-2 sm:contents">
           <button
             type="button"
             class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50 sm:order-1"
@@ -327,7 +327,7 @@ onUnmounted(() => {
           </button>
         </div>
 
-        <div class="flex min-w-0 items-center gap-1 sm:order-2 sm:ml-auto sm:max-w-full sm:justify-end">
+        <div class="order-1 flex min-w-0 items-center gap-1 sm:order-2 sm:ml-auto sm:max-w-full sm:justify-end">
           <div
             class="min-w-0 flex-1 sm:max-w-full sm:flex-none sm:shrink-0"
             data-testid="dashboard-chat-credential-selector"

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -264,7 +264,7 @@ onUnmounted(() => {
     >
 
     <form
-      class="mt-4 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:px-3.5 sm:py-3"
+      class="mt-4 rounded-2xl border border-border/40 bg-muted/40 px-2.5 pb-2.5 pt-4 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:px-3.5 sm:pb-3 sm:pt-4"
       @submit.prevent="submit"
     >
       <div class="relative">

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 const ATTACHMENT_ACCEPT =
   ".txt,.csv,.json,.md,.py,.ts,.js,.html,.xml,.yaml,.yml,.log,.jpg,.jpeg,.png,.gif,.webp,.pdf";
 const MAX_INPUT_HEIGHT_PX = 180;
-const PLACEHOLDER_ROTATION_MS = 3000;
+const PLACEHOLDER_ROTATION_MS = 5000;
 const PROMPT_SUGGESTIONS: string[] = [
   "Ask anything, or describe a workflow to build",
   "Summarize my unread emails every morning",
@@ -54,7 +54,9 @@ const fileInputRef = ref<HTMLInputElement | null>(null);
 const isSubmitting = ref(false);
 const submitError = ref("");
 const placeholderIndex = ref(0);
+const isDraggingFile = ref(false);
 let placeholderTimer: ReturnType<typeof setInterval> | null = null;
+let dragCounter = 0;
 
 const currentPlaceholder = computed<string>(
   () => PROMPT_SUGGESTIONS[placeholderIndex.value] ?? PROMPT_SUGGESTIONS[0],
@@ -100,6 +102,45 @@ async function handleFileInputChange(event: Event): Promise<void> {
   await processFile(file);
   // Allow re-picking the same file after removing it.
   target.value = "";
+}
+
+function dragCarriesFiles(event: DragEvent): boolean {
+  return Boolean(event.dataTransfer?.types.includes("Files"));
+}
+
+function onDragEnter(event: DragEvent): void {
+  if (!dragCarriesFiles(event)) return;
+  event.preventDefault();
+  dragCounter += 1;
+  isDraggingFile.value = true;
+}
+
+function onDragOver(event: DragEvent): void {
+  if (!dragCarriesFiles(event)) return;
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = "copy";
+  }
+  isDraggingFile.value = true;
+}
+
+function onDragLeave(): void {
+  dragCounter -= 1;
+  if (dragCounter <= 0) {
+    dragCounter = 0;
+    isDraggingFile.value = false;
+  }
+}
+
+/** Stops propagation so the Workflows tab does not import the file as a workflow. */
+async function onDrop(event: DragEvent): Promise<void> {
+  event.preventDefault();
+  event.stopPropagation();
+  dragCounter = 0;
+  isDraggingFile.value = false;
+  const file = event.dataTransfer?.files?.[0];
+  if (!file) return;
+  await processFile(file);
 }
 
 function onCredentialSelect(value: string | undefined): void {
@@ -162,15 +203,29 @@ onUnmounted(() => {
   <section
     data-testid="dashboard-chat-composer"
     class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 py-5 shadow-sm sm:px-6 sm:py-6"
+    @dragenter="onDragEnter"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
   >
+    <div
+      v-if="isDraggingFile"
+      class="pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-2xl border-2 border-dashed border-primary bg-background/85"
+    >
+      <div class="flex items-center gap-2 text-sm font-medium text-primary">
+        <Paperclip class="h-4 w-4" />
+        Drop file to attach
+      </div>
+    </div>
+
     <button
       type="button"
-      class="absolute right-3 top-3 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      class="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
       aria-label="Hide chat box"
       title="Hide"
       @click="emit('dismiss')"
     >
-      <X class="h-4 w-4" />
+      <X class="h-[18px] w-[18px]" />
     </button>
 
     <div class="pr-8">
@@ -220,7 +275,7 @@ onUnmounted(() => {
         </Transition>
       </div>
 
-      <div class="mt-2 flex items-center gap-2">
+      <div class="mt-2 flex flex-wrap items-center gap-2">
         <button
           type="button"
           class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
@@ -232,9 +287,9 @@ onUnmounted(() => {
           <Paperclip class="h-4 w-4" />
         </button>
 
-        <div class="ml-auto flex min-w-0 items-center gap-1">
+        <div class="ml-auto flex max-w-full flex-wrap items-center justify-end gap-1">
           <div
-            class="min-w-0 max-w-[130px] sm:max-w-[200px]"
+            class="max-w-full"
             data-testid="dashboard-chat-credential-selector"
           >
             <SearchableSelect
@@ -253,7 +308,7 @@ onUnmounted(() => {
           </div>
 
           <div
-            class="min-w-0 max-w-[130px] sm:max-w-[200px]"
+            class="max-w-full"
             data-testid="dashboard-chat-model-selector"
           >
             <SearchableSelect
@@ -350,8 +405,8 @@ onUnmounted(() => {
 .composer-placeholder-enter-active,
 .composer-placeholder-leave-active {
   transition:
-    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 200ms ease;
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 320ms ease;
 }
 
 .composer-placeholder-enter-from {

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -161,7 +161,7 @@ onMounted(() => {
 
       <div class="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0">
         <div
-          class="min-w-0 sm:w-[190px]"
+          class="min-w-0 sm:max-w-[240px]"
           data-testid="dashboard-chat-credential-selector"
         >
           <SearchableSelect
@@ -172,14 +172,14 @@ onMounted(() => {
             search-placeholder="Search credentials..."
             empty-text="No credentials found."
             :disabled="!hasCredentials"
-            select-class="h-10 rounded-lg border-input bg-background shadow-none"
+            select-class="h-9 rounded-lg border-input bg-background shadow-none"
             content-class="z-[60]"
             @update:model-value="onCredentialSelect"
           />
         </div>
 
         <div
-          class="min-w-0 sm:w-[190px]"
+          class="min-w-0 sm:max-w-[240px]"
           data-testid="dashboard-chat-model-selector"
         >
           <SearchableSelect
@@ -190,7 +190,7 @@ onMounted(() => {
             search-placeholder="Search models..."
             empty-text="No models found."
             :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
-            select-class="h-10 rounded-lg border-input bg-background shadow-none"
+            select-class="h-9 rounded-lg border-input bg-background shadow-none"
             content-class="z-[60]"
             @update:model-value="selectedModel = $event ?? ''"
           />

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
-import { useMediaQuery } from "@vueuse/core";
 import { Loader2, Paperclip, Send, X } from "lucide-vue-next";
 
 import SearchableSelect from "@/components/ui/SearchableSelect.vue";
@@ -18,6 +17,14 @@ const emit = defineEmits<{
 const ATTACHMENT_ACCEPT =
   ".txt,.csv,.json,.md,.py,.ts,.js,.html,.xml,.yaml,.yml,.log,.jpg,.jpeg,.png,.gif,.webp,.pdf";
 const MAX_INPUT_HEIGHT_PX = 180;
+const PLACEHOLDER_ROTATION_MS = 3000;
+const PROMPT_SUGGESTIONS: string[] = [
+  "Ask anything, or describe a workflow to build",
+  "Summarize my unread emails every morning",
+  "Turn a CSV into a clean JSON report",
+  "Read new invoices with OCR and file them",
+  "Post today's GitHub issues to Slack",
+];
 
 const router = useRouter();
 const authStore = useAuthStore();
@@ -46,12 +53,11 @@ const inputRef = ref<HTMLTextAreaElement | null>(null);
 const fileInputRef = ref<HTMLInputElement | null>(null);
 const isSubmitting = ref(false);
 const submitError = ref("");
+const placeholderIndex = ref(0);
+let placeholderTimer: ReturnType<typeof setInterval> | null = null;
 
-const isNarrowViewport = useMediaQuery("(max-width: 639px)");
-
-// The long prompt wraps and clips inside the one-line box on small screens.
-const inputPlaceholder = computed<string>(() =>
-  isNarrowViewport.value ? "Ask anything" : "Ask anything, or describe a workflow to build",
+const currentPlaceholder = computed<string>(
+  () => PROMPT_SUGGESTIONS[placeholderIndex.value] ?? PROMPT_SUGGESTIONS[0],
 );
 
 const greeting = computed<string>(() => {
@@ -139,6 +145,16 @@ async function submit(): Promise<void> {
 
 onMounted(() => {
   void bootstrap();
+  placeholderTimer = setInterval(() => {
+    placeholderIndex.value = (placeholderIndex.value + 1) % PROMPT_SUGGESTIONS.length;
+  }, PLACEHOLDER_ROTATION_MS);
+});
+
+onUnmounted(() => {
+  if (placeholderTimer) {
+    clearInterval(placeholderTimer);
+    placeholderTimer = null;
+  }
 });
 </script>
 
@@ -157,53 +173,13 @@ onMounted(() => {
       <X class="h-4 w-4" />
     </button>
 
-    <div class="flex flex-col gap-3 pr-8 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-      <div class="min-w-0">
-        <h2 class="text-lg font-bold tracking-tight sm:text-xl">
-          {{ greeting }}
-        </h2>
-        <p class="mt-0.5 text-sm text-muted-foreground">
-          What do you want to automate?
-        </p>
-      </div>
-
-      <div class="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0">
-        <div
-          class="min-w-0 sm:max-w-[240px]"
-          data-testid="dashboard-chat-credential-selector"
-        >
-          <SearchableSelect
-            id="dashboard-chat-credential-select"
-            :model-value="selectedCredentialId"
-            :options="credentialOptions"
-            placeholder="Select..."
-            search-placeholder="Search credentials..."
-            empty-text="No credentials found."
-            :disabled="!hasCredentials"
-            select-class="h-8 rounded-lg border-input bg-background shadow-none"
-            content-class="z-[60]"
-            @update:model-value="onCredentialSelect"
-          />
-        </div>
-
-        <div
-          class="min-w-0 sm:max-w-[240px]"
-          data-testid="dashboard-chat-model-selector"
-        >
-          <SearchableSelect
-            id="dashboard-chat-model-select"
-            :model-value="selectedModel"
-            :options="modelOptions"
-            :placeholder="modelPlaceholder"
-            search-placeholder="Search models..."
-            empty-text="No models found."
-            :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
-            select-class="h-8 rounded-lg border-input bg-background shadow-none"
-            content-class="z-[60]"
-            @update:model-value="selectedModel = $event ?? ''"
-          />
-        </div>
-      </div>
+    <div class="pr-8">
+      <h2 class="text-lg font-bold tracking-tight sm:text-xl">
+        {{ greeting }}
+      </h2>
+      <p class="mt-0.5 text-sm text-muted-foreground">
+        What do you want to automate?
+      </p>
     </div>
 
     <input
@@ -215,49 +191,104 @@ onMounted(() => {
     >
 
     <form
-      class="mt-4 flex items-start gap-2 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:gap-2.5 sm:px-3.5 sm:py-3"
+      class="mt-4 rounded-2xl border border-border/40 bg-muted/40 px-2.5 py-2.5 transition-colors focus-within:border-primary/30 focus-within:bg-muted/50 sm:px-3.5 sm:py-3"
       @submit.prevent="submit"
     >
-      <button
-        type="button"
-        class="flex h-11 w-9 shrink-0 items-center justify-center rounded-xl text-muted-foreground sm:h-[52px] sm:w-10 transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-        :disabled="attachmentLoading"
-        title="Attach file"
-        aria-label="Attach file"
-        @click="openFilePicker"
-      >
-        <Paperclip class="h-4 w-4" />
-      </button>
+      <div class="relative">
+        <textarea
+          ref="inputRef"
+          v-model="input"
+          rows="1"
+          data-testid="dashboard-chat-input"
+          aria-label="Message"
+          class="min-h-[36px] w-full resize-none bg-transparent px-1 py-1 text-sm leading-7 text-foreground outline-none sm:text-[15px]"
+          @input="onInput"
+          @keydown="onKeydown"
+        />
 
-      <textarea
-        ref="inputRef"
-        v-model="input"
-        rows="1"
-        data-testid="dashboard-chat-input"
-        :placeholder="inputPlaceholder"
-        class="min-h-[44px] w-full flex-1 resize-none bg-transparent px-1.5 py-2 text-sm leading-7 sm:min-h-[52px] sm:px-2 sm:py-3 text-foreground outline-none placeholder:text-muted-foreground sm:text-[15px]"
-        @input="onInput"
-        @keydown="onKeydown"
-      />
-
-      <div class="flex h-11 shrink-0 items-center sm:h-[52px]">
-        <button
-          type="submit"
-          data-testid="dashboard-chat-send"
-          class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary sm:h-10 sm:w-10 text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-          :disabled="!canSubmit"
-          title="Start chat"
-          aria-label="Start chat"
+        <Transition
+          name="composer-placeholder"
+          mode="out-in"
         >
-          <Loader2
-            v-if="isSubmitting"
-            class="h-4 w-4 animate-spin"
-          />
-          <Send
-            v-else
-            class="h-4 w-4"
-          />
+          <p
+            v-if="!input"
+            :key="placeholderIndex"
+            class="pointer-events-none absolute left-1 right-1 top-1 truncate text-sm leading-7 text-muted-foreground sm:text-[15px]"
+          >
+            {{ currentPlaceholder }}
+          </p>
+        </Transition>
+      </div>
+
+      <div class="mt-2 flex items-center gap-2">
+        <button
+          type="button"
+          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          :disabled="attachmentLoading"
+          title="Attach file"
+          aria-label="Attach file"
+          @click="openFilePicker"
+        >
+          <Paperclip class="h-4 w-4" />
         </button>
+
+        <div class="ml-auto flex min-w-0 items-center gap-1">
+          <div
+            class="min-w-0 max-w-[130px] sm:max-w-[200px]"
+            data-testid="dashboard-chat-credential-selector"
+          >
+            <SearchableSelect
+              id="dashboard-chat-credential-select"
+              :model-value="selectedCredentialId"
+              :options="credentialOptions"
+              placeholder="Credential"
+              search-placeholder="Search credentials..."
+              empty-text="No credentials found."
+              :disabled="!hasCredentials"
+              hide-trigger-icon
+              select-class="h-8 min-h-0 rounded-lg border-transparent bg-transparent text-muted-foreground shadow-none hover:border-transparent hover:bg-muted/70 focus-within:border-transparent focus-within:ring-0"
+              content-class="z-[60]"
+              @update:model-value="onCredentialSelect"
+            />
+          </div>
+
+          <div
+            class="min-w-0 max-w-[130px] sm:max-w-[200px]"
+            data-testid="dashboard-chat-model-selector"
+          >
+            <SearchableSelect
+              id="dashboard-chat-model-select"
+              :model-value="selectedModel"
+              :options="modelOptions"
+              :placeholder="isLoadingModels || modelsLoadFailed ? modelPlaceholder : 'Model'"
+              search-placeholder="Search models..."
+              empty-text="No models found."
+              :disabled="!selectedCredentialId || isLoadingModels || modelsLoadFailed"
+              hide-trigger-icon
+              select-class="h-8 min-h-0 rounded-lg border-transparent bg-transparent text-muted-foreground shadow-none hover:border-transparent hover:bg-muted/70 focus-within:border-transparent focus-within:ring-0"
+              content-class="z-[60]"
+              @update:model-value="selectedModel = $event ?? ''"
+            />
+          </div>
+
+          <button
+            type="submit"
+            data-testid="dashboard-chat-send"
+            class="ml-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+            :disabled="!canSubmit"
+            title="Start chat"
+            aria-label="Start chat"
+          >
+            <Loader2
+              v-if="isSubmitting"
+              class="h-4 w-4 animate-spin"
+            />
+            <Send
+              v-else
+              class="h-4 w-4"
+            />
+          </button>
+        </div>
       </div>
     </form>
 
@@ -314,3 +345,34 @@ onMounted(() => {
     </div>
   </section>
 </template>
+
+<style scoped>
+.composer-placeholder-enter-active,
+.composer-placeholder-leave-active {
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 200ms ease;
+}
+
+.composer-placeholder-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.composer-placeholder-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-placeholder-enter-active,
+  .composer-placeholder-leave-active {
+    transition: opacity 120ms ease;
+  }
+
+  .composer-placeholder-enter-from,
+  .composer-placeholder-leave-to {
+    transform: none;
+  }
+}
+</style>

--- a/frontend/src/components/Chat/DashboardChatComposer.vue
+++ b/frontend/src/components/Chat/DashboardChatComposer.vue
@@ -208,7 +208,7 @@ onUnmounted(() => {
 <template>
   <section
     data-testid="dashboard-chat-composer"
-    class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 py-5 shadow-sm sm:px-6 sm:py-6"
+    class="relative z-10 mb-5 rounded-2xl border border-border/50 bg-card/60 px-4 pb-5 pt-3.5 shadow-sm sm:px-6 sm:pb-6 sm:pt-4"
     @dragenter="onDragEnter"
     @dragover="onDragOver"
     @dragleave="onDragLeave"
@@ -226,7 +226,7 @@ onUnmounted(() => {
 
     <button
       type="button"
-      class="absolute right-6 top-4 flex h-9 w-9 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
+      class="absolute right-6 top-3.5 flex h-9 w-9 items-center justify-center rounded-lg border border-border/60 bg-background/70 text-foreground/70 transition-colors hover:border-border hover:bg-muted hover:text-foreground"
       aria-label="Hide chat box"
       title="Hide"
       @click="emit('dismiss')"
@@ -262,7 +262,7 @@ onUnmounted(() => {
           rows="1"
           data-testid="dashboard-chat-input"
           aria-label="Message"
-          class="min-h-[28px] w-full resize-none bg-transparent px-2.5 py-0 text-[15px] leading-7 text-foreground outline-none sm:text-base"
+          class="min-h-[24px] w-full resize-none bg-transparent px-2.5 py-0 text-[15px] leading-6 text-foreground outline-none sm:text-base"
           @input="onInput"
           @keydown="onKeydown"
           @focus="isInputFocused = true"
@@ -276,17 +276,17 @@ onUnmounted(() => {
           <p
             v-if="!input"
             :key="placeholderIndex"
-            class="pointer-events-none absolute left-2.5 right-2.5 top-0 truncate text-[15px] leading-7 text-muted-foreground sm:text-base"
+            class="pointer-events-none absolute left-2.5 right-2.5 top-0 truncate text-[15px] leading-6 text-muted-foreground sm:text-base"
           >
             {{ currentPlaceholder }}
           </p>
         </Transition>
       </div>
 
-      <div class="mt-0.5 flex flex-wrap items-center gap-2">
+      <div class="mt-0 flex flex-wrap items-center gap-2">
         <button
           type="button"
-          class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+          class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
           :disabled="attachmentLoading"
           title="Attach file"
           aria-label="Attach file"
@@ -337,7 +337,7 @@ onUnmounted(() => {
           <button
             type="submit"
             data-testid="dashboard-chat-send"
-            class="ml-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+            class="ml-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
             :disabled="!canSubmit"
             title="Start chat"
             aria-label="Start chat"

--- a/frontend/src/components/ui/SearchableSelect.vue
+++ b/frontend/src/components/ui/SearchableSelect.vue
@@ -117,7 +117,12 @@ const triggerSizingText = computed<string>(() => {
 /** The search icon always returns while open, where the trigger acts as a search field. */
 const showTriggerIcon = computed<boolean>(() => !props.hideTriggerIcon || open.value);
 
-const sizingSpanPadStart = computed<string>(() => (showTriggerIcon.value ? "pl-12" : "pl-3"));
+/**
+ * The sizing span reserves the space the label cannot use. Without the icon the
+ * trigger still spends 16px on input padding plus 36px on the chevron, so a
+ * pl-3 reservation left the last characters clipped.
+ */
+const sizingSpanPadStart = computed<string>(() => (showTriggerIcon.value ? "pl-12" : "pl-6"));
 
 const inputClass = computed(() =>
   cn(

--- a/frontend/src/components/ui/SearchableSelect.vue
+++ b/frontend/src/components/ui/SearchableSelect.vue
@@ -48,6 +48,8 @@ interface Props {
   disabled?: boolean;
   clearable?: boolean;
   clearAriaLabel?: string;
+  /** Hides the leading search icon while closed, for compact inline triggers. */
+  hideTriggerIcon?: boolean;
   class?: string;
   selectClass?: string;
   contentClass?: string;
@@ -64,6 +66,7 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   clearable: false,
   clearAriaLabel: "Clear selection",
+  hideTriggerIcon: false,
   class: undefined,
   selectClass: undefined,
   contentClass: undefined,
@@ -110,6 +113,18 @@ const hasValue = computed<boolean>(() => {
 const triggerSizingText = computed<string>(() => {
   return selectedOption.value?.label ?? props.placeholder;
 });
+
+/** The search icon always returns while open, where the trigger acts as a search field. */
+const showTriggerIcon = computed<boolean>(() => !props.hideTriggerIcon || open.value);
+
+const sizingSpanPadStart = computed<string>(() => (showTriggerIcon.value ? "pl-12" : "pl-3"));
+
+const inputClass = computed(() =>
+  cn(
+    "h-full w-0 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60 disabled:cursor-not-allowed",
+    showTriggerIcon.value ? "px-2" : "pl-3 pr-1"
+  )
+);
 
 const wrapperClass = computed(() =>
   cn("relative group min-w-0 w-full", props.class)
@@ -224,8 +239,8 @@ function clearValue(): void {
     <ComboboxAnchor :class="wrapperClass">
       <span
         aria-hidden="true"
-        class="invisible block h-0 overflow-hidden whitespace-nowrap pl-12 text-sm"
-        :class="clearable && hasValue ? 'pr-16' : 'pr-9'"
+        class="invisible block h-0 overflow-hidden whitespace-nowrap text-sm"
+        :class="[clearable && hasValue ? 'pr-16' : 'pr-9', sizingSpanPadStart]"
       >
         {{ triggerSizingText }}
       </span>
@@ -233,10 +248,13 @@ function clearValue(): void {
         :class="anchorClass"
         @click="openOptions"
       >
-        <Search class="ml-3.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <Search
+          v-if="showTriggerIcon"
+          class="ml-3.5 h-4 w-4 shrink-0 text-muted-foreground"
+        />
         <ComboboxInput
           :id="id"
-          class="h-full w-0 min-w-0 flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground/60 disabled:cursor-not-allowed"
+          :class="inputClass"
           :placeholder="open ? searchPlaceholder : placeholder"
           :disabled="disabled"
         />

--- a/frontend/src/composables/useChatModelSelection.ts
+++ b/frontend/src/composables/useChatModelSelection.ts
@@ -1,0 +1,184 @@
+import { computed, ref } from "vue";
+import type { ComputedRef, Ref } from "vue";
+
+import type { CredentialListItem, LLMModel } from "@/types/credential";
+
+import { useAiDefaults } from "@/composables/useAiDefaults";
+import { credentialsApi } from "@/services/api";
+
+export interface ChatSelectOption {
+  value: string;
+  label: string;
+}
+
+export interface SavedChatSelection {
+  credentialId?: string | null;
+  model?: string | null;
+}
+
+export interface UseChatModelSelectionOptions {
+  /** Runs after every model load attempt, success or failure. */
+  onModelsSettled?: () => void;
+}
+
+export interface UseChatModelSelectionResult {
+  credentials: Ref<CredentialListItem[]>;
+  models: Ref<LLMModel[]>;
+  selectedCredentialId: Ref<string>;
+  selectedModel: Ref<string>;
+  credentialOptions: ComputedRef<ChatSelectOption[]>;
+  modelOptions: ComputedRef<ChatSelectOption[]>;
+  isLoadingModels: Ref<boolean>;
+  modelsLoadFailed: Ref<boolean>;
+  credentialError: Ref<string>;
+  credentialsLoaded: Ref<boolean>;
+  hasCredentials: ComputedRef<boolean>;
+  isReady: ComputedRef<boolean>;
+  modelPlaceholder: ComputedRef<string>;
+  loadCredentials: () => Promise<void>;
+  loadModels: (credentialId: string, preferredModelId?: string) => Promise<void>;
+  applySavedSelection: (saved?: SavedChatSelection) => Promise<void>;
+  selectCredential: (value: string | undefined) => Promise<void>;
+  bootstrap: (saved?: SavedChatSelection) => Promise<void>;
+}
+
+/**
+ * Shared LLM credential and model selection for chat surfaces.
+ *
+ * Resolution order matches the chat composer: a saved selection wins, then the
+ * user's preferred credential and model, then the first credential and the last
+ * model in the list.
+ */
+export function useChatModelSelection(
+  options: UseChatModelSelectionOptions = {},
+): UseChatModelSelectionResult {
+  const aiDefaults = useAiDefaults();
+
+  const credentials = ref<CredentialListItem[]>([]);
+  const models = ref<LLMModel[]>([]);
+  const selectedCredentialId = ref("");
+  const selectedModel = ref("");
+  const isLoadingModels = ref(false);
+  const modelsLoadFailed = ref(false);
+  const credentialError = ref("");
+  const credentialsLoaded = ref(false);
+
+  const credentialOptions = computed<ChatSelectOption[]>(() =>
+    credentials.value.map((credential) => ({
+      value: credential.id,
+      label: credential.name,
+    })),
+  );
+
+  const modelOptions = computed<ChatSelectOption[]>(() =>
+    models.value.map((model) => ({
+      value: model.id,
+      label: model.name,
+    })),
+  );
+
+  const hasCredentials = computed<boolean>(() => credentials.value.length > 0);
+
+  const isReady = computed<boolean>(
+    () =>
+      Boolean(selectedCredentialId.value) &&
+      Boolean(selectedModel.value) &&
+      !modelsLoadFailed.value,
+  );
+
+  const modelPlaceholder = computed<string>(() => {
+    if (isLoadingModels.value) {
+      return "Loading...";
+    }
+    if (modelsLoadFailed.value) {
+      return "Failed to load";
+    }
+    return "Select...";
+  });
+
+  async function loadModels(credentialId: string, preferredModelId?: string): Promise<void> {
+    if (!credentialId) return;
+    isLoadingModels.value = true;
+    modelsLoadFailed.value = false;
+    models.value = [];
+    selectedModel.value = "";
+    try {
+      models.value = await credentialsApi.getModels(credentialId);
+      if (models.value.length > 0) {
+        const match = preferredModelId
+          ? models.value.find((model) => model.id === preferredModelId)
+          : null;
+        const preferredModel = aiDefaults.resolveModel(credentialId, models.value, {
+          savedModel: preferredModelId ?? null,
+        });
+        selectedModel.value =
+          preferredModel ?? (match ? match.id : models.value[models.value.length - 1].id);
+      }
+    } catch {
+      modelsLoadFailed.value = true;
+    } finally {
+      isLoadingModels.value = false;
+      options.onModelsSettled?.();
+    }
+  }
+
+  async function loadCredentials(): Promise<void> {
+    try {
+      credentials.value = await credentialsApi.listLLM();
+      credentialsLoaded.value = true;
+    } catch {
+      credentialError.value = "Failed to load credentials";
+    }
+  }
+
+  async function applySavedSelection(saved: SavedChatSelection = {}): Promise<void> {
+    if (credentials.value.length === 0) return;
+    const savedCredentialId = saved.credentialId ?? null;
+    if (savedCredentialId && credentials.value.some((c) => c.id === savedCredentialId)) {
+      selectedCredentialId.value = savedCredentialId;
+      await loadModels(savedCredentialId, saved.model ?? undefined);
+      return;
+    }
+    if (selectedCredentialId.value) return;
+    const resolved = aiDefaults.resolveCredentialId(credentials.value, {});
+    if (!resolved) return;
+    selectedCredentialId.value = resolved;
+    await loadModels(resolved);
+  }
+
+  async function selectCredential(value: string | undefined): Promise<void> {
+    selectedCredentialId.value = value ?? "";
+    if (!selectedCredentialId.value) {
+      models.value = [];
+      selectedModel.value = "";
+      return;
+    }
+    await loadModels(selectedCredentialId.value);
+  }
+
+  async function bootstrap(saved: SavedChatSelection = {}): Promise<void> {
+    await loadCredentials();
+    await applySavedSelection(saved);
+  }
+
+  return {
+    credentials,
+    models,
+    selectedCredentialId,
+    selectedModel,
+    credentialOptions,
+    modelOptions,
+    isLoadingModels,
+    modelsLoadFailed,
+    credentialError,
+    credentialsLoaded,
+    hasCredentials,
+    isReady,
+    modelPlaceholder,
+    loadCredentials,
+    loadModels,
+    applySavedSelection,
+    selectCredential,
+    bootstrap,
+  };
+}

--- a/frontend/src/docs/content/tabs/chat-tab.md
+++ b/frontend/src/docs/content/tabs/chat-tab.md
@@ -11,6 +11,8 @@ The **Chat** tab provides a direct LLM chat interface. Use it to test models, as
 2. Choose a model from the dropdown (models are loaded from the selected credential)
 3. Start typing to send messages
 
+You can also start a conversation from the chat box on the [Workflows tab](./workflows-tab.md). It sends your first message and opens the new conversation here with the answer already streaming.
+
 ## Features
 
 - **Global variables context** – Your [Global Variables](../reference/global-variables.md) are available to the LLM, so you can ask about or reference stored values

--- a/frontend/src/docs/content/tabs/workflows-tab.md
+++ b/frontend/src/docs/content/tabs/workflows-tab.md
@@ -5,6 +5,16 @@ The **Workflows** tab is the default dashboard view. It shows your workflow list
 <video src="/features/showcase/workflows.webm" controls playsinline muted preload="metadata" style="width:100%;border-radius:12px;margin:16px 0"></video>
 <p class="github-video-link"><a href="../../../../public/features/showcase/workflows.webm">▶ Watch Workflows demo</a></p>
 
+## Start a Chat
+
+Above the workflow list there is a chat box that greets you by name and asks what you want to automate. Type a prompt, optionally attach one file, and pick the credential and model you want. Both dropdowns are searchable and start on your [AI defaults](../reference/user-settings.md).
+
+Sending creates a new conversation and opens it in the [Chat tab](./chat-tab.md), where the reply streams in. Supported attachments are text files, images, and PDFs, one per message, same as the chat composer.
+
+If you have no LLM credential yet, the box shows a link to the [Credentials tab](./credentials-tab.md) and sending stays disabled.
+
+Click the **x** to hide the box. An **Ask AI** button then appears next to the Workflows heading and brings it back. The choice is remembered in your browser.
+
 ## Workflow List
 
 - View all workflows in a card grid or list

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1547,7 +1547,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                   v-if="chatComposerDismissed"
                   variant="ghost"
                   size="sm"
-                  class="order-2 mr-auto gap-1.5 sm:order-none sm:mr-0"
+                  class="order-1 mr-auto gap-1.5 sm:order-none sm:mr-0"
                   data-testid="dashboard-chat-composer-restore"
                   @click="restoreChatComposer"
                 >
@@ -1556,7 +1556,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 </Button>
                 <div
                   v-if="!loading && (workflows.length > 0 || folderStore.folderTree.length > 0)"
-                  class="relative order-1 w-full min-w-[220px] sm:order-none sm:w-72 md:w-80"
+                  class="relative order-4 w-full min-w-[220px] sm:order-none sm:w-72 md:w-80"
                 >
                   <Search class="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
                   <input
@@ -1582,7 +1582,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 <Button
                   variant="outline"
                   size="sm"
-                  class="order-3 sm:hidden min-h-[36px] min-w-[36px]"
+                  class="order-2 sm:hidden min-h-[36px] min-w-[36px]"
                   @click="openCreateFolderDialog(null)"
                 >
                   <FolderPlus class="w-3.5 h-3.5" />
@@ -1590,7 +1590,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 <Button
                   variant="outline"
                   size="sm"
-                  class="order-3 hidden sm:order-none sm:inline-flex"
+                  class="order-2 hidden sm:order-none sm:inline-flex"
                   @click="openCreateFolderDialog(null)"
                 >
                   <FolderPlus class="w-3.5 h-3.5" />
@@ -1599,7 +1599,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 <Button
                   variant="gradient"
                   size="sm"
-                  class="order-4 sm:order-none"
+                  class="order-3 sm:order-none"
                   data-testid="new-workflow-button"
                   @click="showCreateDialog = true; pushOverlayState()"
                 >

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1542,7 +1542,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                   <span class="sm:hidden"> · Long press for move/delete</span>
                 </p>
               </div>
-              <div class="flex flex-wrap items-center justify-end gap-1.5 sm:flex-nowrap">
+              <div class="flex flex-wrap items-center justify-end gap-x-1.5 gap-y-5 sm:flex-nowrap sm:gap-y-1.5">
                 <Button
                   v-if="chatComposerDismissed"
                   variant="ghost"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1547,7 +1547,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                   v-if="chatComposerDismissed"
                   variant="ghost"
                   size="sm"
-                  class="gap-1.5"
+                  class="order-2 mr-auto gap-1.5 sm:order-none sm:mr-0"
                   data-testid="dashboard-chat-composer-restore"
                   @click="restoreChatComposer"
                 >
@@ -1556,7 +1556,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 </Button>
                 <div
                   v-if="!loading && (workflows.length > 0 || folderStore.folderTree.length > 0)"
-                  class="relative w-full min-w-[220px] sm:w-72 md:w-80"
+                  class="relative order-1 w-full min-w-[220px] sm:order-none sm:w-72 md:w-80"
                 >
                   <Search class="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
                   <input
@@ -1582,7 +1582,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 <Button
                   variant="outline"
                   size="sm"
-                  class="sm:hidden min-h-[36px] min-w-[36px]"
+                  class="order-3 sm:hidden min-h-[36px] min-w-[36px]"
                   @click="openCreateFolderDialog(null)"
                 >
                   <FolderPlus class="w-3.5 h-3.5" />
@@ -1590,7 +1590,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 <Button
                   variant="outline"
                   size="sm"
-                  class="hidden sm:inline-flex"
+                  class="order-3 hidden sm:order-none sm:inline-flex"
                   @click="openCreateFolderDialog(null)"
                 >
                   <FolderPlus class="w-3.5 h-3.5" />
@@ -1599,6 +1599,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 <Button
                   variant="gradient"
                   size="sm"
+                  class="order-4 sm:order-none"
                   data-testid="new-workflow-button"
                   @click="showCreateDialog = true; pushOverlayState()"
                 >

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1524,7 +1524,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
               @open-credentials="openCredentialsTab"
             />
 
-            <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
+            <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
               <div>
                 <div class="flex items-center gap-3">
                   <h2 class="text-xl md:text-2xl font-bold tracking-tight">
@@ -1542,7 +1542,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                   <span class="sm:hidden"> · Long press for move/delete</span>
                 </p>
               </div>
-              <div class="flex flex-wrap items-center justify-end gap-x-1.5 gap-y-3 sm:flex-nowrap sm:gap-y-1.5">
+              <div class="flex flex-wrap items-center justify-end gap-x-1.5 gap-y-2 sm:flex-nowrap sm:gap-y-1.5">
                 <Button
                   v-if="chatComposerDismissed"
                   variant="ghost"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1027,8 +1027,18 @@ async function downloadFolderAsZip(folder: FolderTree): Promise<void> {
   }
 }
 
+/** The chat composer is its own drop target for attachments, so skip workflow import there. */
+function isEventInsideChatComposer(event: DragEvent): boolean {
+  const target = event.target as HTMLElement | null;
+  return Boolean(target?.closest?.("[data-testid='dashboard-chat-composer']"));
+}
+
 function handleJsonDragOver(event: DragEvent): void {
   event.preventDefault();
+  if (isEventInsideChatComposer(event)) {
+    isDraggingJsonFile.value = false;
+    return;
+  }
   if (event.dataTransfer) {
     const items = event.dataTransfer.items;
     if (items && items.length > 0 && items[0].kind === "file") {
@@ -1264,6 +1274,7 @@ async function importZipFile(file: File): Promise<void> {
 async function handleJsonDrop(event: DragEvent): Promise<void> {
   event.preventDefault();
   isDraggingJsonFile.value = false;
+  if (isEventInsideChatComposer(event)) return;
 
   const files = event.dataTransfer?.files;
   if (!files || files.length === 0) return;

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1524,7 +1524,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
               @open-credentials="openCredentialsTab"
             />
 
-            <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-5">
+            <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-3">
               <div>
                 <div class="flex items-center gap-3">
                   <h2 class="text-xl md:text-2xl font-bold tracking-tight">
@@ -1542,7 +1542,7 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                   <span class="sm:hidden"> · Long press for move/delete</span>
                 </p>
               </div>
-              <div class="flex flex-wrap items-center justify-end gap-x-1.5 gap-y-5 sm:flex-nowrap sm:gap-y-1.5">
+              <div class="flex flex-wrap items-center justify-end gap-x-1.5 gap-y-3 sm:flex-nowrap sm:gap-y-1.5">
                 <Button
                   v-if="chatComposerDismissed"
                   variant="ghost"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -21,6 +21,7 @@ import {
   RotateCcw,
   Search,
   Settings,
+  Sparkles,
   Trash2,
   Workflow,
   X,
@@ -32,6 +33,7 @@ import type { CredentialListItem } from "@/types/credential";
 import type { FolderTree, NodeData, WorkflowEdge, WorkflowListItem, WorkflowNode } from "@/types/workflow";
 import AnalyticsDashboard from "@/components/Analytics/AnalyticsDashboard.vue";
 import BoardPanel from "@/components/Board/BoardPanel.vue";
+import DashboardChatComposer from "@/components/Chat/DashboardChatComposer.vue";
 import CredentialsPanel from "@/components/Credentials/CredentialsPanel.vue";
 import DashboardsPanel from "@/components/Dashboards/DashboardsPanel.vue";
 import DataTablePanel from "@/components/DataTable/DataTablePanel.vue";
@@ -110,6 +112,41 @@ type TabKey = "workflows" | "board" | "schedules" | "credentials" | "globalvaria
 const initialTab: TabKey = validTabs.has(parsedInitial.tab) ? (parsedInitial.tab as TabKey) : "workflows";
 const dataTableInitialId = ref<string | null>(parsedInitial.tab === "datatable" ? parsedInitial.subPath : null);
 const activeTab = ref<TabKey>(initialTab);
+
+const CHAT_COMPOSER_DISMISSED_KEY = "heym-dashboard-chat-composer-dismissed";
+
+function readChatComposerDismissed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CHAT_COMPOSER_DISMISSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+const chatComposerDismissed = ref(readChatComposerDismissed());
+
+function dismissChatComposer(): void {
+  chatComposerDismissed.value = true;
+  try {
+    window.localStorage.setItem(CHAT_COMPOSER_DISMISSED_KEY, "1");
+  } catch {
+    // Ignore storage failures; the composer still hides for this session.
+  }
+}
+
+function restoreChatComposer(): void {
+  chatComposerDismissed.value = false;
+  try {
+    window.localStorage.removeItem(CHAT_COMPOSER_DISMISSED_KEY);
+  } catch {
+    // Ignore storage failures; the composer still shows for this session.
+  }
+}
+
+function openCredentialsTab(): void {
+  activeTab.value = "credentials";
+}
 
 watch(activeTab, (newTab) => {
   const query: Record<string, string> = newTab === "workflows" ? {} : { tab: newTab };
@@ -1470,6 +1507,12 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
               </div>
             </Transition>
 
+            <DashboardChatComposer
+              v-if="!chatComposerDismissed"
+              @dismiss="dismissChatComposer"
+              @open-credentials="openCredentialsTab"
+            />
+
             <div class="relative z-10 flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-5">
               <div>
                 <div class="flex items-center gap-3">
@@ -1489,6 +1532,17 @@ async function restoreFromTrash(workflowId: string, event: Event): Promise<void>
                 </p>
               </div>
               <div class="flex flex-wrap items-center justify-end gap-1.5 sm:flex-nowrap">
+                <Button
+                  v-if="chatComposerDismissed"
+                  variant="ghost"
+                  size="sm"
+                  class="gap-1.5"
+                  data-testid="dashboard-chat-composer-restore"
+                  @click="restoreChatComposer"
+                >
+                  <Sparkles class="w-4 h-4" />
+                  Ask AI
+                </Button>
                 <div
                   v-if="!loading && (workflows.length > 0 || folderStore.folderTree.length > 0)"
                   class="relative w-full min-w-[220px] sm:w-72 md:w-80"


### PR DESCRIPTION
## What

Adds a chat composer to the top of the dashboard Workflows tab. It greets the user, takes a prompt plus one optional file, and lets them pick an LLM credential and model. Submitting creates a conversation, sends the first message, and opens it in the Chats tab with the answer already streaming.

Design spec: `docs/superpowers/specs/2026-08-07-dashboard-chat-composer-design.md`
Plan: `docs/superpowers/plans/2026-08-07-dashboard-chat-composer.md`

## How it works

- `DashboardChatComposer.vue` calls `chatStore.createConversation()` then `chatStore.sendMessage(...)`, then routes to `/chats/:id`. The stream starts on the dashboard and continues without a second subscription, because `loadConversation` reuses the active conversation and `foregroundSubscribedConvIds` guards re-subscribing.
- Credential and model bootstrap moved out of `ChatConversation.vue` into a shared `useChatModelSelection` composable. `ChatConversation` behavior is unchanged; an `onModelsSettled` callback keeps its focus and context-summary side effects at the same points.
- Layout follows the Perplexity pattern: prompt on top, controls in one row underneath (attach left, credential and model selectors plus send on the right). On mobile the selectors sit above the action row and spread to both edges.
- The prompt line rotates through 18 suggestions every 5s with a bottom-to-top transition. It holds still while the box is focused or has a draft, and respects `prefers-reduced-motion`. Suggestions cover chat capabilities (run a workflow, scheduled runs, Kanban, global variables, templates) plus the 12 beginner template titles from heym.run.
- Files can be attached with the paperclip or by dropping anywhere on the card. The composer stops drop propagation, and the Workflows tab skips its JSON/ZIP import when the event lands inside the composer, so a dropped `.json` attaches to the chat instead of importing as a workflow.
- The card can be hidden with the `x`; an `Ask AI` button next to the Workflows heading brings it back. The choice persists in `localStorage`.

## Shared component change

`SearchableSelect` gains an optional `hideTriggerIcon` prop (default `false`, so no existing usage changes). It hides the leading search icon while closed for compact inline triggers, and the hidden width-sizing span reserves the correct padding in that mode so labels are not clipped.

## Errors

- No LLM credential: controls disabled with a link to the Credentials tab
- Model list fails: model select disabled with a warning, sending blocked
- `createConversation` fails: no navigation, draft and attachment kept, `Could not start chat. Try again.`
- Double submit is blocked by an `isSubmitting` guard

## Verification

- `./check.sh`: frontend lint and typecheck, backend ruff, 2833/2833 backend tests pass
- `bun run build` passes
- No backend change, so no new pytest. Per repo preference no frontend UI tests were added.
- Interactive checks (sending with a real credential, attachment round trip, dismiss persistence) still need a manual pass with a live LLM credential.

## Docs

`frontend/src/docs/content/tabs/workflows-tab.md` gets a "Start a Chat" section, and `chat-tab.md` notes that conversations can start from the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
