### PR TITLE
impl/cancel-bus

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -21,7 +21,16 @@ async_session_maker = async_sessionmaker(
 )
 
 
-sync_database_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+def libpq_dsn() -> str:
+    """Plain libpq URL for consumers that bypass SQLAlchemy's async driver prefix.
+
+    Used by the sync engine and by the raw asyncpg connections that hold
+    LISTEN/NOTIFY channels open.
+    """
+    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+
+
+sync_database_url = libpq_dsn()
 sync_engine = create_engine(
     sync_database_url,
     echo=False,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -68,6 +68,7 @@ from app.services.clickhouse_pool import close_all_clients as close_clickhouse_c
 from app.services.clickhouse_pool import warm_up_pools as warm_up_clickhouse_pools
 from app.services.cron_scheduler import cron_scheduler
 from app.services.distributed_lock import lock_service
+from app.services.execution_cancel_bus import execution_cancel_listener
 from app.services.execution_cancellation import (
     active_execution_registry,
     mark_own_executions_orphaned,
@@ -187,6 +188,7 @@ async def lifespan(app: FastAPI):
         logger.info("ClickHouse pools warmed up: %d", clickhouse_count)
 
     await active_execution_registry.start()
+    await execution_cancel_listener.start()
     await execution_recovery_service.start()
     await cron_scheduler.start()
 
@@ -204,6 +206,7 @@ async def lifespan(app: FastAPI):
     await RabbitMQPool.close_all()
     await cron_scheduler.stop()
     await execution_recovery_service.stop()
+    await execution_cancel_listener.stop()
     await active_execution_registry.stop()
     with suppress(Exception):
         await mark_own_executions_orphaned()

--- a/backend/app/services/chat_task_registry.py
+++ b/backend/app/services/chat_task_registry.py
@@ -24,8 +24,7 @@ from typing import Any
 import asyncpg
 import sqlalchemy as sa
 
-from app.config import settings
-from app.db.session import async_session_maker
+from app.db.session import async_session_maker, libpq_dsn
 
 ChatEvent = str | dict[str, Any]
 logger = logging.getLogger(__name__)
@@ -38,10 +37,6 @@ def _channel_name(conv_id: str) -> str:
     UUID hex without hyphens (32) = 44 chars, well under the limit.
     """
     return f"chat_stream_{conv_id.replace('-', '_').replace('+', '_')}"
-
-
-def _asyncpg_dsn() -> str:
-    return settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
 
 
 def _serialize_event(event: ChatEvent) -> str:
@@ -198,7 +193,7 @@ async def subscribe(
         notify_wakeup.set()
 
     try:
-        listen_conn = await asyncpg.connect(_asyncpg_dsn())
+        listen_conn = await asyncpg.connect(libpq_dsn())
         await listen_conn.add_listener(channel, on_notify)
         # Drain whatever already exists before yielding the queue so the consumer
         # never misses early events that arrived before LISTEN was attached.

--- a/backend/app/services/execution_cancel_bus.py
+++ b/backend/app/services/execution_cancel_bus.py
@@ -1,0 +1,151 @@
+"""Cross-worker execution cancel signalling over Postgres LISTEN/NOTIFY.
+
+A cancel used to reach the worker running an execution only through
+`active_workflow_executions.cancel_requested_at`, which the owning worker polls
+every registry tick. That has two problems under `uvicorn --workers N`: the HTTP
+request almost never lands on the worker that owns the execution, and the poll
+reads the busiest table in the schema, so when that table is unreadable the stop
+never arrives and the run keeps going.
+
+`NOTIFY` does not touch the table, so it delivers the stop independently. The
+database poll stays in place as the fallback for a worker that was reconnecting
+when the signal fired. This mirrors `chat_task_registry`, which already solves
+the same cross-worker delivery problem the same way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from typing import Any
+
+import asyncpg
+import sqlalchemy as sa
+
+from app.db.session import libpq_dsn
+from app.services.execution_cancellation import cancel_execution
+
+logger = logging.getLogger(__name__)
+
+CANCEL_CHANNEL = "heym_execution_cancel"
+# The listener holds one long-lived connection, and this deployment's database
+# restarts on its own, so a dropped socket has to be re-established rather than
+# silently ending the loop.
+_RECONNECT_DELAY_SECONDS = 2.0
+# asyncpg surfaces a dead connection only on use; poke it so a socket that died
+# quietly is noticed instead of leaving the worker deaf to cancels.
+_CONNECTION_PROBE_SECONDS = 15.0
+
+
+def encode_cancel_payload(workflow_id: uuid.UUID, execution_id: uuid.UUID) -> str:
+    return f"{workflow_id}:{execution_id}"
+
+
+def decode_cancel_payload(payload: str) -> tuple[uuid.UUID, uuid.UUID] | None:
+    workflow_raw, _, execution_raw = str(payload).partition(":")
+    try:
+        return uuid.UUID(workflow_raw), uuid.UUID(execution_raw)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+async def publish_execution_cancel(
+    session: Any,
+    *,
+    workflow_id: uuid.UUID,
+    execution_id: uuid.UUID,
+) -> None:
+    """Broadcast a cancel to every worker. Delivered when the transaction commits.
+
+    Uses ``pg_notify`` rather than the ``NOTIFY`` statement because only the
+    function form accepts bind parameters.
+    """
+    await session.execute(
+        sa.text("SELECT pg_notify(:channel, :payload)"),
+        {
+            "channel": CANCEL_CHANNEL,
+            "payload": encode_cancel_payload(workflow_id, execution_id),
+        },
+    )
+
+
+class ExecutionCancelListener:
+    """Applies cancel broadcasts to whichever worker actually owns the execution."""
+
+    def __init__(self) -> None:
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("Execution cancel listener started (channel=%s)", CANCEL_CHANNEL)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        self._connected = False
+        logger.info("Execution cancel listener stopped")
+
+    def handle_payload(self, payload: str) -> bool:
+        """Apply one broadcast locally. Returns True when this worker owned the run."""
+        decoded = decode_cancel_payload(payload)
+        if decoded is None:
+            logger.warning("Ignoring malformed execution cancel payload %r", payload)
+            return False
+        workflow_id, execution_id = decoded
+        cancelled = cancel_execution(workflow_id=workflow_id, execution_id=execution_id)
+        if cancelled:
+            logger.info("Cancelled execution %s from cancel broadcast", execution_id)
+        return cancelled
+
+    def _on_notify(self, _connection: Any, _pid: int, _channel: str, payload: str) -> None:
+        # asyncpg runs this on the event loop; cancel_execution only sets a
+        # threading.Event, so it never blocks here.
+        try:
+            self.handle_payload(payload)
+        except Exception:
+            logger.exception("Execution cancel broadcast handling failed")
+
+    async def _run_loop(self) -> None:
+        while self._running:
+            connection: asyncpg.Connection | None = None
+            try:
+                connection = await asyncpg.connect(libpq_dsn())
+                await connection.add_listener(CANCEL_CHANNEL, self._on_notify)
+                self._connected = True
+                logger.info("Execution cancel listener connected")
+                while self._running:
+                    await asyncio.sleep(_CONNECTION_PROBE_SECONDS)
+                    await connection.execute("SELECT 1")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Execution cancel listener disconnected (%s); retrying in %.0fs",
+                    exc,
+                    _RECONNECT_DELAY_SECONDS,
+                )
+            finally:
+                self._connected = False
+                if connection is not None:
+                    with contextlib.suppress(Exception):
+                        await connection.close()
+            if self._running:
+                await asyncio.sleep(_RECONNECT_DELAY_SECONDS)
+
+
+execution_cancel_listener = ExecutionCancelListener()

--- a/backend/app/services/execution_cancellation.py
+++ b/backend/app/services/execution_cancellation.py
@@ -31,6 +31,11 @@ _REGISTRY_FAILURE_LOG_INTERVAL_SECONDS = 60.0
 # Start/finish commands are replayed until the database accepts them; cap the
 # backlog so a permanently unreachable database cannot grow it without bound.
 _MAX_PENDING_REGISTRY_COMMANDS = 2000
+# Replays happen every _REGISTRY_POLL_SECONDS, so this is ~60s of retrying: long
+# enough to ride out a database restart, short enough that a command which can
+# never be written (corrupt row, missing workflow) is dropped instead of spinning
+# forever and holding back the finish that follows it.
+_MAX_REGISTRY_COMMAND_ATTEMPTS = 120
 # Live SSE events kept per execution so a canvas that attaches mid-run replays the
 # same stream the runner emitted (agent tool progress, sub-agent node lifecycle).
 # Bounded by both count and total bytes: the oldest events are dropped first.
@@ -463,6 +468,7 @@ class ActiveExecutionRegistry:
     def __init__(self) -> None:
         self._commands: queue.Queue[_RegistryCommand] = queue.Queue()
         self._pending: list[_RegistryCommand] = []
+        self._command_attempts: dict[tuple[str, uuid.UUID], int] = {}
         self._task: asyncio.Task[None] | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._wakeup: asyncio.Event | None = None
@@ -608,13 +614,31 @@ class ActiveExecutionRegistry:
                         async with session.begin_nested():
                             await self._apply_command(session, command, now)
                     except Exception as exc:
-                        deferred.append(command)
-                        deferred_execution_ids.add(command.execution_id)
+                        key = (command.action, command.execution_id)
+                        attempts = self._command_attempts.get(key, 0) + 1
                         self._failures.failure(
                             "command flush",
                             exc,
-                            f"{command.action} {command.execution_id}",
+                            f"{command.action} {command.execution_id} attempt {attempts}",
                         )
+                        if attempts >= _MAX_REGISTRY_COMMAND_ATTEMPTS:
+                            # Give up on this one rather than replaying it forever and
+                            # blocking every later command for the same execution.
+                            self._command_attempts.pop(key, None)
+                            logger.error(
+                                "Dropping active execution registry %s for %s after %d "
+                                "failed attempts; the row may be stale until the sweep "
+                                "clears it",
+                                command.action,
+                                command.execution_id,
+                                attempts,
+                            )
+                            continue
+                        self._command_attempts[key] = attempts
+                        deferred.append(command)
+                        deferred_execution_ids.add(command.execution_id)
+                    else:
+                        self._command_attempts.pop((command.action, command.execution_id), None)
                 await session.commit()
         except Exception:
             self._pending = commands + self._pending
@@ -772,21 +796,43 @@ async def request_persisted_execution_cancel(
     workflow_id: uuid.UUID,
     execution_id: uuid.UUID,
 ) -> bool:
-    """Mark a running execution as cancelled so its owning worker can stop it."""
+    """Mark a running execution as cancelled and broadcast the stop to every worker.
+
+    The row update is only the durable record (it drives the dashboard filter and
+    the registry's fallback poll). Delivery is the broadcast, so the update runs in
+    its own savepoint: an unwritable registry row must not swallow the cancel.
+
+    Returns False only when the row is provably absent, since that is the one case
+    where the caller can honestly report "not found". A failed update leaves the
+    state unknown, and the broadcast has gone out regardless.
+    """
     from sqlalchemy import update
 
     from app.db.models import ActiveWorkflowExecution
+    from app.services.execution_cancel_bus import publish_execution_cancel
 
-    result = await db.execute(
-        update(ActiveWorkflowExecution)
-        .where(
-            ActiveWorkflowExecution.workflow_id == workflow_id,
-            ActiveWorkflowExecution.execution_id == execution_id,
+    marked_rows: int | None = None
+    try:
+        async with db.begin_nested():
+            result = await db.execute(
+                update(ActiveWorkflowExecution)
+                .where(
+                    ActiveWorkflowExecution.workflow_id == workflow_id,
+                    ActiveWorkflowExecution.execution_id == execution_id,
+                )
+                .values(cancel_requested_at=_utcnow())
+            )
+            marked_rows = result.rowcount or 0
+    except Exception:
+        logger.warning(
+            "Could not record cancel for execution %s; broadcasting anyway",
+            execution_id,
+            exc_info=True,
         )
-        .values(cancel_requested_at=_utcnow())
-    )
+
+    await publish_execution_cancel(db, workflow_id=workflow_id, execution_id=execution_id)
     await db.commit()
-    return bool(result.rowcount or 0)
+    return marked_rows is None or marked_rows > 0
 
 
 async def cleanup_stale_persisted_executions() -> int:
@@ -818,6 +864,8 @@ async def mark_own_executions_orphaned() -> int:
             .where(
                 ActiveWorkflowExecution.worker_id == _WORKER_ID,
                 ActiveWorkflowExecution.recoverable.is_(True),
+                # Never hand a cancelled run to recovery on shutdown.
+                ActiveWorkflowExecution.cancel_requested_at.is_(None),
             )
             .values(heartbeat_at=epoch)
         )
@@ -855,6 +903,11 @@ async def claim_orphaned_executions(*, now: datetime | None = None) -> list["Cla
                         ).where(
                             ActiveWorkflowExecution.recoverable.is_(True),
                             ActiveWorkflowExecution.heartbeat_at < cutoff,
+                            # A cancelled run is not an orphan. Its row only survives
+                            # because the finish DELETE could not be written, and
+                            # re-running work the user explicitly stopped is worse
+                            # than leaving the row for the stale sweep to clear.
+                            ActiveWorkflowExecution.cancel_requested_at.is_(None),
                         )
                     )
                 ).all()

