### PR TITLE
Show Kanban Board label for board in Ctrl+K palette

### DIFF
--- a/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
+++ b/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
@@ -40,7 +40,7 @@ import { templatesApi } from "@/services/api";
 
 const TABS = [
   { id: "workflows", label: "Workflows", icon: Workflow },
-  { id: "board", label: "Board", icon: SquareKanban },
+  { id: "board", label: "Kanban Board", icon: SquareKanban },
   { id: "globalvariables", label: "Variables", icon: Variable },
   { id: "chat", label: "Chat", icon: MessageCircle },
   { id: "drive", label: "Drive", icon: HardDrive },

--- a/frontend/src/docs/manifest.ts
+++ b/frontend/src/docs/manifest.ts
@@ -144,7 +144,7 @@ export const DOCS_MANIFEST: Record<string, DocCategory> = {
     label: "Tabs",
     items: [
       { slug: "workflows-tab", title: "Workflows" },
-      { slug: "board-tab", title: "Board" },
+      { slug: "board-tab", title: "Kanban Board" },
       { slug: "templates-tab", title: "Templates" },
       { slug: "global-variables-tab", title: "Variables" },
       { slug: "chat-tab", title: "Chat" },


### PR DESCRIPTION
## Change Summary

Updated the Ctrl+K command palette wording so the board option reads "Kanban Board" and is discoverable when typing "kanban":

- `frontend/src/components/Dialogs/WorkflowCommandPalette.vue` — changed the "Go to tab" entry label from `Board` to `Kanban Board`.
- `frontend/src/docs/manifest.ts` — changed the `board-tab` documentation title from `Board` to `Kanban Board` (this feeds the palette's Documentation section).

The underlying command id (`board`) and doc slug (`board-tab`)/route are unchanged, so links and navigation behavior are preserved.

## Screenshots

![codex-ctrl-k-kanban-wording-ctrl-k-kanban-board.png](https://github.com/heymrun/heym/releases/download/opencode-pr-assets/codex-ctrl-k-kanban-wording-ctrl-k-kanban-board.png)
