### PR TITLE
fix/canvas-workflow-execution-live

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -82,9 +82,13 @@ from app.services.execution_cancellation import (
     clear_execution as clear_active_execution,
 )
 from app.services.execution_cancellation import (
+    complete_execution as complete_active_execution,
+)
+from app.services.execution_cancellation import (
     get_active_execution_events,
     get_active_execution_inputs,
     get_active_execution_stream_snapshot,
+    get_completed_execution_result,
     register_execution,
     request_persisted_execution_cancel,
 )
@@ -1106,6 +1110,13 @@ async def stream_active_workflow_execution(
                 running_node_ids = snapshot.running_node_ids
                 node_results = snapshot.node_results
             else:
+                completed_result = get_completed_execution_result(
+                    execution_id,
+                    workflow_id=workflow_id,
+                )
+                if completed_result is not None:
+                    yield f"data: {json.dumps(completed_result)}\n\n"
+                    break
                 async with async_session_maker() as stream_db:
                     active_result = await stream_db.execute(
                         select(ActiveWorkflowExecution).where(
@@ -3373,7 +3384,16 @@ async def execute_workflow_stream(
             return
         finally:
             event_queue.put(None)
-            clear_active_execution(execution_id)
+            if test_run and final_result:
+                complete_active_execution(
+                    execution_id,
+                    workflow_id=workflow.id,
+                    result={
+                        key: value for key, value in final_result.items() if not key.startswith("_")
+                    },
+                )
+            else:
+                clear_active_execution(execution_id)
 
     async def event_generator():
         nonlocal final_result, was_cancelled

--- a/backend/app/services/execution_cancellation.py
+++ b/backend/app/services/execution_cancellation.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import copy
 import json
 import logging
 import os
@@ -44,6 +45,10 @@ MAX_PROGRESS_EVENT_BYTES = 8 * 1024 * 1024
 # A single oversized payload (large node output) is buffered without its payload
 # fields; the full value still reaches the canvas with the final history entry.
 MAX_PROGRESS_EVENT_PAYLOAD_BYTES = 256 * 1024
+# Canvas test runs deliberately do not create persistent ExecutionHistory rows. Keep their final
+# SSE payload briefly so another tab already observing the run can still receive its result.
+TERMINAL_EXECUTION_RESULT_TTL_SECONDS = 60.0
+MAX_TERMINAL_EXECUTION_RESULTS = 500
 # Events the observer synthesizes itself, plus executor-internal plumbing that is
 # not JSON serializable.
 _UNBUFFERED_EVENT_TYPES = frozenset({"execution_started", "execution_complete"})
@@ -92,6 +97,15 @@ class ActiveExecutionStreamSnapshot:
 
 
 @dataclass(frozen=True)
+class CompletedExecutionResult:
+    """Short-lived terminal result for a non-persisted execution."""
+
+    workflow_id: uuid.UUID
+    result: dict[str, Any]
+    completed_at: float
+
+
+@dataclass(frozen=True)
 class ActiveExecutionRecord:
     """Persisted active execution visible across API workers."""
 
@@ -129,6 +143,7 @@ class _RegistryCommand:
 
 
 _ACTIVE_EXECUTIONS: dict[uuid.UUID, ExecutionCancellationHandle] = {}
+_COMPLETED_EXECUTIONS: dict[uuid.UUID, CompletedExecutionResult] = {}
 _LOCK = threading.Lock()
 
 
@@ -158,6 +173,7 @@ def register_execution(
     )
     with _LOCK:
         _ACTIVE_EXECUTIONS[execution_id] = handle
+        _COMPLETED_EXECUTIONS.pop(execution_id, None)
     active_execution_registry.record_started(handle)
     return event
 
@@ -174,7 +190,56 @@ def cancel_execution(*, workflow_id: uuid.UUID, execution_id: uuid.UUID) -> bool
 def clear_execution(execution_id: uuid.UUID) -> None:
     with _LOCK:
         _ACTIVE_EXECUTIONS.pop(execution_id, None)
+        _COMPLETED_EXECUTIONS.pop(execution_id, None)
     active_execution_registry.record_finished(execution_id)
+
+
+def complete_execution(
+    execution_id: uuid.UUID,
+    *,
+    workflow_id: uuid.UUID,
+    result: dict[str, Any],
+) -> None:
+    """Finish a non-persisted run while retaining its final SSE payload briefly."""
+
+    now = time.monotonic()
+    with _LOCK:
+        _ACTIVE_EXECUTIONS.pop(execution_id, None)
+        _purge_expired_completed_executions(now)
+        _COMPLETED_EXECUTIONS[execution_id] = CompletedExecutionResult(
+            workflow_id=workflow_id,
+            result=copy.deepcopy(result),
+            completed_at=now,
+        )
+        while len(_COMPLETED_EXECUTIONS) > MAX_TERMINAL_EXECUTION_RESULTS:
+            oldest_execution_id = next(iter(_COMPLETED_EXECUTIONS))
+            _COMPLETED_EXECUTIONS.pop(oldest_execution_id, None)
+    active_execution_registry.record_finished(execution_id)
+
+
+def get_completed_execution_result(
+    execution_id: uuid.UUID,
+    *,
+    workflow_id: uuid.UUID,
+) -> dict[str, Any] | None:
+    """Return a terminal payload while its short cross-tab handoff window is open."""
+
+    with _LOCK:
+        _purge_expired_completed_executions(time.monotonic())
+        completed = _COMPLETED_EXECUTIONS.get(execution_id)
+        if completed is None or completed.workflow_id != workflow_id:
+            return None
+        return copy.deepcopy(completed.result)
+
+
+def _purge_expired_completed_executions(now: float) -> None:
+    expired_ids = [
+        execution_id
+        for execution_id, completed in _COMPLETED_EXECUTIONS.items()
+        if now - completed.completed_at >= TERMINAL_EXECUTION_RESULT_TTL_SECONDS
+    ]
+    for execution_id in expired_ids:
+        _COMPLETED_EXECUTIONS.pop(execution_id, None)
 
 
 def list_active_executions() -> list[ExecutionCancellationHandle]:

--- a/backend/tests/test_active_executions_api.py
+++ b/backend/tests/test_active_executions_api.py
@@ -18,6 +18,7 @@ from app.services.execution_cancellation import (
     ExecutionCancellationHandle,
     active_execution_registry,
     clear_execution,
+    complete_execution,
     get_active_execution_events,
     get_active_execution_inputs,
     get_active_execution_progress,
@@ -679,6 +680,66 @@ class LiveExecutionSnapshotTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(gone["type"], "error")
         self.assertEqual(gone["code"], "execution_gone")
+
+    async def test_stream_returns_cached_test_run_completion_after_active_state_clears(
+        self,
+    ) -> None:
+        """A second canvas can receive the final result of a test run from another tab."""
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        complete_execution(
+            execution_id,
+            workflow_id=workflow_id,
+            result={
+                "type": "execution_complete",
+                "workflow_id": str(workflow_id),
+                "status": "success",
+                "outputs": {"result": "done"},
+                "node_results": [],
+                "execution_time_ms": 12.5,
+                "highlight": {"records": []},
+            },
+        )
+
+        workflow = MagicMock()
+        workflow.id = workflow_id
+        workflow.nodes = []
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        request = MagicMock()
+        request.is_disconnected = AsyncMock(return_value=False)
+        stream_db = AsyncMock()
+        stream_db.execute.return_value = MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        session_context = MagicMock()
+        session_context.__aenter__ = AsyncMock(return_value=stream_db)
+        session_context.__aexit__ = AsyncMock(return_value=None)
+
+        try:
+            with (
+                patch(
+                    "app.api.workflows.get_workflow_for_user",
+                    AsyncMock(return_value=workflow),
+                ),
+                patch("app.api.workflows.async_session_maker", return_value=session_context),
+            ):
+                response = await stream_active_workflow_execution(
+                    workflow_id=workflow_id,
+                    execution_id=execution_id,
+                    request=request,
+                    current_user=user,
+                    db=AsyncMock(),
+                )
+
+                iterator = response.body_iterator
+                self.assertIn('"type": "execution_started"', await anext(iterator))
+                completed = json.loads((await anext(iterator)).removeprefix("data: "))
+                with self.assertRaises(StopAsyncIteration):
+                    await anext(iterator)
+        finally:
+            clear_execution(execution_id)
+
+        self.assertEqual(completed["type"], "execution_complete")
+        self.assertEqual(completed["outputs"], {"result": "done"})
 
     async def test_stream_sends_heartbeat_while_active_node_is_idle(self) -> None:
         workflow_id = uuid.uuid4()

--- a/backend/tests/test_workflow_execution_api.py
+++ b/backend/tests/test_workflow_execution_api.py
@@ -534,6 +534,78 @@ class PortalExecuteStreamCancelPersistenceTests(unittest.IsolatedAsyncioTestCase
 
 
 class ExecuteWorkflowStreamHeartbeatTests(unittest.IsolatedAsyncioTestCase):
+    async def test_test_run_caches_its_terminal_payload_for_live_observers(self) -> None:
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Canvas Workflow",
+            nodes=[{"id": "n1", "type": "textInput", "data": {"label": "Input"}}],
+            edges=[],
+            sse_enabled=True,
+            rate_limit_requests=None,
+            rate_limit_window_seconds=None,
+            cache_ttl_seconds=None,
+            sse_node_config={},
+            workflow_timeout_seconds=None,
+        )
+
+        def fake_streaming_executor(**_kwargs: object):
+            yield {
+                "type": "execution_complete",
+                "workflow_id": str(workflow.id),
+                "status": "success",
+                "outputs": {"result": "done"},
+                "node_results": [],
+                "sub_workflow_executions": [],
+                "execution_time_ms": 12.5,
+            }
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_ScalarResult(workflow))
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        complete_active_execution = MagicMock()
+
+        with (
+            patch("app.api.workflows.validate_workflow_auth", AsyncMock()),
+            patch("app.api.workflows.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.workflows.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.register_execution", return_value=Event()),
+            patch("app.api.workflows.complete_active_execution", complete_active_execution),
+            patch("app.api.workflows.clear_active_execution"),
+            patch("app.api.workflows.execute_workflow_streaming", fake_streaming_executor),
+            patch("app.api.workflows._persist_global_variables_from_execution", AsyncMock()),
+            patch("app.api.workflows.upsert_workflow_analytics_snapshot", AsyncMock()),
+        ):
+            response = await execute_workflow_stream(
+                workflow_id=workflow.id,
+                request=make_request(
+                    query_string=b"test_run=true&trigger_source=Canvas",
+                    headers=[(b"x-simple-response", b"false")],
+                ),
+                current_user=None,
+                db=db,
+            )
+            stream = response.body_iterator
+            started = json.loads((await stream.__anext__()).removeprefix("data: "))
+            async for _chunk in stream:
+                pass
+
+        complete_active_execution.assert_called_once_with(
+            uuid.UUID(started["execution_id"]),
+            workflow_id=workflow.id,
+            result={
+                "type": "execution_complete",
+                "workflow_id": str(workflow.id),
+                "status": "success",
+                "outputs": {"result": "done"},
+                "node_results": [],
+                "sub_workflow_executions": [],
+                "execution_time_ms": 12.5,
+            },
+        )
+
     async def test_emits_hidden_heartbeat_while_waiting_for_workflow_events(self) -> None:
         workflow = SimpleNamespace(
             id=uuid.uuid4(),

--- a/frontend/src/stores/workflow.test.ts
+++ b/frontend/src/stores/workflow.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+import type { ExecutionResult, ServerExecutionHistory, Workflow } from "@/types/workflow";
+
+vi.mock("@/services/api", () => ({
+  lastWrittenWorkflowRevision: vi.fn(() => null),
+  workflowApi: {
+    get: vi.fn(),
+    executeStream: vi.fn(),
+    getWorkflowHistoryEntry: vi.fn(),
+    streamActiveExecution: vi.fn(),
+  },
+}));
+
+import { workflowApi } from "@/services/api";
+import { useWorkflowStore } from "@/stores/workflow";
+
+function makeWorkflow(id: string): Workflow {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    description: null,
+    nodes: [
+      {
+        id: `${id}-node`,
+        type: "textInput",
+        position: { x: 0, y: 0 },
+        data: { label: `${id} node` },
+      },
+    ],
+    edges: [],
+    auth_type: "jwt",
+    auth_header_key: null,
+    auth_header_value: null,
+    webhook_body_mode: "legacy",
+    allow_anonymous: false,
+    owner_id: "owner-id",
+    cache_ttl_seconds: null,
+    rate_limit_requests: null,
+    rate_limit_window_seconds: null,
+    sse_enabled: false,
+    sse_node_config: {},
+    auto_recover_runs: false,
+    error_workflow_id: null,
+    minutes_saved_per_run: null,
+    workflow_timeout_seconds: null,
+    created_at: "2026-08-11T00:00:00.000Z",
+    updated_at: "2026-08-11T00:00:00.000Z",
+  };
+}
+
+describe("workflow execution state", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("does not apply an old workflow's completed stream to a newly opened workflow", async () => {
+    const workflowA = makeWorkflow("workflow-a");
+    const workflowB = makeWorkflow("workflow-b");
+    const getWorkflow = vi.mocked(workflowApi.get);
+    const executeStream = vi.mocked(workflowApi.executeStream);
+    const stream = {
+      started: null as ((data: { execution_id: string }) => void) | null,
+      complete: null as ((result: ExecutionResult) => void) | null,
+      signal: undefined as AbortSignal | undefined,
+    };
+
+    getWorkflow.mockImplementation(async (id: string): Promise<Workflow> => {
+      return id === workflowA.id ? workflowA : workflowB;
+    });
+    executeStream.mockImplementation(
+      (
+        _id,
+        _body,
+        onExecutionStarted,
+        _onNodeStart,
+        _onNodeComplete,
+        onComplete,
+        _onError,
+        _testRun,
+        signal,
+      ): void => {
+        stream.started = onExecutionStarted;
+        stream.complete = onComplete;
+        stream.signal = signal;
+      },
+    );
+
+    const store = useWorkflowStore();
+    await store.loadWorkflow(workflowA.id);
+
+    const execution = store.executeWorkflow({});
+    await vi.waitFor(() => expect(executeStream).toHaveBeenCalledOnce());
+
+    stream.started?.({ execution_id: "execution-a" });
+    store.clearWorkflow();
+    await store.loadWorkflow(workflowB.id);
+    expect(stream.signal?.aborted).toBe(true);
+
+    stream.complete?.({
+      workflow_id: workflowA.id,
+      status: "success",
+      outputs: { leaked: true },
+      execution_time_ms: 42,
+      node_results: [
+        {
+          node_id: `${workflowA.id}-node`,
+          node_label: "A node",
+          node_type: "textInput",
+          status: "success",
+          output: { leaked: true },
+          execution_time_ms: 42,
+          error: null,
+        },
+      ],
+      highlight: { records: [] },
+    });
+    await execution;
+
+    expect(store.currentWorkflow?.id).toBe(workflowB.id);
+    expect(store.executionResult).toBeNull();
+    expect(store.nodeResults).toEqual([]);
+    expect(store.nodes[0]?.data.status).toBeUndefined();
+    expect(store.isExecuting).toBe(false);
+  });
+
+  it("does not resume a canvas execution after leaving and reopening the same workflow", async () => {
+    const workflow = makeWorkflow("workflow-a");
+    const getWorkflow = vi.mocked(workflowApi.get);
+    const executeStream = vi.mocked(workflowApi.executeStream);
+    const stream = {
+      started: null as ((data: { execution_id: string }) => void) | null,
+      complete: null as ((result: ExecutionResult) => void) | null,
+      signal: undefined as AbortSignal | undefined,
+    };
+
+    getWorkflow.mockResolvedValue(workflow);
+    executeStream.mockImplementation(
+      (
+        _id,
+        _body,
+        onExecutionStarted,
+        _onNodeStart,
+        _onNodeComplete,
+        onComplete,
+        _onError,
+        _testRun,
+        signal,
+      ): void => {
+        stream.started = onExecutionStarted;
+        stream.complete = onComplete;
+        stream.signal = signal;
+      },
+    );
+
+    const store = useWorkflowStore();
+    await store.loadWorkflow(workflow.id);
+
+    const execution = store.executeWorkflow({});
+    await vi.waitFor(() => expect(executeStream).toHaveBeenCalledOnce());
+    stream.started?.({ execution_id: "execution-a" });
+
+    store.clearWorkflow();
+    await store.loadWorkflow(workflow.id);
+    expect(stream.signal?.aborted).toBe(true);
+
+    stream.complete?.({
+      workflow_id: workflow.id,
+      status: "success",
+      outputs: { shouldNotAppear: true },
+      execution_time_ms: 42,
+      node_results: [],
+      highlight: { records: [] },
+    });
+    await execution;
+
+    expect(store.currentWorkflow?.id).toBe(workflow.id);
+    expect(store.executionResult).toBeNull();
+    expect(store.nodeResults).toEqual([]);
+    expect(store.nodes[0]?.data.status).toBeUndefined();
+    expect(store.isExecuting).toBe(false);
+  });
+
+  it("applies the completion of a live execution opened in another tab", async () => {
+    const workflow = makeWorkflow("workflow-a");
+    const getWorkflow = vi.mocked(workflowApi.get);
+    const getWorkflowHistoryEntry = vi.mocked(workflowApi.getWorkflowHistoryEntry);
+    const streamActiveExecution = vi.mocked(workflowApi.streamActiveExecution);
+    const stream = {
+      started: null as ((data: { execution_id: string; inputs: Record<string, unknown> }) => void) | null,
+      complete: null as ((result: ExecutionResult) => void) | null,
+    };
+
+    getWorkflow.mockResolvedValue(workflow);
+    getWorkflowHistoryEntry.mockResolvedValue({
+      id: "execution-a",
+      workflow_id: workflow.id,
+      inputs: {},
+      outputs: { completed: true },
+      node_results: [],
+      status: "success",
+      execution_time_ms: 42,
+      started_at: "2026-08-11T00:00:00.000Z",
+      highlight: { records: [] },
+    } satisfies ServerExecutionHistory);
+    streamActiveExecution.mockImplementation(
+      (
+        _workflowId,
+        _executionId,
+        onExecutionStarted,
+        _onNodeStart,
+        _onNodeComplete,
+        onComplete,
+      ): void => {
+        stream.started = onExecutionStarted;
+        stream.complete = onComplete;
+      },
+    );
+
+    const store = useWorkflowStore();
+    await store.loadWorkflow(workflow.id);
+
+    const observation = store.observeExecution("execution-a");
+    await vi.waitFor(() => expect(streamActiveExecution).toHaveBeenCalledOnce());
+    stream.started?.({ execution_id: "execution-a", inputs: {} });
+    await stream.complete?.({
+      workflow_id: workflow.id,
+      status: "success",
+      outputs: { completed: true },
+      execution_time_ms: 42,
+      node_results: [],
+      execution_history_id: "execution-a",
+      highlight: { records: [] },
+    });
+    await observation;
+
+    expect(store.executionResult?.outputs).toEqual({ completed: true });
+    expect(store.executionResult?.highlight).toEqual({ records: [] });
+    expect(store.isExecuting).toBe(false);
+  });
+});

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -83,8 +83,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
   // "reload": this tab has no edits, so it is simply showing an outdated workflow.
   const staleSaveMode = ref<"overwrite" | "reload">("overwrite");
   // Every node currently in flight. A set, not a single id: parallel branches and
-  // orchestrator fan-out run several nodes at once. It outlives `clearWorkflow`, so
-  // leaving and re-entering the editor mid-run restores the running highlights.
+  // orchestrator fan-out run several nodes at once.
   const runningNodeIds = ref<Set<string>>(new Set());
   const propertiesPanelOpen = ref(false);
   const propertiesPanelVisible = ref(false);
@@ -117,6 +116,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
   /** When true, the next `propertiesPanelOpen` pulse skips `openPrimaryExpandDialogForSelectedNode`. */
   const skipPrimaryExpandOnNextPropertiesOpen = ref(false);
   const abortController = ref<AbortController | null>(null);
+  const fileUploadPollAbortController = ref<AbortController | null>(null);
   const debugPanelHeight = ref(192);
   const nodeSearchQuery = ref("");
   const runInputText = ref("");
@@ -441,26 +441,31 @@ export const useWorkflowStore = defineStore("workflow", () => {
       search,
     }: { keepDetails?: boolean; search?: string } = {},
   ): Promise<void> {
-    if (!currentWorkflow.value) return;
+    const workflowId = currentWorkflow.value?.id;
+    if (!workflowId) return;
     isHistoryLoading.value = true;
     try {
       const { total, items } = await workflowApi.getHistory(
-        currentWorkflow.value.id,
+        workflowId,
         50,
         0,
         search,
         triggerSource,
       );
+      if (currentWorkflow.value?.id !== workflowId) return;
       executionHistoryList.value = items;
       executionHistoryTotal.value = total;
       if (!keepDetails) {
         executionHistoryDetails.value = new Map();
       }
     } catch {
+      if (currentWorkflow.value?.id !== workflowId) return;
       executionHistoryList.value = [];
       executionHistoryTotal.value = 0;
     } finally {
-      isHistoryLoading.value = false;
+      if (currentWorkflow.value?.id === workflowId) {
+        isHistoryLoading.value = false;
+      }
     }
   }
 
@@ -468,24 +473,28 @@ export const useWorkflowStore = defineStore("workflow", () => {
     triggerSource?: string,
     { search }: { search?: string } = {},
   ): Promise<void> {
-    if (!currentWorkflow.value) return;
+    const workflowId = currentWorkflow.value?.id;
+    if (!workflowId) return;
     if (isHistoryLoadingMore.value) return;
     if (executionHistoryList.value.length >= executionHistoryTotal.value) return;
     isHistoryLoadingMore.value = true;
     try {
       const { total, items } = await workflowApi.getHistory(
-        currentWorkflow.value.id,
+        workflowId,
         50,
         executionHistoryList.value.length,
         search,
         triggerSource,
       );
+      if (currentWorkflow.value?.id !== workflowId) return;
       executionHistoryList.value = [...executionHistoryList.value, ...items];
       executionHistoryTotal.value = total;
     } catch {
       // silently ignore — next scroll will retry
     } finally {
-      isHistoryLoadingMore.value = false;
+      if (currentWorkflow.value?.id === workflowId) {
+        isHistoryLoadingMore.value = false;
+      }
     }
   }
 
@@ -493,22 +502,26 @@ export const useWorkflowStore = defineStore("workflow", () => {
     entryId: string,
     force = false,
   ): Promise<ExecutionHistoryEntry | null> {
-    if (!currentWorkflow.value) return null;
+    const workflowId = currentWorkflow.value?.id;
+    if (!workflowId) return null;
     const cached = !force ? executionHistoryDetails.value.get(entryId) : undefined;
     if (cached) return cached;
     isHistoryDetailLoading.value = true;
     try {
       const serverHistory = await workflowApi.getWorkflowHistoryEntry(
-        currentWorkflow.value.id,
+        workflowId,
         entryId,
       );
+      if (currentWorkflow.value?.id !== workflowId) return null;
       const entry = convertServerHistoryToEntry(serverHistory);
       upsertExecutionHistoryEntry(entry);
       return entry;
     } catch {
       return null;
     } finally {
-      isHistoryDetailLoading.value = false;
+      if (currentWorkflow.value?.id === workflowId) {
+        isHistoryDetailLoading.value = false;
+      }
     }
   }
 
@@ -516,6 +529,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     result: ExecutionResult,
     options?: { preserveSelection?: boolean },
   ): void {
+    if (!isWorkflowOpen(result.workflow_id)) return;
     executionResult.value = result;
     timelinePickedNodeResultIndex.value = null;
     nodeResults.value = result.node_results || [];
@@ -552,7 +566,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
   }
 
   function applyExecutionHistoryEntry(entry: ExecutionHistoryEntry): void {
-    if (!entry.result) return;
+    if (!entry.result || !isWorkflowOpen(entry.result.workflow_id)) return;
     upsertExecutionHistoryEntry(entry);
     const result: ExecutionResult = {
       ...entry.result,
@@ -563,6 +577,16 @@ export const useWorkflowStore = defineStore("workflow", () => {
   }
 
   async function loadWorkflow(id: string): Promise<void> {
+    if (currentExecutionWorkflowId.value && currentExecutionWorkflowId.value !== id) {
+      // The backend keeps the run alive, but this canvas must stop consuming its stream before
+      // another workflow is loaded. Otherwise late events from the old run mutate the new canvas.
+      abortController.value?.abort();
+      abortController.value = null;
+      isExecuting.value = false;
+      isObservingExecution.value = false;
+      currentExecutionId.value = null;
+      currentExecutionWorkflowId.value = null;
+    }
     const activeExecutionId =
       isExecuting.value && currentExecutionWorkflowId.value === id
         ? currentExecutionId.value
@@ -607,16 +631,23 @@ export const useWorkflowStore = defineStore("workflow", () => {
     executionHistoryList.value = [];
     executionHistoryDetails.value = new Map();
     executionHistoryTotal.value = 0;
+    isHistoryLoading.value = false;
+    isHistoryLoadingMore.value = false;
+    isHistoryDetailLoading.value = false;
     if (!preserveActiveExecution) {
       clearRunInputs();
       executionResult.value = null;
       nodeResults.value = [];
+      agentProgressLogs.value = new Map();
+      llmBatchProgressLogs.value = new Map();
+      isExecuting.value = false;
+      isObservingExecution.value = false;
+      abortController.value = null;
       currentExecutionId.value = null;
+      currentExecutionWorkflowId.value = null;
       clearNodeStatuses();
     } else {
       // Taken before the reset below, which clears the set as it marks nodes pending.
-      // The store tracks these across `clearWorkflow`, so they survive leaving and
-      // re-entering the editor while the run continues in the background.
       const stillRunningNodeIds = [...runningNodeIds.value];
       nodes.value.forEach((node) => setNodeStatus(node.id, "pending"));
       for (const nodeResult of nodeResults.value) {
@@ -1265,6 +1296,22 @@ export const useWorkflowStore = defineStore("workflow", () => {
     runningNodeIds.value.clear();
   }
 
+  function isWorkflowOpen(workflowId: string): boolean {
+    return currentWorkflow.value?.id === workflowId;
+  }
+
+  function isActiveExecutionStream(
+    workflowId: string,
+    streamAbort: AbortController,
+  ): boolean {
+    return (
+      !streamAbort.signal.aborted &&
+      isWorkflowOpen(workflowId) &&
+      currentExecutionWorkflowId.value === workflowId &&
+      abortController.value === streamAbort
+    );
+  }
+
   /**
    * After a fileUploadTrigger workflow mints an upload link, the canvas run ends
    * with status "awaiting_file_upload". The actual file upload happens out of band
@@ -1280,6 +1327,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     while (!signal.aborted && Date.now() < deadlineMs) {
       await new Promise((r) => setTimeout(r, 2500));
       if (signal.aborted) return;
+      if (!isWorkflowOpen(workflowId)) return;
       // Stop if the user started another run or cleared the result.
       if (executionResult.value?.status !== "awaiting_file_upload") return;
 
@@ -1291,6 +1339,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
       }
 
       if (slot.run) {
+        if (!isWorkflowOpen(workflowId)) return;
         const finalRows = (slot.run.node_results || []) as NodeResult[];
         nodeResults.value = finalRows;
         executionResult.value = {
@@ -1317,6 +1366,8 @@ export const useWorkflowStore = defineStore("workflow", () => {
   ): Promise<void> {
     const wf = currentWorkflow.value;
     if (!wf) return;
+    fileUploadPollAbortController.value?.abort();
+    fileUploadPollAbortController.value = null;
 
     // Check freshness before touching any execution state, so cancelling leaves the editor
     // exactly as it was. The dialog resumes the run through `forceSaveWorkflow` /
@@ -1377,12 +1428,15 @@ export const useWorkflowStore = defineStore("workflow", () => {
           wf.id,
           body,
           (data) => {
+            if (!isActiveExecutionStream(wf.id, streamAbort)) return;
             currentExecutionId.value = data.execution_id;
           },
           (nodeId) => {
+            if (!isActiveExecutionStream(wf.id, streamAbort)) return;
             setNodeStatus(nodeId, "running");
           },
           (data) => {
+            if (!isActiveExecutionStream(wf.id, streamAbort)) return;
             setNodeStatus(
               data.node_id,
               data.status as "success" | "error" | "pending" | "skipped",
@@ -1424,6 +1478,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
             }
           },
           (result) => {
+            if (!isActiveExecutionStream(wf.id, streamAbort)) {
+              settle(resolve);
+              return;
+            }
             if (result.status === "awaiting_file_upload") {
               // The run minted an upload link; reset node states and poll for the
               // upload-triggered run so the canvas advances once the file arrives.
@@ -1438,7 +1496,13 @@ export const useWorkflowStore = defineStore("workflow", () => {
               currentExecutionWorkflowId.value = null;
               const slotId = (result.outputs as Record<string, unknown>)?.slot_id;
               if (typeof slotId === "string") {
-                void pollFileUploadSlot(slotId, streamAbort.signal, wf.id);
+                const pollAbort = new AbortController();
+                fileUploadPollAbortController.value = pollAbort;
+                void pollFileUploadSlot(slotId, pollAbort.signal, wf.id).finally(() => {
+                  if (fileUploadPollAbortController.value === pollAbort) {
+                    fileUploadPollAbortController.value = null;
+                  }
+                });
               }
               settle(() => resolve());
               return;
@@ -1492,6 +1556,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
             settle(() => resolve());
           },
           (error: Error) => {
+            if (!isActiveExecutionStream(wf.id, streamAbort)) {
+              settle(resolve);
+              return;
+            }
             clearNodeStatuses();
             isExecuting.value = false;
             runningNodeIds.value.clear();
@@ -1503,6 +1571,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
           true,
           streamAbort.signal,
         (data) => {
+          if (!isActiveExecutionStream(wf.id, streamAbort)) return;
           receivedFinalOutput = true;
           const mapperNode = nodes.value.find((n) => n.id === data.node_id);
           const unwrappedJsonMapper =
@@ -1522,6 +1591,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
           };
         },
         (data) => {
+          if (!isActiveExecutionStream(wf.id, streamAbort)) return;
           const node = nodes.value.find((n) => n.id === data.node_id);
           if (node) {
             node.data = {
@@ -1550,6 +1620,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
           nodeResults.value = [...nodeResults.value, row];
         },
         (data) => {
+          if (!isActiveExecutionStream(wf.id, streamAbort)) return;
           const m = new Map(agentProgressLogs.value);
           const arr = m.get(data.node_id) ?? [];
           const entry = data.entry;
@@ -1572,6 +1643,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
           agentProgressLogs.value = m;
         },
         (data) => {
+          if (!isActiveExecutionStream(wf.id, streamAbort)) return;
           const m = new Map(llmBatchProgressLogs.value);
           const arr = m.get(data.node_id) ?? [];
           arr.push(data.entry);
@@ -1862,6 +1934,8 @@ export const useWorkflowStore = defineStore("workflow", () => {
       abortController.value.abort();
       abortController.value = null;
     }
+    fileUploadPollAbortController.value?.abort();
+    fileUploadPollAbortController.value = null;
     isExecuting.value = false;
     isObservingExecution.value = false;
     runningNodeIds.value.clear();
@@ -1872,8 +1946,10 @@ export const useWorkflowStore = defineStore("workflow", () => {
   }
 
   function clearWorkflow(): void {
-    const preserveActiveExecution =
-      isExecuting.value && currentExecutionId.value !== null;
+    abortController.value?.abort();
+    abortController.value = null;
+    fileUploadPollAbortController.value?.abort();
+    fileUploadPollAbortController.value = null;
     currentWorkflow.value = null;
     nodes.value = [];
     edges.value = [];
@@ -1882,13 +1958,16 @@ export const useWorkflowStore = defineStore("workflow", () => {
     executionHistoryList.value = [];
     executionHistoryDetails.value = new Map();
     executionHistoryTotal.value = 0;
-    if (!preserveActiveExecution) {
-      clearRunInputs();
-      executionResult.value = null;
-      nodeResults.value = [];
-      currentExecutionId.value = null;
-      currentExecutionWorkflowId.value = null;
-    }
+    clearRunInputs();
+    executionResult.value = null;
+    nodeResults.value = [];
+    agentProgressLogs.value = new Map();
+    llmBatchProgressLogs.value = new Map();
+    isExecuting.value = false;
+    isObservingExecution.value = false;
+    currentExecutionId.value = null;
+    currentExecutionWorkflowId.value = null;
+    runningNodeIds.value.clear();
     hasUnsavedChanges.value = false;
     workflowLoadedAt.value = null;
     staleSaveDialogOpen.value = false;


### PR DESCRIPTION
fix: enhance execution handling with completion tracking

- Introduced `complete_execution` function to manage non-persisted execution results, allowing for temporary storage of final payloads.
- Added `get_completed_execution_result` function to retrieve cached results for completed executions.
- Updated `stream_active_workflow_execution` to yield completed results when available.
- Enhanced tests to verify the caching of terminal payloads for live observers and ensure proper execution completion handling.

This update improves the workflow execution lifecycle by enabling better management of execution results across multiple tabs.