### PR TITLE
fix/multiple-execution-stop

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -3,7 +3,7 @@ import copy
 import json
 import logging
 import uuid
-from collections.abc import Iterator
+from collections.abc import Coroutine, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -152,6 +152,16 @@ def _non_blocking_thread_pool(max_workers: int) -> Iterator[ThreadPoolExecutor]:
         pool.shutdown(wait=False, cancel_futures=True)
 
 
+_DETACHED_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _spawn_detached_task(coro: Coroutine[Any, Any, None]) -> None:
+    """Run a coroutine outside the request that started it, holding a strong reference."""
+    task = asyncio.create_task(coro)
+    _DETACHED_TASKS.add(task)
+    task.add_done_callback(_DETACHED_TASKS.discard)
+
+
 def _coerce_bool(value: object, *, default: bool = False) -> bool:
     if value is None:
         return default
@@ -278,6 +288,120 @@ def _persist_playwright_save_steps(
             modified = _apply_saved_steps(steps, save_steps) or modified
     if modified:
         flag_modified(workflow, "nodes")
+
+
+async def persist_stream_execution_result(
+    db: AsyncSession,
+    *,
+    workflow: Workflow,
+    execution_id: uuid.UUID,
+    enriched_inputs: dict,
+    trigger_source: str,
+    raw_body: Any,
+    query_params: dict[str, str],
+    workflow_cache: dict[str, dict],
+    credentials_owner_id: uuid.UUID,
+    final_result: dict,
+    was_cancelled: bool,
+) -> bool:
+    """Record a streamed run's terminal state. Returns False when there is nothing to write.
+
+    Pending (HITL/Codex) runs are persisted while streaming because their history id has to
+    reach the client, so they are skipped here.
+    """
+    if was_cancelled:
+        db.add(
+            ExecutionHistory(
+                id=execution_id,
+                workflow_id=workflow.id,
+                inputs=enriched_inputs,
+                outputs={},
+                node_results=[],
+                status="cancelled",
+                execution_time_ms=0,
+                trigger_source=trigger_source,
+            )
+        )
+        await upsert_workflow_analytics_snapshot(
+            db,
+            workflow_id=workflow.id,
+            owner_id=workflow.owner_id,
+            workflow_name_snapshot=workflow.name,
+            status="cancelled",
+            execution_time_ms=0.0,
+        )
+        return True
+
+    if not final_result or final_result.get("status") == "pending":
+        return False
+
+    status_value = final_result.get("status", "error")
+    node_results = final_result.get("node_results", [])
+    sub_workflow_executions = final_result.get("sub_workflow_executions", [])
+
+    if workflow.cache_ttl_seconds and workflow.cache_ttl_seconds > 0 and status_value == "success":
+        await response_cache.set(
+            db,
+            str(workflow.id),
+            raw_body,
+            query_params,
+            {"outputs": final_result.get("outputs", {})},
+            workflow.cache_ttl_seconds,
+        )
+
+    if status_value == "success":
+        _persist_playwright_save_steps(workflow, node_results, db)
+
+    await _persist_global_variables_from_execution(
+        db,
+        credentials_owner_id,
+        workflow.nodes,
+        workflow_cache,
+        node_results,
+        sub_workflow_executions,
+    )
+    db.add(
+        ExecutionHistory(
+            id=execution_id,
+            workflow_id=workflow.id,
+            inputs=enriched_inputs,
+            outputs=final_result.get("outputs", {}),
+            node_results=node_results,
+            status=status_value,
+            execution_time_ms=final_result.get("execution_time_ms", 0),
+            trigger_source=trigger_source,
+        )
+    )
+    await upsert_workflow_analytics_snapshot(
+        db,
+        workflow_id=workflow.id,
+        owner_id=workflow.owner_id,
+        workflow_name_snapshot=workflow.name,
+        status=status_value,
+        execution_time_ms=float(final_result.get("execution_time_ms", 0)),
+    )
+
+    for sub_exec in sub_workflow_executions:
+        db.add(
+            ExecutionHistory(
+                workflow_id=uuid.UUID(sub_exec["workflow_id"]),
+                inputs=sub_exec["inputs"],
+                outputs=sub_exec["outputs"],
+                node_results=sub_exec.get("node_results", []),
+                status=sub_exec["status"],
+                execution_time_ms=sub_exec["execution_time_ms"],
+                trigger_source=sub_exec.get("trigger_source", "SUB_WORKFLOW"),
+            )
+        )
+        await upsert_workflow_analytics_snapshot(
+            db,
+            workflow_id=uuid.UUID(sub_exec["workflow_id"]),
+            owner_id=None,
+            workflow_name_snapshot=sub_exec.get("workflow_name") or "Sub-workflow",
+            status=sub_exec["status"],
+            execution_time_ms=float(sub_exec["execution_time_ms"]),
+        )
+    return True
 
 
 async def _finalize_allow_downstream_history(
@@ -3327,6 +3451,7 @@ async def execute_workflow_stream(
     final_result: dict = {}
     executor_holder: dict = {}
     was_cancelled: bool = False
+    query_params = dict(request.query_params)
 
     def run_executor():
         nonlocal final_result, was_cancelled
@@ -3395,11 +3520,48 @@ async def execute_workflow_stream(
             else:
                 clear_active_execution(execution_id)
 
+    async def persist_terminal_result() -> None:
+        async with async_session_maker() as session:
+            run_workflow = await session.get(Workflow, workflow_id)
+            if run_workflow is None:
+                return
+            written = await persist_stream_execution_result(
+                session,
+                workflow=run_workflow,
+                execution_id=execution_id,
+                enriched_inputs=enriched_inputs,
+                trigger_source=trigger_source,
+                raw_body=raw_body,
+                query_params=query_params,
+                workflow_cache=workflow_cache,
+                credentials_owner_id=credentials_owner_id,
+                final_result=final_result,
+                was_cancelled=was_cancelled,
+            )
+            if written:
+                await session.commit()
+
+    async def finalize_execution(run_future: asyncio.Future[Any]) -> None:
+        """Persist the run once it ends, whether or not anyone is still reading the stream.
+
+        Starlette cancels the response task the moment the client disconnects, so a run
+        recorded by ``event_generator`` would finish on the server and leave no history.
+        """
+        try:
+            await run_future
+        except Exception:
+            logger.exception("Streaming execution %s failed", execution_id)
+        try:
+            await persist_terminal_result()
+        except Exception:
+            logger.exception("Could not persist execution %s", execution_id)
+
     async def event_generator():
         nonlocal final_result, was_cancelled
         loop = asyncio.get_event_loop()
         with _non_blocking_thread_pool(max_workers=1) as pool:
             future = loop.run_in_executor(pool, run_executor)
+            _spawn_detached_task(finalize_execution(future))
             last_heartbeat_at = loop.time()
             yield (
                 "data: "
@@ -3565,97 +3727,6 @@ async def execute_workflow_stream(
                 except Exception:
                     cancel_event.set()
                     break
-
-            if was_cancelled:
-                cancelled_entry = ExecutionHistory(
-                    id=execution_id,
-                    workflow_id=workflow.id,
-                    inputs=enriched_inputs,
-                    outputs={},
-                    node_results=[],
-                    status="cancelled",
-                    execution_time_ms=0,
-                    trigger_source=trigger_source,
-                )
-                db.add(cancelled_entry)
-                await upsert_workflow_analytics_snapshot(
-                    db,
-                    workflow_id=workflow.id,
-                    owner_id=workflow.owner_id,
-                    workflow_name_snapshot=workflow.name,
-                    status="cancelled",
-                    execution_time_ms=0.0,
-                )
-                await db.flush()
-            elif final_result and final_result.get("status") != "pending":
-                if (
-                    workflow.cache_ttl_seconds
-                    and workflow.cache_ttl_seconds > 0
-                    and final_result.get("status") == "success"
-                ):
-                    await response_cache.set(
-                        db,
-                        workflow_id_str,
-                        raw_body,
-                        dict(request.query_params),
-                        {"outputs": final_result.get("outputs", {})},
-                        workflow.cache_ttl_seconds,
-                    )
-
-                if final_result.get("status") == "success":
-                    _persist_playwright_save_steps(
-                        workflow, final_result.get("node_results", []), db
-                    )
-
-                await _persist_global_variables_from_execution(
-                    db,
-                    credentials_owner_id,
-                    workflow.nodes,
-                    workflow_cache,
-                    final_result.get("node_results", []),
-                    final_result.get("sub_workflow_executions", []),
-                )
-                history_entry = ExecutionHistory(
-                    id=execution_id,
-                    workflow_id=workflow.id,
-                    inputs=enriched_inputs,
-                    outputs=final_result.get("outputs", {}),
-                    node_results=final_result.get("node_results", []),
-                    status=final_result.get("status", "error"),
-                    execution_time_ms=final_result.get("execution_time_ms", 0),
-                    trigger_source=trigger_source,
-                )
-                db.add(history_entry)
-                await upsert_workflow_analytics_snapshot(
-                    db,
-                    workflow_id=workflow.id,
-                    owner_id=workflow.owner_id,
-                    workflow_name_snapshot=workflow.name,
-                    status=final_result.get("status", "error"),
-                    execution_time_ms=float(final_result.get("execution_time_ms", 0)),
-                )
-
-                for sub_exec in final_result.get("sub_workflow_executions", []):
-                    sub_history = ExecutionHistory(
-                        workflow_id=uuid.UUID(sub_exec["workflow_id"]),
-                        inputs=sub_exec["inputs"],
-                        outputs=sub_exec["outputs"],
-                        node_results=sub_exec.get("node_results", []),
-                        status=sub_exec["status"],
-                        execution_time_ms=sub_exec["execution_time_ms"],
-                        trigger_source=sub_exec.get("trigger_source", "SUB_WORKFLOW"),
-                    )
-                    db.add(sub_history)
-                    await upsert_workflow_analytics_snapshot(
-                        db,
-                        workflow_id=uuid.UUID(sub_exec["workflow_id"]),
-                        owner_id=None,
-                        workflow_name_snapshot=sub_exec.get("workflow_name") or "Sub-workflow",
-                        status=sub_exec["status"],
-                        execution_time_ms=float(sub_exec["execution_time_ms"]),
-                    )
-
-                await db.flush()
 
     return StreamingResponse(
         event_generator(),

--- a/backend/tests/test_stream_execution_disconnect.py
+++ b/backend/tests/test_stream_execution_disconnect.py
@@ -1,0 +1,108 @@
+"""A streamed run must be recorded even when its client stops reading.
+
+Starlette cancels the SSE response task on `http.disconnect`, so a run recorded by the
+generator that feeds the browser would complete on the server and leave no history row.
+"""
+
+import asyncio
+import unittest
+import uuid
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.api.workflows import execute_workflow_stream
+from app.db.models import ExecutionHistory
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {"x-simple-response": "false"}
+        self.query_params: dict[str, str] = {"trigger_source": "Canvas"}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class StreamedRunSurvivesClientDisconnectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_completed_run_is_recorded_after_the_client_stops_reading(self) -> None:
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="wait",
+            nodes=[{"id": "n1", "type": "wait", "data": {"duration": 10}}],
+            edges=[],
+            sse_enabled=False,
+            sse_node_config={},
+            cache_ttl_seconds=None,
+            rate_limit_requests=None,
+            rate_limit_window_seconds=None,
+            workflow_timeout_seconds=None,
+        )
+        request_db = AsyncMock()
+        request_db.execute = AsyncMock(
+            return_value=SimpleNamespace(scalar_one_or_none=lambda: workflow)
+        )
+        run_session = AsyncMock()
+        run_session.add = MagicMock()
+        run_session.get = AsyncMock(return_value=workflow)
+
+        @asynccontextmanager
+        async def fake_session_maker():
+            yield run_session
+
+        def fake_streaming_run(**kwargs):
+            yield {"type": "node_start", "node_id": "n1"}
+            yield {
+                "type": "execution_complete",
+                "workflow_id": str(workflow.id),
+                "status": "success",
+                "outputs": {"done": True},
+                "execution_time_ms": 10,
+                "node_results": [{"node_id": "n1", "status": "success"}],
+                "sub_workflow_executions": [],
+            }
+
+        with (
+            patch(
+                "app.api.workflows.parse_execute_body",
+                AsyncMock(return_value=({}, False, "Canvas", False)),
+            ),
+            patch("app.api.workflows.validate_workflow_auth", AsyncMock()),
+            patch("app.api.workflows.get_client_ip", return_value="127.0.0.1"),
+            patch(
+                "app.api.workflows.file_intake_service.find_file_upload_trigger",
+                return_value=None,
+            ),
+            patch("app.api.workflows.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.workflows.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.build_public_base_url", return_value="http://testserver"),
+            patch("app.api.workflows.execute_workflow_streaming", fake_streaming_run),
+            patch("app.api.workflows.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch("app.api.workflows._persist_global_variables_from_execution", AsyncMock()),
+            patch("app.api.workflows.async_session_maker", fake_session_maker),
+        ):
+            response = await execute_workflow_stream(
+                workflow_id=workflow.id,
+                request=_FakeRequest(),
+                current_user=SimpleNamespace(id=workflow.owner_id),
+                db=request_db,
+            )
+
+            # The browser reads the opening event and then goes away mid-run.
+            first_event = await response.body_iterator.__anext__()
+            self.assertIn("execution_started", first_event)
+            await response.body_iterator.aclose()
+
+            for _ in range(200):
+                if run_session.add.call_count:
+                    break
+                await asyncio.sleep(0.01)
+
+        run_session.add.assert_called_once()
+        entry = run_session.add.call_args.args[0]
+        self.assertIsInstance(entry, ExecutionHistory)
+        self.assertEqual(entry.status, "success")
+        self.assertEqual(entry.outputs, {"done": True})
+        run_session.commit.assert_awaited()

--- a/backend/tests/test_stream_execution_persistence.py
+++ b/backend/tests/test_stream_execution_persistence.py
@@ -1,0 +1,183 @@
+"""Terminal persistence for streamed workflow runs.
+
+Starlette cancels the SSE response task as soon as the browser goes away, so the run's
+outcome is written by a detached task instead of by the generator feeding the client.
+"""
+
+import asyncio
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.api.workflows import _spawn_detached_task, persist_stream_execution_result
+
+
+def _workflow(**overrides: object) -> SimpleNamespace:
+    defaults: dict[str, object] = {
+        "id": uuid.uuid4(),
+        "owner_id": uuid.uuid4(),
+        "name": "Workflow",
+        "nodes": [],
+        "cache_ttl_seconds": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _session() -> AsyncMock:
+    db = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+class PersistStreamExecutionResultTests(unittest.IsolatedAsyncioTestCase):
+    async def _persist(
+        self,
+        db: AsyncMock,
+        workflow: SimpleNamespace,
+        *,
+        final_result: dict,
+        was_cancelled: bool = False,
+        execution_id: uuid.UUID | None = None,
+    ) -> bool:
+        with (
+            patch("app.api.workflows.upsert_workflow_analytics_snapshot", AsyncMock()) as analytics,
+            patch(
+                "app.api.workflows._persist_global_variables_from_execution",
+                AsyncMock(),
+            ),
+        ):
+            self.analytics = analytics
+            return await persist_stream_execution_result(
+                db,
+                workflow=workflow,
+                execution_id=execution_id or uuid.uuid4(),
+                enriched_inputs={"body": {}},
+                trigger_source="Canvas",
+                raw_body={},
+                query_params={},
+                workflow_cache={},
+                credentials_owner_id=uuid.uuid4(),
+                final_result=final_result,
+                was_cancelled=was_cancelled,
+            )
+
+    async def test_completed_run_is_recorded(self) -> None:
+        db = _session()
+        workflow = _workflow()
+        execution_id = uuid.uuid4()
+
+        written = await self._persist(
+            db,
+            workflow,
+            execution_id=execution_id,
+            final_result={
+                "type": "execution_complete",
+                "status": "success",
+                "outputs": {"answer": 42},
+                "node_results": [{"node_id": "n1", "status": "success"}],
+                "execution_time_ms": 6185,
+            },
+        )
+
+        self.assertTrue(written)
+        db.add.assert_called_once()
+        entry = db.add.call_args.args[0]
+        self.assertEqual(entry.id, execution_id)
+        self.assertEqual(entry.workflow_id, workflow.id)
+        self.assertEqual(entry.status, "success")
+        self.assertEqual(entry.outputs, {"answer": 42})
+        self.assertEqual(entry.trigger_source, "Canvas")
+        self.assertEqual(self.analytics.await_args.kwargs["status"], "success")
+
+    async def test_cancelled_run_is_recorded(self) -> None:
+        db = _session()
+        workflow = _workflow()
+        execution_id = uuid.uuid4()
+
+        written = await self._persist(
+            db,
+            workflow,
+            execution_id=execution_id,
+            final_result={},
+            was_cancelled=True,
+        )
+
+        self.assertTrue(written)
+        entry = db.add.call_args.args[0]
+        self.assertEqual(entry.id, execution_id)
+        self.assertEqual(entry.status, "cancelled")
+        self.assertEqual(self.analytics.await_args.kwargs["status"], "cancelled")
+
+    async def test_run_that_never_completed_writes_nothing(self) -> None:
+        db = _session()
+
+        written = await self._persist(db, _workflow(), final_result={})
+
+        self.assertFalse(written)
+        db.add.assert_not_called()
+
+    async def test_pending_run_is_left_to_the_stream(self) -> None:
+        db = _session()
+
+        written = await self._persist(
+            db,
+            _workflow(),
+            final_result={"status": "pending", "outputs": {}, "node_results": []},
+        )
+
+        self.assertFalse(written)
+        db.add.assert_not_called()
+
+    async def test_sub_workflow_runs_are_recorded_too(self) -> None:
+        db = _session()
+        sub_workflow_id = uuid.uuid4()
+
+        written = await self._persist(
+            db,
+            _workflow(),
+            final_result={
+                "status": "success",
+                "outputs": {},
+                "node_results": [],
+                "execution_time_ms": 10,
+                "sub_workflow_executions": [
+                    {
+                        "workflow_id": str(sub_workflow_id),
+                        "inputs": {},
+                        "outputs": {},
+                        "status": "success",
+                        "execution_time_ms": 5,
+                    }
+                ],
+            },
+        )
+
+        self.assertTrue(written)
+        self.assertEqual(db.add.call_count, 2)
+        sub_entry = db.add.call_args_list[1].args[0]
+        self.assertEqual(sub_entry.workflow_id, sub_workflow_id)
+        self.assertEqual(sub_entry.trigger_source, "SUB_WORKFLOW")
+
+
+class DetachedTaskTests(unittest.IsolatedAsyncioTestCase):
+    async def test_detached_task_outlives_the_task_that_spawned_it(self) -> None:
+        """A disconnect cancels the streaming task; the run's finalizer must survive it."""
+        finished = asyncio.Event()
+
+        async def finalize() -> None:
+            await asyncio.sleep(0.01)
+            finished.set()
+
+        async def stream() -> None:
+            _spawn_detached_task(finalize())
+            await asyncio.sleep(3600)
+
+        streaming_task = asyncio.create_task(stream())
+        await asyncio.sleep(0)
+        streaming_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await streaming_task
+
+        await asyncio.wait_for(finished.wait(), timeout=2)

--- a/frontend/src/components/Panels/ExecutionHistoryAllDialog.vue
+++ b/frontend/src/components/Panels/ExecutionHistoryAllDialog.vue
@@ -412,11 +412,9 @@ async function cancelActiveExecution(item: ActiveExecutionItem): Promise<void> {
     // 404 = already finished
   } finally {
     isCancellingId.value = null;
-    // If the cancelled execution belongs to the currently open workflow,
-    // also abort the live SSE stream so the canvas stops mid-run.
-    if (workflowStore.isExecuting && workflowStore.currentWorkflow?.id === item.workflow_id) {
-      await workflowStore.stopExecution();
-    }
+    // Only abort the live SSE stream when the canvas is on this very execution; a
+    // second run of the same workflow must survive.
+    await workflowStore.stopExecutionIfCurrent(item.execution_id);
     await loadHistory();
   }
 }

--- a/frontend/src/components/Panels/ExecutionHistoryDialog.vue
+++ b/frontend/src/components/Panels/ExecutionHistoryDialog.vue
@@ -260,11 +260,9 @@ async function cancelActiveExecution(item: ActiveExecutionItem): Promise<void> {
     // 404 = already finished, treat as success
   } finally {
     isCancellingId.value = null;
-    // If the cancelled execution belongs to the currently open workflow,
-    // also abort the live SSE stream so the canvas stops mid-run.
-    if (workflowStore.isExecuting && workflowStore.currentWorkflow?.id === item.workflow_id) {
-      await workflowStore.stopExecution();
-    }
+    // Only abort the live SSE stream when the canvas is on this very execution; a
+    // second run of the same workflow must survive.
+    await workflowStore.stopExecutionIfCurrent(item.execution_id);
     await refreshHistory();
   }
 }

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -1945,6 +1945,12 @@ export const useWorkflowStore = defineStore("workflow", () => {
     currentExecutionWorkflowId.value = null;
   }
 
+  /** Stop the canvas run only when it is the cancelled one, so a sibling run keeps going. */
+  async function stopExecutionIfCurrent(executionId: string): Promise<void> {
+    if (!isExecuting.value || currentExecutionId.value !== executionId) return;
+    await stopExecution();
+  }
+
   function clearWorkflow(): void {
     abortController.value?.abort();
     abortController.value = null;
@@ -3578,6 +3584,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     observeExecution,
     disconnectExecutionObservation,
     stopExecution,
+    stopExecutionIfCurrent,
     clearWorkflow,
     clearExecution,
     clearCanvas,


### PR DESCRIPTION
feat: enhance workflow execution persistence and cancellation handling

- Added `_spawn_detached_task` to manage coroutines outside the request context.
- Implemented `persist_stream_execution_result` to record execution results, including handling for cancelled runs and sub-workflow executions.
- Updated `execute_workflow_stream` to ensure terminal results are persisted even if the client disconnects.
- Refactored execution cancellation logic in the frontend to only stop the stream for the current execution, allowing sibling runs to continue.

This update improves the reliability of workflow execution tracking and enhances user experience during cancellations.