--- a/backend/tests/test_active_execution_registry_resilience.py
+++ b/backend/tests/test_active_execution_registry_resilience.py
@@ -73,6 +73,7 @@ class _FakeSession:
         self._handler = handler
         self._select_rows = select_rows or []
         self.statements: list[tuple[str, uuid.UUID | None]] = []
+        self.compiled_selects: list[str] = []
         self.committed = 0
         self.rolled_back_savepoints = 0
 
@@ -100,6 +101,7 @@ class _FakeSession:
         execution_id = _bound_execution_id(statement)
         self.statements.append((kind, execution_id))
         if kind == "select":
+            self.compiled_selects.append(str(statement))
             return _FakeResult(rows=self._select_rows)
         return self._handler(kind, execution_id)
 
@@ -280,6 +282,35 @@ class DrainCommandsRetryTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(("insert", healthy_id), session.statements)
         self.assertEqual([broken_id], [command.execution_id for command in self.registry._pending])
 
+    async def test_permanently_failing_command_is_dropped_not_replayed_forever(self) -> None:
+        """A poison command must not hold back the finish queued behind it."""
+        from app.services.execution_cancellation import _MAX_REGISTRY_COMMAND_ATTEMPTS
+
+        execution_id = uuid.uuid4()
+        self._record_start(execution_id)
+
+        session = _FakeSession(self._raise)
+        with patch("app.db.session.async_session_maker", _session_maker(session)):
+            for _ in range(_MAX_REGISTRY_COMMAND_ATTEMPTS):
+                await self.registry._drain_commands()
+
+        self.assertEqual([], self.registry._pending)
+        self.assertEqual({}, self.registry._command_attempts)
+
+    async def test_attempt_counter_resets_once_a_command_succeeds(self) -> None:
+        execution_id = uuid.uuid4()
+        self._record_start(execution_id)
+
+        failing = _FakeSession(self._raise)
+        with patch("app.db.session.async_session_maker", _session_maker(failing)):
+            await self.registry._drain_commands()
+        self.assertEqual(1, self.registry._command_attempts[("start", execution_id)])
+
+        healthy = _FakeSession(lambda _kind, _eid: _FakeResult(rowcount=1))
+        with patch("app.db.session.async_session_maker", _session_maker(healthy)):
+            await self.registry._drain_commands()
+        self.assertEqual({}, self.registry._command_attempts)
+
     async def test_backlog_is_capped(self) -> None:
         for _ in range(2100):
             self._record_start(uuid.uuid4())
