### PR TITLE
update/readme-and-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ cancels the production run.
 
 ## 🚀 Quick Start
 
+Prefer to watch it first? **[Set Up Heym Locally in Under 2 Minutes](https://www.youtube.com/watch?v=P6YvlupUboU)** walks the whole path: clone the repository, start PostgreSQL and create your account on a local instance.
+
 ```bash
 git clone https://github.com/heymrun/heym.git
 cd heym

--- a/frontend/src/docs/content/getting-started/quick-start.md
+++ b/frontend/src/docs/content/getting-started/quick-start.md
@@ -2,6 +2,8 @@
 
 Get your first Heym workflow running in minutes.
 
+Do not have Heym running yet? See [Running & Deployment](./running-and-deployment.md), or follow the video walkthrough: [Set Up Heym Locally in Under 2 Minutes](https://www.youtube.com/watch?v=P6YvlupUboU).
+
 ## 1. Create a Workflow
 
 1. Go to the [Workflows](../tabs/workflows-tab.md) tab

--- a/frontend/src/docs/content/getting-started/running-and-deployment.md
+++ b/frontend/src/docs/content/getting-started/running-and-deployment.md
@@ -2,6 +2,8 @@
 
 Heym provides two scripts for different environments: `run.sh` for local development and `deploy.sh` for production deployments using Docker Compose.
 
+> **Video walkthrough:** [Set Up Heym Locally in Under 2 Minutes](https://www.youtube.com/watch?v=P6YvlupUboU) — clone the repository, start PostgreSQL, fill in the required environment variables, and create your first account on a local instance.
+
 ## Prerequisites
 
 Both scripts require the following tools to be installed:


### PR DESCRIPTION
docs: add video walkthrough for local setup in README and related documentation

- Included a link to the video "Set Up Heym Locally in Under 2 Minutes" in README.md, quick-start.md, and running-and-deployment.md to assist users in setting up Heym quickly.