@@ -406,6 +437,24 @@ class ClaimOrphanedExecutionsIsolationTests(unittest.IsolatedAsyncioTestCase):
                 await claim_orphaned_executions()
 
         self.assertEqual(1, len(logs.records))
+
+    async def test_cancelled_rows_are_excluded_from_the_candidate_scan(self) -> None:
+        """A cancelled run whose finish DELETE failed must never be re-run."""
+        session = _FakeSession(lambda _kind, _eid: _FakeResult(rowcount=1))
+        with patch(
+            "app.services.execution_cancellation.async_session_maker",
+            _session_maker(session),
+        ):
+            await claim_orphaned_executions()
+
+        select_statements = [
+            stmt for stmt in session.compiled_selects if "cancel_requested_at" in stmt
+        ]
+        self.assertTrue(
+            select_statements,
+            "orphan candidate scan must filter on cancel_requested_at",
+        )
+        self.assertIn("cancel_requested_at IS NULL", select_statements[0])
 
     async def test_only_rows_the_update_actually_won_are_claimed(self) -> None:
         lost_race = _orphan_row(uuid.uuid4())

--- a/backend/tests/test_execution_cancel_bus.py
+++ b/backend/tests/test_execution_cancel_bus.py
@@ -1,0 +1,175 @@
+"""Cancel must reach the worker running the execution, not just the one serving HTTP.
+
+Under `uvicorn --workers N` the cancel request almost never lands on the owning
+worker, and the fallback poll reads the busiest table in the schema. These tests
+cover the NOTIFY path that carries the stop independently of that table.
+"""
+
+import threading
+import unittest
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.services.execution_cancel_bus import (
+    CANCEL_CHANNEL,
+    ExecutionCancelListener,
+    decode_cancel_payload,
+    encode_cancel_payload,
+    publish_execution_cancel,
+)
+from app.services.execution_cancellation import (
+    _ACTIVE_EXECUTIONS,
+    register_execution,
+    request_persisted_execution_cancel,
+)
+
+
+class CancelPayloadTests(unittest.TestCase):
+    def test_round_trips(self) -> None:
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        decoded = decode_cancel_payload(encode_cancel_payload(workflow_id, execution_id))
+        self.assertEqual((workflow_id, execution_id), decoded)
+
+    def test_malformed_payloads_are_rejected(self) -> None:
+        for payload in ["", "nope", "not-a-uuid:also-not", str(uuid.uuid4()), None]:
+            self.assertIsNone(decode_cancel_payload(payload))  # type: ignore[arg-type]
+
+
+class CancelListenerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _ACTIVE_EXECUTIONS.clear()
+        self.listener = ExecutionCancelListener()
+
+    def tearDown(self) -> None:
+        _ACTIVE_EXECUTIONS.clear()
+
+    def test_broadcast_stops_a_locally_owned_execution(self) -> None:
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        event = register_execution(workflow_id=workflow_id, execution_id=execution_id)
+        self.assertFalse(event.is_set())
+
+        applied = self.listener.handle_payload(encode_cancel_payload(workflow_id, execution_id))
+
+        self.assertTrue(applied)
+        self.assertTrue(event.is_set())
+
+    def test_broadcast_for_another_worker_is_a_no_op(self) -> None:
+        event = threading.Event()
+        register_execution(workflow_id=uuid.uuid4(), execution_id=uuid.uuid4(), event=event)
+
+        applied = self.listener.handle_payload(encode_cancel_payload(uuid.uuid4(), uuid.uuid4()))
+
+        self.assertFalse(applied)
+        self.assertFalse(event.is_set())
+
+    def test_mismatched_workflow_does_not_cancel(self) -> None:
+        execution_id = uuid.uuid4()
+        event = register_execution(workflow_id=uuid.uuid4(), execution_id=execution_id)
+
+        applied = self.listener.handle_payload(encode_cancel_payload(uuid.uuid4(), execution_id))
+
+        self.assertFalse(applied)
+        self.assertFalse(event.is_set())
+
+    def test_malformed_payload_is_ignored(self) -> None:
+        self.assertFalse(self.listener.handle_payload("garbage"))
+
+
+class PublishCancelTests(unittest.IsolatedAsyncioTestCase):
+    async def test_publishes_on_the_shared_channel(self) -> None:
+        session = AsyncMock()
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+
+        await publish_execution_cancel(session, workflow_id=workflow_id, execution_id=execution_id)
+
+        params = session.execute.await_args.args[1]
+        self.assertEqual(CANCEL_CHANNEL, params["channel"])
+        self.assertEqual(encode_cancel_payload(workflow_id, execution_id), params["payload"])
+        self.assertIn("pg_notify", str(session.execute.await_args.args[0]))
+
+
+class RequestPersistedCancelTests(unittest.IsolatedAsyncioTestCase):
+    def _session(self, *, update_raises: bool = False, rowcount: int = 1) -> MagicMock:
+        db = MagicMock()
+        savepoint = MagicMock()
+        savepoint.__aenter__ = AsyncMock(return_value=savepoint)
+        savepoint.__aexit__ = AsyncMock(return_value=False)
+        db.begin_nested = MagicMock(return_value=savepoint)
+        db.commit = AsyncMock()
+
+        calls: list[object] = []
+
+        async def execute(statement, params=None):
+            calls.append(statement)
+            if "pg_notify" in str(statement):
+                return MagicMock()
+            if update_raises:
+                raise SQLAlchemyError("could not read block 189")
+            return MagicMock(rowcount=rowcount)
+
+        db.execute = AsyncMock(side_effect=execute)
+        db.calls = calls
+        return db
+
+    async def test_broadcast_still_goes_out_when_the_row_update_fails(self) -> None:
+        db = self._session(update_raises=True)
+
+        result = await request_persisted_execution_cancel(
+            db, workflow_id=uuid.uuid4(), execution_id=uuid.uuid4()
+        )
+
+        self.assertTrue(any("pg_notify" in str(call) for call in db.calls))
+        db.commit.assert_awaited_once()
+        # State is unknown, so the caller must not report "not found".
+        self.assertTrue(result)
+
+    async def test_reports_not_found_only_when_the_row_is_provably_absent(self) -> None:
+        db = self._session(rowcount=0)
+
+        result = await request_persisted_execution_cancel(
+            db, workflow_id=uuid.uuid4(), execution_id=uuid.uuid4()
+        )
+
+        self.assertFalse(result)
+        self.assertTrue(any("pg_notify" in str(call) for call in db.calls))
+
+    async def test_marked_row_reports_success(self) -> None:
+        db = self._session(rowcount=1)
+
+        result = await request_persisted_execution_cancel(
+            db, workflow_id=uuid.uuid4(), execution_id=uuid.uuid4()
+        )
+
+        self.assertTrue(result)
+
+
+class ListenerReconnectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_connection_failure_is_retried_not_fatal(self) -> None:
+        listener = ExecutionCancelListener()
+        attempts = 0
+
+        async def connect(_dsn):
+            nonlocal attempts
+            attempts += 1
+            if attempts >= 3:
+                listener._running = False
+            raise OSError("connection refused")
+
+        with (
+            patch("app.services.execution_cancel_bus.asyncpg.connect", connect),
+            patch("app.services.execution_cancel_bus._RECONNECT_DELAY_SECONDS", 0),
+        ):
+            listener._running = True
+            await listener._run_loop()
+
+        self.assertGreaterEqual(attempts, 3)
+        self.assertFalse(listener.is_connected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
feat: enhance execution cancellation logic and add retry mechanism

- Introduced `execution_cancel_listener` to manage execution cancellation events.
- Updated `ActiveExecutionRegistry` to track command attempts and drop permanently failing commands after a set number of retries.
- Modified `request_persisted_execution_cancel` to ensure cancellation broadcasts occur even if the database update fails.
- Added tests to verify that cancelled executions are excluded from processing and that command attempts reset upon success.

This improves the resilience of the execution cancellation process and prevents blocking due to persistent failures.