### PR TITLE
Link unpriced trace models to the LLM Cost Table

### DIFF
--- a/backend/app/api/ai_assistant.py
+++ b/backend/app/api/ai_assistant.py
@@ -168,7 +168,7 @@ A bulleted list of concrete, actionable suggestions (reliability, error handling
 1. **Error handling** — Inspect the provided `analysisContext`. ONLY when BOTH `hasErrorHandler` is false AND `errorWorkflowConfigured` is false (the workflow has no error handling at all), call this out and recommend adding an errorHandler node and/or configuring an error workflow ("on error, run workflow"). If at least one is present (`hasErrorHandler` true OR `errorWorkflowConfigured` true), the workflow already catches errors — do NOT mention error handling at all: no suggestion to add more, and no acknowledgement.
 2. **Time saved** — ONLY when `minutesSavedPerRun` is null or zero, recommend setting an estimated "time saved per run" so the analytics time saved metric can populate. If it is already set, do NOT mention time saved at all (no acknowledgement).
 3. **Network nodes** — For any node that performs network I/O (e.g. `httpRequest` and integration/API nodes such as slack, drive, notion, etc.), recommend node-specific error handling (enable retry and/or onError "continue on error") on those specific nodes by label.
-4. **Alerts** — Inspect the provided `analysisContext`. ONLY when `hasProductionTrigger` is true AND `hasAlertConfigured` is false (the workflow runs on a trigger but has no alerts watching it), recommend setting up alerts before going to prod — for example an error, duration, or cost alert. If the workflow has no production trigger or alerts are already configured, do NOT mention alerts at all.
+4. **Alerts** — Inspect the provided `analysisContext`. ONLY when `hasAlertConfigured` is false (no alerts watch this workflow), recommend setting up alerts before going to prod — for example an error, duration, or cost alert. If alerts are already configured, do NOT mention alerts at all.
 
 If the workflow already looks solid, say so and suggest small refinements.
 
@@ -179,22 +179,6 @@ One or two sentences on what this workflow is for.
 A numbered, step-by-step walk through the nodes in execution order, in plain language.
 
 Output ONLY Markdown. Do not include JSON, code fences around the whole document, or tool calls. Be concise and specific to THIS workflow."""
-
-
-_PRODUCTION_TRIGGER_NODE_TYPES = {"textInput", "cron"}
-
-
-def _has_production_trigger(nodes: list[Any] | None) -> bool:
-    """True when the workflow has a trigger/input node that runs it in production."""
-    for node in nodes or []:
-        if not isinstance(node, dict):
-            continue
-        node_type = node.get("type")
-        if isinstance(node_type, str) and (
-            node_type in _PRODUCTION_TRIGGER_NODE_TYPES or node_type.endswith("Trigger")
-        ):
-            return True
-    return False
 
 
 def _build_workflow_analysis_context(
@@ -209,7 +193,6 @@ def _build_workflow_analysis_context(
         "hasErrorHandler": has_error_handler,
         "errorWorkflowConfigured": bool(workflow.get("error_workflow_id")),
         "minutesSavedPerRun": workflow.get("minutes_saved_per_run"),
-        "hasProductionTrigger": _has_production_trigger(nodes),
         "hasAlertConfigured": has_alert_configured,
     }
 

--- a/backend/app/api/ai_assistant.py
+++ b/backend/app/api/ai_assistant.py
@@ -164,10 +164,11 @@ WORKFLOW_ANALYZE_SYSTEM_PROMPT = """You analyze an automation workflow and produ
 Given the workflow's nodes and edges, write Markdown with these sections, in this exact order:
 
 ## Improvement areas
-A bulleted list of concrete, actionable suggestions (reliability, error handling, missing validation, cost, clarity). Whenever the workflow handles credentials, user input, external requests, data exposure, injection-prone steps, or anything else security-relevant, include a clear **security** angle here (risks and how to mitigate them). Always cover these three checks explicitly:
+A bulleted list of concrete, actionable suggestions (reliability, error handling, missing validation, cost, clarity). Whenever the workflow handles credentials, user input, external requests, data exposure, injection-prone steps, or anything else security-relevant, include a clear **security** angle here (risks and how to mitigate them). Always cover these four checks explicitly:
 1. **Error handling** — Inspect the provided `analysisContext`. ONLY when BOTH `hasErrorHandler` is false AND `errorWorkflowConfigured` is false (the workflow has no error handling at all), call this out and recommend adding an errorHandler node and/or configuring an error workflow ("on error, run workflow"). If at least one is present (`hasErrorHandler` true OR `errorWorkflowConfigured` true), the workflow already catches errors — do NOT mention error handling at all: no suggestion to add more, and no acknowledgement.
 2. **Time saved** — ONLY when `minutesSavedPerRun` is null or zero, recommend setting an estimated "time saved per run" so the analytics time saved metric can populate. If it is already set, do NOT mention time saved at all (no acknowledgement).
 3. **Network nodes** — For any node that performs network I/O (e.g. `httpRequest` and integration/API nodes such as slack, drive, notion, etc.), recommend node-specific error handling (enable retry and/or onError "continue on error") on those specific nodes by label.
+4. **Alerts** — Inspect the provided `analysisContext`. ONLY when `hasProductionTrigger` is true AND `hasAlertConfigured` is false (the workflow runs on a trigger but has no alerts watching it), recommend setting up alerts before going to prod — for example an error, duration, or cost alert. If the workflow has no production trigger or alerts are already configured, do NOT mention alerts at all.
 
 If the workflow already looks solid, say so and suggest small refinements.
 
@@ -178,6 +179,54 @@ One or two sentences on what this workflow is for.
 A numbered, step-by-step walk through the nodes in execution order, in plain language.
 
 Output ONLY Markdown. Do not include JSON, code fences around the whole document, or tool calls. Be concise and specific to THIS workflow."""
+
+
+_PRODUCTION_TRIGGER_NODE_TYPES = {"textInput", "cron"}
+
+
+def _has_production_trigger(nodes: list[Any] | None) -> bool:
+    """True when the workflow has a trigger/input node that runs it in production."""
+    for node in nodes or []:
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type")
+        if isinstance(node_type, str) and (
+            node_type in _PRODUCTION_TRIGGER_NODE_TYPES or node_type.endswith("Trigger")
+        ):
+            return True
+    return False
+
+
+def _build_workflow_analysis_context(
+    current_workflow: dict | None,
+    has_alert_configured: bool,
+) -> dict[str, Any]:
+    """Derive the ``analysisContext`` block the analyzer prompt reasons over."""
+    workflow = current_workflow or {}
+    nodes = workflow.get("nodes") or []
+    has_error_handler = any(isinstance(n, dict) and n.get("type") == "errorHandler" for n in nodes)
+    return {
+        "hasErrorHandler": has_error_handler,
+        "errorWorkflowConfigured": bool(workflow.get("error_workflow_id")),
+        "minutesSavedPerRun": workflow.get("minutes_saved_per_run"),
+        "hasProductionTrigger": _has_production_trigger(nodes),
+        "hasAlertConfigured": has_alert_configured,
+    }
+
+
+async def _workflow_has_alert(db: AsyncSession, user: Any, workflow_id: uuid.UUID | None) -> bool:
+    """True when at least one alert already watches the given workflow."""
+    if workflow_id is None:
+        return False
+    from app.db.models import Alert
+    from app.services.alert_access import accessible_alerts_filter
+
+    result = await db.execute(
+        select(func.count())
+        .select_from(Alert)
+        .where(accessible_alerts_filter(user.id), Alert.workflow_id == workflow_id)
+    )
+    return bool((result.scalar_one() or 0) > 0)
 
 
 MAX_DASHBOARD_CHAT_HISTORY = 25
@@ -4511,31 +4560,26 @@ async def analyze_workflow_stream(
     config = decrypt_config(credential.encrypted_config)
     client, provider = get_openai_client(credential.type, config)
 
+    workflow_id = None
+    if request.current_workflow:
+        wf_id = request.current_workflow.get("id")
+        if wf_id:
+            workflow_id = uuid.UUID(wf_id) if isinstance(wf_id, str) else wf_id
+
     system_prompt = WORKFLOW_ANALYZE_SYSTEM_PROMPT
     if request.current_workflow:
         wf_summary = json.dumps(request.current_workflow, ensure_ascii=False)
         system_prompt += f"\n\nWorkflow:\n```json\n{wf_summary}\n```"
-        nodes = request.current_workflow.get("nodes") or []
-        has_error_handler = any(
-            isinstance(n, dict) and n.get("type") == "errorHandler" for n in nodes
+        has_alert_configured = await _workflow_has_alert(db, current_user, workflow_id)
+        analysis_context = _build_workflow_analysis_context(
+            request.current_workflow, has_alert_configured
         )
-        analysis_context = {
-            "hasErrorHandler": has_error_handler,
-            "errorWorkflowConfigured": bool(request.current_workflow.get("error_workflow_id")),
-            "minutesSavedPerRun": request.current_workflow.get("minutes_saved_per_run"),
-        }
         system_prompt += (
             "\n\nanalysisContext:\n```json\n"
             + json.dumps(analysis_context, ensure_ascii=False)
             + "\n```"
         )
     system_prompt = _append_execution_log_to_prompt(system_prompt, request.execution_log)
-
-    workflow_id = None
-    if request.current_workflow:
-        wf_id = request.current_workflow.get("id")
-        if wf_id:
-            workflow_id = uuid.UUID(wf_id) if isinstance(wf_id, str) else wf_id
 
     trace_context = LLMTraceContext(
         user_id=current_user.id,

--- a/backend/app/services/alerts/ai_draft.py
+++ b/backend/app/services/alerts/ai_draft.py
@@ -45,7 +45,8 @@ Alert types, and the config each one requires:
 
 Top-level fields:
   name          short, specific, human readable
-  description   optional one line
+  description   REQUIRED - always write one natural English sentence that says what
+                the alert watches and when it fires
   alert_type    one of the four above
   scope         "workflow" for one workflow, "system" for all of the user's workflows
   workflow_id   REQUIRED when scope is "workflow", omitted when scope is "system"

--- a/backend/app/services/coding_agent/pr_publish.py
+++ b/backend/app/services/coding_agent/pr_publish.py
@@ -349,19 +349,22 @@ def resolve_update_existing_pr_branch(
     base_branch: str,
     configured_branch: str,
 ) -> str:
-    """Head branch to reuse for ``update_existing_pr`` so a re-run updates the agent's existing
+    """Head branch to reuse for ``update_existing_pr`` so a re-run updates *this task's* existing
     open pull request instead of opening a new one.
 
-    ``update_existing_pr`` used to trust ``configured_branch`` to already equal an open PR's head.
-    In agentic/board flows the branch name is generated per run (e.g. by an LLM planner), so it
-    never matches and every "update the open PR" run opened a *new* PR. This resolves the real
-    target:
+    Every candidate has to be tied back to ``configured_branch``. An earlier version adopted the
+    token account's most-recently-updated open PR whenever the branch did not match, which made
+    concurrent board cards land on whichever pull request happened to be touched last: one agent
+    pushed its alerts work onto an unrelated dialog PR. Resolution order:
 
     * an open PR whose head already equals ``configured_branch`` wins (explicit targeting);
-    * otherwise the token account's most-recently-updated open PR into ``base_branch`` is adopted;
+    * a branch that names a pull request (``reuse-branch-from-pr-401``) resolves to that PR's head;
+    * an open PR whose head carries the same task slug, ignoring the agent prefix, is adopted, so
+      the same card re-run through a different agent keeps one pull request;
     * otherwise ``configured_branch`` is returned unchanged (a fresh PR is created downstream).
 
-    Best-effort: any GitHub error falls back to ``configured_branch`` (never raises).
+    Adoption is limited to the token account's own pull requests. Best-effort: any GitHub error
+    falls back to ``configured_branch`` (never raises).
     """
     try:
         pulls = gh.list_pull_requests(owner, repo, state="open", per_page=100)
@@ -374,16 +377,37 @@ def resolve_update_existing_pr_branch(
             return configured_branch
 
     author = _authenticated_login(gh)
-    if author:
-        candidates = [pull for pull in to_base if _pr_author_login(pull) == author]
-    else:
-        # Without a known author, only adopt when there is exactly one open PR into the base,
-        # so a re-run never hijacks an unrelated contributor's pull request.
-        candidates = to_base if len(to_base) == 1 else []
-    if not candidates:
-        return configured_branch
-    target = max(candidates, key=lambda pull: str(pull.get("updated_at") or ""))
-    return _pr_head_ref(target) or configured_branch
+    candidates = [pull for pull in to_base if _pr_author_login(pull) == author] if author else []
+
+    referenced = _referenced_pr_number(configured_branch)
+    if referenced is not None:
+        for pull in candidates:
+            if pull.get("number") == referenced:
+                return _pr_head_ref(pull) or configured_branch
+
+    slug = _branch_task_slug(configured_branch)
+    if slug:
+        matching = [pull for pull in candidates if _branch_task_slug(_pr_head_ref(pull)) == slug]
+        if matching:
+            target = max(matching, key=lambda pull: str(pull.get("updated_at") or ""))
+            return _pr_head_ref(target) or configured_branch
+
+    return configured_branch
+
+
+def _referenced_pr_number(branch: str) -> int | None:
+    """PR number a placeholder branch such as ``reuse-branch-from-pr-401`` points at."""
+    match = re.search(r"(?:^|[-_/])pr[-_]?(\d+)(?:$|[-_/])", str(branch or ""), re.IGNORECASE)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _branch_task_slug(branch: str) -> str:
+    """``opencode/alerts-dialog-improvements`` and ``codex/alerts_dialog_improvements`` share a
+    slug, so one card keeps one pull request across agents. Unrelated tasks never collide."""
+    tail = str(branch or "").strip().strip("/").split("/")[-1].lower()
+    return re.sub(r"[^a-z0-9]+", "-", tail).strip("-")
 
 
 def _pr_head_ref(pull: dict) -> str:

--- a/backend/tests/test_alert_ai_draft.py
+++ b/backend/tests/test_alert_ai_draft.py
@@ -247,3 +247,7 @@ class TestDraftSystemPrompt(unittest.TestCase):
     def test_prompt_asks_for_partial_answers(self):
         prompt = build_draft_system_prompt([])
         self.assertIn("A partial answer", prompt)
+
+    def test_prompt_requires_a_description(self):
+        prompt = build_draft_system_prompt([])
+        self.assertIn("description   REQUIRED", prompt)

--- a/backend/tests/test_coding_agent_pr_publish.py
+++ b/backend/tests/test_coding_agent_pr_publish.py
@@ -311,18 +311,25 @@ class TestChangeSummaryExtraction(unittest.TestCase):
         self.assertEqual(pr_publish.extract_change_summary_section("Just prose."), "")
 
 
-def _pr(head: str, base: str = "main", login: str = "heym-coder", updated_at: str = "") -> dict:
+def _pr(
+    head: str,
+    base: str = "main",
+    login: str = "heym-coder",
+    updated_at: str = "",
+    number: int = 1,
+) -> dict:
     return {
         "head": {"ref": head},
         "base": {"ref": base},
         "user": {"login": login},
         "updated_at": updated_at,
-        "html_url": f"https://github.com/acme/app/pull/{head}",
+        "number": number,
+        "html_url": f"https://github.com/acme/app/pull/{number}",
     }
 
 
 class TestResolveUpdateExistingPrBranch(unittest.TestCase):
-    """update_existing_pr must find the agent's real open PR, not trust the configured branch."""
+    """update_existing_pr must find this task's open PR, never an unrelated one."""
 
     def _gh(self, pulls: list[dict], login: str = "heym-coder") -> MagicMock:
         gh = MagicMock()
@@ -337,53 +344,67 @@ class TestResolveUpdateExistingPrBranch(unittest.TestCase):
         )
         self.assertEqual(branch, "configured")
 
-    def test_adopts_authors_open_pr_when_branch_does_not_match(self):
-        # The real board bug: the configured branch was LLM-generated and never matched PR #401.
-        gh = self._gh([_pr("feat/running-workflow-count-badge")])
+    def test_branch_naming_a_pull_request_resolves_to_its_head(self):
+        # The board bug behind this fallback: the planner emitted a placeholder for PR #401.
+        gh = self._gh([_pr("feat/running-workflow-count-badge", number=401)])
         branch = pr_publish.resolve_update_existing_pr_branch(
             gh, "acme", "app", base_branch="main", configured_branch="reuse-branch-from-pr-401"
         )
         self.assertEqual(branch, "feat/running-workflow-count-badge")
 
-    def test_picks_most_recently_updated_of_the_authors_prs(self):
+    def test_adopts_the_same_task_under_a_different_agent_prefix(self):
+        gh = self._gh([_pr("codex/alerts-dialog-improvements", number=7)])
+        branch = pr_publish.resolve_update_existing_pr_branch(
+            gh,
+            "acme",
+            "app",
+            base_branch="main",
+            configured_branch="opencode/alerts-dialog-improvements",
+        )
+        self.assertEqual(branch, "codex/alerts-dialog-improvements")
+
+    def test_never_adopts_an_unrelated_task(self):
+        # A concurrent card pushed its alerts work onto an unrelated dialog PR this way.
         gh = self._gh(
             [
-                _pr("older", updated_at="2026-07-20T10:00:00Z"),
-                _pr("newest", updated_at="2026-07-22T10:00:00Z"),
+                _pr(
+                    "codex/traces-models-without-pricing-dialog", updated_at="2026-08-13T15:00:00Z"
+                ),
+                _pr("opencode/board-card-filters", updated_at="2026-08-13T14:00:00Z"),
             ]
         )
         branch = pr_publish.resolve_update_existing_pr_branch(
-            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+            gh,
+            "acme",
+            "app",
+            base_branch="main",
+            configured_branch="opencode/alerts-dialog-improvements",
         )
-        self.assertEqual(branch, "newest")
+        self.assertEqual(branch, "opencode/alerts-dialog-improvements")
 
     def test_ignores_other_authors_and_other_base_branches(self):
         gh = self._gh(
             [
-                _pr("human-pr", login="someone-else"),
-                _pr("wrong-base", base="develop"),
+                _pr("human/unmatched", login="someone-else"),
+                _pr("bot/unmatched", base="develop"),
             ]
         )
         branch = pr_publish.resolve_update_existing_pr_branch(
-            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+            gh, "acme", "app", base_branch="main", configured_branch="agent/unmatched"
         )
-        self.assertEqual(branch, "unmatched")
+        self.assertEqual(branch, "agent/unmatched")
 
-    def test_without_author_only_adopts_a_single_open_pr(self):
-        gh = self._gh([_pr("only-one")])
+    def test_without_a_readable_author_nothing_is_adopted(self):
+        gh = self._gh([_pr("codex/alerts-dialog-improvements")])
         gh.get_authenticated_user.side_effect = ValueError("token cannot read /user")
         branch = pr_publish.resolve_update_existing_pr_branch(
-            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
+            gh,
+            "acme",
+            "app",
+            base_branch="main",
+            configured_branch="opencode/alerts-dialog-improvements",
         )
-        self.assertEqual(branch, "only-one")
-
-    def test_without_author_does_not_adopt_when_ambiguous(self):
-        gh = self._gh([_pr("one"), _pr("two")])
-        gh.get_authenticated_user.side_effect = ValueError("token cannot read /user")
-        branch = pr_publish.resolve_update_existing_pr_branch(
-            gh, "acme", "app", base_branch="main", configured_branch="unmatched"
-        )
-        self.assertEqual(branch, "unmatched")
+        self.assertEqual(branch, "opencode/alerts-dialog-improvements")
 
     def test_github_error_falls_back_to_configured_branch(self):
         gh = MagicMock()

--- a/backend/tests/test_workflow_analysis_context.py
+++ b/backend/tests/test_workflow_analysis_context.py
@@ -1,0 +1,78 @@
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from app.api.ai_assistant import (
+    _build_workflow_analysis_context,
+    _has_production_trigger,
+    _workflow_has_alert,
+)
+
+
+class HasProductionTriggerTests(unittest.TestCase):
+    def test_true_for_cron_node(self) -> None:
+        self.assertTrue(_has_production_trigger([{"type": "cron"}]))
+
+    def test_true_for_text_input_node(self) -> None:
+        self.assertTrue(_has_production_trigger([{"type": "textInput"}]))
+
+    def test_true_for_trigger_node(self) -> None:
+        self.assertTrue(_has_production_trigger([{"type": "telegramTrigger"}]))
+
+    def test_false_for_regular_node(self) -> None:
+        self.assertFalse(_has_production_trigger([{"type": "llm"}]))
+
+    def test_false_for_empty_or_none(self) -> None:
+        self.assertFalse(_has_production_trigger([]))
+        self.assertFalse(_has_production_trigger(None))
+
+    def test_ignores_non_dict_entries(self) -> None:
+        self.assertFalse(_has_production_trigger(["cron", None, 42]))
+
+
+class BuildWorkflowAnalysisContextTests(unittest.TestCase):
+    def test_includes_existing_checks(self) -> None:
+        workflow = {
+            "nodes": [{"type": "errorHandler"}],
+            "error_workflow_id": str(uuid.uuid4()),
+            "minutes_saved_per_run": 12.5,
+        }
+        ctx = _build_workflow_analysis_context(workflow, has_alert_configured=False)
+        self.assertTrue(ctx["hasErrorHandler"])
+        self.assertTrue(ctx["errorWorkflowConfigured"])
+        self.assertEqual(ctx["minutesSavedPerRun"], 12.5)
+
+    def test_flags_production_trigger_and_alert_configured(self) -> None:
+        workflow = {"nodes": [{"type": "cron"}]}
+        ctx = _build_workflow_analysis_context(workflow, has_alert_configured=True)
+        self.assertTrue(ctx["hasProductionTrigger"])
+        self.assertTrue(ctx["hasAlertConfigured"])
+
+    def test_defaults_when_workflow_none(self) -> None:
+        ctx = _build_workflow_analysis_context(None, has_alert_configured=False)
+        self.assertFalse(ctx["hasErrorHandler"])
+        self.assertFalse(ctx["errorWorkflowConfigured"])
+        self.assertIsNone(ctx["minutesSavedPerRun"])
+        self.assertFalse(ctx["hasProductionTrigger"])
+        self.assertFalse(ctx["hasAlertConfigured"])
+
+
+class WorkflowHasAlertTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_false_when_no_workflow_id(self) -> None:
+        db = AsyncMock()
+        user = SimpleNamespace(id=uuid.uuid4())
+        self.assertFalse(await _workflow_has_alert(db, user, None))
+        db.execute.assert_not_called()
+
+    async def test_returns_true_when_alerts_exist(self) -> None:
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(scalar_one=MagicMock(return_value=3)))
+        user = SimpleNamespace(id=uuid.uuid4())
+        self.assertTrue(await _workflow_has_alert(db, user, uuid.uuid4()))
+
+    async def test_returns_false_when_no_alerts(self) -> None:
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=MagicMock(scalar_one=MagicMock(return_value=0)))
+        user = SimpleNamespace(id=uuid.uuid4())
+        self.assertFalse(await _workflow_has_alert(db, user, uuid.uuid4()))

--- a/backend/tests/test_workflow_analysis_context.py
+++ b/backend/tests/test_workflow_analysis_context.py
@@ -5,30 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from app.api.ai_assistant import (
     _build_workflow_analysis_context,
-    _has_production_trigger,
     _workflow_has_alert,
 )
-
-
-class HasProductionTriggerTests(unittest.TestCase):
-    def test_true_for_cron_node(self) -> None:
-        self.assertTrue(_has_production_trigger([{"type": "cron"}]))
-
-    def test_true_for_text_input_node(self) -> None:
-        self.assertTrue(_has_production_trigger([{"type": "textInput"}]))
-
-    def test_true_for_trigger_node(self) -> None:
-        self.assertTrue(_has_production_trigger([{"type": "telegramTrigger"}]))
-
-    def test_false_for_regular_node(self) -> None:
-        self.assertFalse(_has_production_trigger([{"type": "llm"}]))
-
-    def test_false_for_empty_or_none(self) -> None:
-        self.assertFalse(_has_production_trigger([]))
-        self.assertFalse(_has_production_trigger(None))
-
-    def test_ignores_non_dict_entries(self) -> None:
-        self.assertFalse(_has_production_trigger(["cron", None, 42]))
 
 
 class BuildWorkflowAnalysisContextTests(unittest.TestCase):
@@ -43,10 +21,9 @@ class BuildWorkflowAnalysisContextTests(unittest.TestCase):
         self.assertTrue(ctx["errorWorkflowConfigured"])
         self.assertEqual(ctx["minutesSavedPerRun"], 12.5)
 
-    def test_flags_production_trigger_and_alert_configured(self) -> None:
+    def test_flags_alert_configured(self) -> None:
         workflow = {"nodes": [{"type": "cron"}]}
         ctx = _build_workflow_analysis_context(workflow, has_alert_configured=True)
-        self.assertTrue(ctx["hasProductionTrigger"])
         self.assertTrue(ctx["hasAlertConfigured"])
 
     def test_defaults_when_workflow_none(self) -> None:
@@ -54,7 +31,6 @@ class BuildWorkflowAnalysisContextTests(unittest.TestCase):
         self.assertFalse(ctx["hasErrorHandler"])
         self.assertFalse(ctx["errorWorkflowConfigured"])
         self.assertIsNone(ctx["minutesSavedPerRun"])
-        self.assertFalse(ctx["hasProductionTrigger"])
         self.assertFalse(ctx["hasAlertConfigured"])
 
 

--- a/frontend/e2e/tab-traces.spec.ts
+++ b/frontend/e2e/tab-traces.spec.ts
@@ -45,7 +45,7 @@ test("reloads traces on time range change and toggles the search box", async ({ 
   await expect(search).toHaveValue("");
 });
 
-test("opens the pricing dialog and prefills each selected unpriced trace model", async ({ page }) => {
+test("opens nested pricing dialogs and prefills each selected unpriced trace model", async ({ page }) => {
   const createdAt = "2026-07-20T12:00:00Z";
   const unpricedModels = ["acme/private-chat", "acme/private-reasoner"];
   let customPricingPayload: Record<string, unknown> | null = null;
@@ -181,7 +181,7 @@ test("opens the pricing dialog and prefills each selected unpriced trace model",
 
   await expect(page).toHaveURL(/tab=traces/);
   await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
-  await page.getByRole("button", { name: "Add Custom Model", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Add Custom Model Pricing", exact: true })).toBeVisible();
 
   const modelInput = page.getByPlaceholder("e.g. my-org/private-llm");
   await expect(modelInput).toHaveValue(unpricedModels[0]);
@@ -199,7 +199,7 @@ test("opens the pricing dialog and prefills each selected unpriced trace model",
   await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).not.toBeVisible();
 
   await secondPricingLink.click();
-  await page.getByRole("button", { name: "Add Custom Model", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Add Custom Model Pricing", exact: true })).toBeVisible();
   await expect(modelInput).toHaveValue(unpricedModels[1]);
 });
 

--- a/frontend/e2e/tab-traces.spec.ts
+++ b/frontend/e2e/tab-traces.spec.ts
@@ -45,7 +45,7 @@ test("reloads traces on time range change and toggles the search box", async ({ 
   await expect(search).toHaveValue("");
 });
 
-test("opens the pricing table and prefills an unpriced trace model", async ({ page }) => {
+test("opens the pricing dialog and prefills each selected unpriced trace model", async ({ page }) => {
   const createdAt = "2026-07-20T12:00:00Z";
   const unpricedModels = ["acme/private-chat", "acme/private-reasoner"];
   let customPricingPayload: Record<string, unknown> | null = null;
@@ -173,11 +173,13 @@ test("opens the pricing table and prefills an unpriced trace model", async ({ pa
   });
 
   await page.goto("/?tab=traces");
-  const pricingLink = page.getByRole("link", { name: /2 model\(s\) without pricing/ });
-  await expect(pricingLink).toBeVisible();
-  await pricingLink.click();
+  const firstPricingLink = page.getByRole("link", { name: unpricedModels[0], exact: true });
+  const secondPricingLink = page.getByRole("link", { name: unpricedModels[1], exact: true });
+  await expect(firstPricingLink).toBeVisible();
+  await expect(secondPricingLink).toBeVisible();
+  await firstPricingLink.click();
 
-  await expect(page).toHaveURL(/tab=datatable(?:%2F|\/)llm-pricing/);
+  await expect(page).toHaveURL(/tab=traces/);
   await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
   await page.getByRole("button", { name: "Add Custom Model", exact: true }).click();
 
@@ -193,6 +195,10 @@ test("opens the pricing table and prefills an unpriced trace model", async ({ pa
     output_per_1m_usd: "1.25",
   });
 
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).not.toBeVisible();
+
+  await secondPricingLink.click();
   await page.getByRole("button", { name: "Add Custom Model", exact: true }).click();
   await expect(modelInput).toHaveValue(unpricedModels[1]);
 });

--- a/frontend/e2e/tab-traces.spec.ts
+++ b/frontend/e2e/tab-traces.spec.ts
@@ -45,6 +45,158 @@ test("reloads traces on time range change and toggles the search box", async ({ 
   await expect(search).toHaveValue("");
 });
 
+test("opens the pricing table and prefills an unpriced trace model", async ({ page }) => {
+  const createdAt = "2026-07-20T12:00:00Z";
+  const unpricedModels = ["acme/private-chat", "acme/private-reasoner"];
+  let customPricingPayload: Record<string, unknown> | null = null;
+  const pricingRows = [
+    {
+      id: "33333333-3333-4333-8333-333333333333",
+      provider: "OpenAI",
+      model: "gpt-4.1-mini",
+      operator: "equals",
+      input_per_1m_usd: "0.40",
+      output_per_1m_usd: "1.60",
+      source: "seed",
+      is_override: false,
+      is_custom: false,
+      override_id: null,
+      updated_at: createdAt,
+    },
+  ];
+
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      json: {
+        id: "22222222-2222-4222-8222-222222222222",
+        email: "trace-pricing@example.com",
+        name: "Trace Pricing Test",
+        user_rules: null,
+        tts_credential_id: null,
+        tts_voice_id: null,
+        preferred_credential_id: null,
+        preferred_model: null,
+        created_at: createdAt,
+      },
+    });
+  });
+  await page.route("**/api/credentials/llm", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/workflows/with-inputs", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/workflows", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/folders/tree", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/templates**", async (route) => {
+    await route.fulfill({ json: { workflow_templates: [], node_templates: [] } });
+  });
+  await page.route("**/api/data-tables", async (route) => {
+    await route.fulfill({ json: [] });
+  });
+  await page.route("**/api/traces**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === "/api/traces/stats") {
+      await route.fulfill({
+        json: {
+          range: { start: null, end: createdAt, bucket_seconds: 3600 },
+          kpis: {
+            total_calls: 2,
+            success_calls: 2,
+            error_calls: 0,
+            error_pct: 0,
+            prompt_tokens: 90,
+            completion_tokens: 30,
+            total_tokens: 120,
+            total_cost_usd: "0",
+            avg_latency_ms: 450,
+            unpriced_models: unpricedModels,
+          },
+          by_model: [
+            {
+              model: unpricedModels[0],
+              prompt_tokens: 90,
+              completion_tokens: 30,
+              total_tokens: 120,
+              calls: 2,
+              cost_usd: "0",
+            },
+          ],
+          by_time: [],
+        },
+      });
+      return;
+    }
+    if (pathname === "/api/traces") {
+      await route.fulfill({ json: { items: [], total: 0, limit: 25, offset: 0 } });
+      return;
+    }
+    await route.continue();
+  });
+  await page.route("**/api/llm-pricing**", async (route) => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === "/api/llm-pricing/sync-status") {
+      await route.fulfill({
+        json: { last_synced_at: "2025-01-01T00:00:00Z", total_rows: 1, override_rows: 0 },
+      });
+      return;
+    }
+    if (pathname === "/api/llm-pricing" && request.method() === "GET") {
+      await route.fulfill({ json: pricingRows });
+      return;
+    }
+    if (pathname === "/api/llm-pricing/custom" && request.method() === "POST") {
+      customPricingPayload = request.postDataJSON() as Record<string, unknown>;
+      const customPricing = {
+        id: "44444444-4444-4444-8444-444444444444",
+        provider: "acme",
+        model: "private-chat",
+        operator: "equals",
+        input_per_1m_usd: "0.75",
+        output_per_1m_usd: "1.25",
+        source: "user",
+        is_override: false,
+        is_custom: true,
+        override_id: "44444444-4444-4444-8444-444444444444",
+        updated_at: createdAt,
+      };
+      pricingRows.push(customPricing);
+      await route.fulfill({ status: 201, json: customPricing });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/?tab=traces");
+  const pricingLink = page.getByRole("link", { name: /2 model\(s\) without pricing/ });
+  await expect(pricingLink).toBeVisible();
+  await pricingLink.click();
+
+  await expect(page).toHaveURL(/tab=datatable(?:%2F|\/)llm-pricing/);
+  await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Add Custom Model", exact: true }).click();
+
+  const modelInput = page.getByPlaceholder("e.g. my-org/private-llm");
+  await expect(modelInput).toHaveValue(unpricedModels[0]);
+  await page.getByPlaceholder("0.50").fill("0.75");
+  await page.getByPlaceholder("1.50").fill("1.25");
+  await page.getByRole("button", { name: "Add", exact: true }).click();
+
+  await expect.poll(() => customPricingPayload).toEqual({
+    model: unpricedModels[0],
+    input_per_1m_usd: "0.75",
+    output_per_1m_usd: "1.25",
+  });
+
+  await page.getByRole("button", { name: "Add Custom Model", exact: true }).click();
+  await expect(modelInput).toHaveValue(unpricedModels[1]);
+});
+
 test("renders JSON trace events as expandable trees with a raw toggle", async ({ page }) => {
   const traceId = "11111111-1111-4111-8111-111111111111";
   const createdAt = "2026-07-20T12:00:00Z";

--- a/frontend/e2e/tab-traces.spec.ts
+++ b/frontend/e2e/tab-traces.spec.ts
@@ -45,10 +45,9 @@ test("reloads traces on time range change and toggles the search box", async ({ 
   await expect(search).toHaveValue("");
 });
 
-test("opens nested pricing dialogs and prefills each selected unpriced trace model", async ({ page }) => {
+test("opens nested pricing dialogs with layered Escape behavior", async ({ page }) => {
   const createdAt = "2026-07-20T12:00:00Z";
   const unpricedModels = ["acme/private-chat", "acme/private-reasoner"];
-  let customPricingPayload: Record<string, unknown> | null = null;
   const pricingRows = [
     {
       id: "33333333-3333-4333-8333-333333333333",
@@ -151,7 +150,6 @@ test("opens nested pricing dialogs and prefills each selected unpriced trace mod
       return;
     }
     if (pathname === "/api/llm-pricing/custom" && request.method() === "POST") {
-      customPricingPayload = request.postDataJSON() as Record<string, unknown>;
       const customPricing = {
         id: "44444444-4444-4444-8444-444444444444",
         provider: "acme",
@@ -185,15 +183,16 @@ test("opens nested pricing dialogs and prefills each selected unpriced trace mod
 
   const modelInput = page.getByPlaceholder("e.g. my-org/private-llm");
   await expect(modelInput).toHaveValue(unpricedModels[0]);
-  await page.getByPlaceholder("0.50").fill("0.75");
-  await page.getByPlaceholder("1.50").fill("1.25");
-  await page.getByRole("button", { name: "Add", exact: true }).click();
 
-  await expect.poll(() => customPricingPayload).toEqual({
-    model: unpricedModels[0],
-    input_per_1m_usd: "0.75",
-    output_per_1m_usd: "1.25",
-  });
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("heading", { name: "Add Custom Model Pricing", exact: true })).not.toBeVisible();
+  await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
+
+  const pricingSearch = page.getByPlaceholder("Search model or provider…");
+  await pricingSearch.fill("gpt-4.1-mini");
+  await page.keyboard.press("Escape");
+  await expect(pricingSearch).toHaveValue("");
+  await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
 
   await page.keyboard.press("Escape");
   await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).not.toBeVisible();

--- a/frontend/e2e/tab-traces.spec.ts
+++ b/frontend/e2e/tab-traces.spec.ts
@@ -48,6 +48,10 @@ test("reloads traces on time range change and toggles the search box", async ({ 
 test("opens nested pricing dialogs with layered Escape behavior", async ({ page }) => {
   const createdAt = "2026-07-20T12:00:00Z";
   const unpricedModels = ["acme/private-chat", "acme/private-reasoner"];
+  let releasePricingRows = (): void => {};
+  const pricingRowsGate = new Promise<void>((resolve) => {
+    releasePricingRows = resolve;
+  });
   const pricingRows: Record<string, string | boolean | null>[] = [
     {
       id: "33333333-3333-4333-8333-333333333333",
@@ -146,8 +150,8 @@ test("opens nested pricing dialogs with layered Escape behavior", async ({ page 
       return;
     }
     if (pathname === "/api/llm-pricing" && request.method() === "GET") {
-      // Land the rows after the open animation, as a real fetch does.
-      await new Promise((resolve) => setTimeout(resolve, 400));
+      // Held so the dialog can be measured before and after its rows land.
+      await pricingRowsGate;
       await route.fulfill({ json: pricingRows });
       return;
     }
@@ -178,13 +182,13 @@ test("opens nested pricing dialogs with layered Escape behavior", async ({ page 
   await expect(firstPricingLink).toBeVisible();
   await expect(secondPricingLink).toBeVisible();
 
-  // Each layer needs its own backdrop for depth, without either flash: a fading ancestor above
-  // a backdrop, or a panel that resizes once its rows land.
+  // A backdrop under an ancestor below opacity 1 becomes its own backdrop root, so its blur only
+  // appears once the fade ends. Sample on a timer rather than per frame: a loaded runner drops
+  // frames, and this has to hold through the whole 250ms open animation.
   await page.evaluate(() => {
-    const samples: { backdrops: number; fadingAncestors: number; outerHeight: number }[] = [];
+    const samples: { backdrops: number; fadingAncestors: number }[] = [];
     (window as unknown as { __openSamples: typeof samples }).__openSamples = samples;
-    let frames = 0;
-    const tick = (): void => {
+    const timer = setInterval(() => {
       const backdrops = Array.from(document.querySelectorAll(".dialog-backdrop"));
       const fadingAncestors = backdrops.filter((backdrop) => {
         let node = backdrop.parentElement;
@@ -196,18 +200,11 @@ test("opens nested pricing dialogs with layered Escape behavior", async ({ page 
         }
         return false;
       });
-      const outerPanel = document.querySelector(".dialog-content");
-      samples.push({
-        backdrops: backdrops.length,
-        fadingAncestors: fadingAncestors.length,
-        outerHeight: Math.round(outerPanel?.getBoundingClientRect().height ?? 0),
-      });
-      frames += 1;
-      if (frames < 60) {
-        requestAnimationFrame(tick);
-      }
-    };
-    requestAnimationFrame(tick);
+      samples.push({ backdrops: backdrops.length, fadingAncestors: fadingAncestors.length });
+    }, 10);
+    (window as unknown as { __stopOpenSamples: () => void }).__stopOpenSamples = () =>
+      clearInterval(timer);
+    setTimeout(() => clearInterval(timer), 30_000);
   });
 
   await firstPricingLink.click();
@@ -216,21 +213,28 @@ test("opens nested pricing dialogs with layered Escape behavior", async ({ page 
   await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Add Custom Model Pricing", exact: true })).toBeVisible();
 
-  await page.waitForTimeout(1200);
-  const openSamples = await page.evaluate(
-    () =>
-      (
-        window as unknown as {
-          __openSamples: { backdrops: number; fadingAncestors: number; outerHeight: number }[];
-        }
-      ).__openSamples,
-  );
+  // Both dialogs are up; give the 250ms animation room to finish, then stop sampling.
+  await page.waitForTimeout(400);
+  const openSamples = await page.evaluate(() => {
+    const scope = window as unknown as {
+      __openSamples: { backdrops: number; fadingAncestors: number }[];
+      __stopOpenSamples: () => void;
+    };
+    scope.__stopOpenSamples();
+    return scope.__openSamples;
+  });
+  expect(openSamples.length).toBeGreaterThan(0);
   expect(Math.max(...openSamples.map((sample) => sample.backdrops))).toBe(2);
   expect(Math.max(...openSamples.map((sample) => sample.fadingAncestors))).toBe(0);
 
-  // Frame 20 onwards the scale-in is over.
-  const settledHeights = new Set(openSamples.slice(20).map((sample) => sample.outerHeight));
-  expect([...settledHeights]).toHaveLength(1);
+  // The rows are still held, so this is the dialog at its reserved height.
+  const outerPanel = page.locator(".dialog-content").first();
+  const heightBeforeRows = (await outerPanel.boundingBox())?.height ?? 0;
+  expect(heightBeforeRows).toBeGreaterThan(0);
+
+  releasePricingRows();
+  await expect(page.getByText("gpt-4.1-mini", { exact: true })).toBeVisible();
+  expect((await outerPanel.boundingBox())?.height).toBe(heightBeforeRows);
 
   const modelInput = page.getByPlaceholder("e.g. my-org/private-llm");
   await expect(modelInput).toHaveValue(unpricedModels[0]);

--- a/frontend/e2e/tab-traces.spec.ts
+++ b/frontend/e2e/tab-traces.spec.ts
@@ -48,7 +48,7 @@ test("reloads traces on time range change and toggles the search box", async ({ 
 test("opens nested pricing dialogs with layered Escape behavior", async ({ page }) => {
   const createdAt = "2026-07-20T12:00:00Z";
   const unpricedModels = ["acme/private-chat", "acme/private-reasoner"];
-  const pricingRows = [
+  const pricingRows: Record<string, string | boolean | null>[] = [
     {
       id: "33333333-3333-4333-8333-333333333333",
       provider: "OpenAI",
@@ -146,6 +146,8 @@ test("opens nested pricing dialogs with layered Escape behavior", async ({ page 
       return;
     }
     if (pathname === "/api/llm-pricing" && request.method() === "GET") {
+      // Land the rows after the open animation, as a real fetch does.
+      await new Promise((resolve) => setTimeout(resolve, 400));
       await route.fulfill({ json: pricingRows });
       return;
     }
@@ -175,11 +177,60 @@ test("opens nested pricing dialogs with layered Escape behavior", async ({ page 
   const secondPricingLink = page.getByRole("link", { name: unpricedModels[1], exact: true });
   await expect(firstPricingLink).toBeVisible();
   await expect(secondPricingLink).toBeVisible();
+
+  // Each layer needs its own backdrop for depth, without either flash: a fading ancestor above
+  // a backdrop, or a panel that resizes once its rows land.
+  await page.evaluate(() => {
+    const samples: { backdrops: number; fadingAncestors: number; outerHeight: number }[] = [];
+    (window as unknown as { __openSamples: typeof samples }).__openSamples = samples;
+    let frames = 0;
+    const tick = (): void => {
+      const backdrops = Array.from(document.querySelectorAll(".dialog-backdrop"));
+      const fadingAncestors = backdrops.filter((backdrop) => {
+        let node = backdrop.parentElement;
+        while (node !== null && node !== document.body) {
+          if (Number(getComputedStyle(node).opacity) < 1) {
+            return true;
+          }
+          node = node.parentElement;
+        }
+        return false;
+      });
+      const outerPanel = document.querySelector(".dialog-content");
+      samples.push({
+        backdrops: backdrops.length,
+        fadingAncestors: fadingAncestors.length,
+        outerHeight: Math.round(outerPanel?.getBoundingClientRect().height ?? 0),
+      });
+      frames += 1;
+      if (frames < 60) {
+        requestAnimationFrame(tick);
+      }
+    };
+    requestAnimationFrame(tick);
+  });
+
   await firstPricingLink.click();
 
   await expect(page).toHaveURL(/tab=traces/);
   await expect(page.getByRole("heading", { name: "LLM Cost Table", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Add Custom Model Pricing", exact: true })).toBeVisible();
+
+  await page.waitForTimeout(1200);
+  const openSamples = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __openSamples: { backdrops: number; fadingAncestors: number; outerHeight: number }[];
+        }
+      ).__openSamples,
+  );
+  expect(Math.max(...openSamples.map((sample) => sample.backdrops))).toBe(2);
+  expect(Math.max(...openSamples.map((sample) => sample.fadingAncestors))).toBe(0);
+
+  // Frame 20 onwards the scale-in is over.
+  const settledHeights = new Set(openSamples.slice(20).map((sample) => sample.outerHeight));
+  expect([...settledHeights]).toHaveLength(1);
 
   const modelInput = page.getByPlaceholder("e.g. my-org/private-llm");
   await expect(modelInput).toHaveValue(unpricedModels[0]);

--- a/frontend/src/components/Alerts/wizard/AlertAiPrompt.vue
+++ b/frontend/src/components/Alerts/wizard/AlertAiPrompt.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { Loader2, Sparkles } from "lucide-vue-next";
 
 import Button from "@/components/ui/Button.vue";
@@ -27,6 +27,16 @@ const prompt = ref("");
 const loading = ref(false);
 const clarification = ref<string | null>(null);
 const error = ref<string | null>(null);
+
+const navigatorPlatformIsMac = computed((): boolean => {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  return (
+    navigator.platform.toLowerCase().startsWith("mac") ||
+    navigator.userAgent.includes("Mac")
+  );
+});
 
 onMounted(bootstrap);
 
@@ -103,6 +113,7 @@ async function submit(): Promise<void> {
         size="sm"
         class="ml-auto"
         :disabled="!prompt.trim() || !isReady || loading"
+        :title="navigatorPlatformIsMac ? 'Fill the form (⌘Enter)' : 'Fill the form (Ctrl+Enter)'"
         @click="submit"
       >
         <Loader2
@@ -110,11 +121,10 @@ async function submit(): Promise<void> {
           class="mr-1 h-3.5 w-3.5 animate-spin"
         />
         Fill the form
+        <span class="text-[11px] font-normal tracking-wide text-primary-foreground/80">
+          {{ navigatorPlatformIsMac ? "⌘↵" : "⌃↵" }}
+        </span>
       </Button>
-    </div>
-
-    <div class="mt-1.5 text-[11px] text-muted-foreground">
-      Ctrl or Cmd + Enter sends.
     </div>
 
     <p

--- a/frontend/src/components/DataTable/DataTablePanel.vue
+++ b/frontend/src/components/DataTable/DataTablePanel.vue
@@ -562,6 +562,14 @@ const isLLMPricingSelected = computed(() => {
   return parsed.kind === "detail" && parsed.id === LLM_PRICING_ROUTE_ID;
 });
 
+const initialPricingModels = computed(() => {
+  const rawModels = route.query.unpricedModel;
+  const models = Array.isArray(rawModels) ? rawModels : [rawModels];
+  return models.filter(
+    (model): model is string => typeof model === "string" && model.trim().length > 0,
+  );
+});
+
 watch(
   () => route.query.tab,
   async (tab) => {
@@ -655,7 +663,7 @@ onUnmounted(() => window.removeEventListener("keydown", handleCreateDialogEscape
     <template v-if="detailLoading" />
 
     <template v-else-if="isLLMPricingSelected">
-      <LLMPricingPanel />
+      <LLMPricingPanel :initial-models="initialPricingModels" />
     </template>
 
     <template v-else-if="!selectedTable">

--- a/frontend/src/components/DataTable/LLMPricingPanel.vue
+++ b/frontend/src/components/DataTable/LLMPricingPanel.vue
@@ -31,6 +31,7 @@ const syncing = ref(false);
 const clearing = ref(false);
 const error = ref("");
 const search = ref("");
+const isSearchFocused = ref(false);
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let pollGeneration = 0;
 
@@ -186,6 +187,14 @@ function openAddDialog(): void {
   showAddDialog.value = true;
 }
 
+function clearFocusedSearchOnEscape(): boolean {
+  if (!isSearchFocused.value || !search.value) {
+    return false;
+  }
+  search.value = "";
+  return true;
+}
+
 function startEdit(row: LLMPricingRow): void {
   editingId.value = row.id;
   editInput.value = {
@@ -269,16 +278,19 @@ function badgeFor(row: LLMPricingRow): { label: string; classes: string } | null
   return null;
 }
 
+if (props.autoOpenAddDialog) {
+  openAddDialog();
+}
+
 onMounted(() => {
-  if (props.autoOpenAddDialog) {
-    openAddDialog();
-  }
   loadAll({ startPoll: true });
 });
 
 onBeforeUnmount(() => {
   stopPolling();
 });
+
+defineExpose({ clearFocusedSearchOnEscape });
 </script>
 
 <template>
@@ -353,6 +365,8 @@ onBeforeUnmount(() => {
     <Input
       v-model="search"
       placeholder="Search model or provider…"
+      @focus="isSearchFocused = true"
+      @blur="isSearchFocused = false"
     />
 
     <div

--- a/frontend/src/components/DataTable/LLMPricingPanel.vue
+++ b/frontend/src/components/DataTable/LLMPricingPanel.vue
@@ -15,11 +15,13 @@ import { llmPricingApi } from "@/services/api";
 interface Props {
   initialModels?: string[];
   embedded?: boolean;
+  autoOpenAddDialog?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   initialModels: () => [],
   embedded: false,
+  autoOpenAddDialog: false,
 });
 
 const rows = ref<LLMPricingRow[]>([]);
@@ -268,6 +270,9 @@ function badgeFor(row: LLMPricingRow): { label: string; classes: string } | null
 }
 
 onMounted(() => {
+  if (props.autoOpenAddDialog) {
+    openAddDialog();
+  }
   loadAll({ startPoll: true });
 });
 

--- a/frontend/src/components/DataTable/LLMPricingPanel.vue
+++ b/frontend/src/components/DataTable/LLMPricingPanel.vue
@@ -12,6 +12,14 @@ import Label from "@/components/ui/Label.vue";
 import { formatDate } from "@/lib/utils";
 import { llmPricingApi } from "@/services/api";
 
+interface Props {
+  initialModels?: string[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  initialModels: () => [],
+});
+
 const rows = ref<LLMPricingRow[]>([]);
 const syncStatus = ref<LLMPricingSyncStatus | null>(null);
 const loading = ref(false);
@@ -49,6 +57,17 @@ const filteredRows = computed(() => {
 const customizedRowsCount = computed(
   () => rows.value.filter((row) => row.is_custom || row.is_override).length,
 );
+
+function rowMatchesModel(row: LLMPricingRow, model: string): boolean {
+  return row.model === model || (row.provider !== null && `${row.provider}/${row.model}` === model);
+}
+
+const suggestedModel = computed(() => {
+  const missingModel = props.initialModels.find(
+    (model) => !rows.value.some((row) => rowMatchesModel(row, model)),
+  );
+  return missingModel ?? props.initialModels[0] ?? "";
+});
 
 function stopPolling(): void {
   pollGeneration += 1;
@@ -154,6 +173,13 @@ async function clearAll(): Promise<void> {
   } finally {
     clearing.value = false;
   }
+}
+
+function openAddDialog(): void {
+  if (!addForm.value.model && suggestedModel.value) {
+    addForm.value = { ...addForm.value, model: suggestedModel.value };
+  }
+  showAddDialog.value = true;
 }
 
 function startEdit(row: LLMPricingRow): void {
@@ -291,7 +317,7 @@ onBeforeUnmount(() => {
         <Button
           variant="outline"
           size="sm"
-          @click="showAddDialog = true"
+          @click="openAddDialog"
         >
           <Plus class="w-4 h-4 mr-1" />
           <span class="hidden sm:inline">Add Custom Model</span>

--- a/frontend/src/components/DataTable/LLMPricingPanel.vue
+++ b/frontend/src/components/DataTable/LLMPricingPanel.vue
@@ -294,7 +294,8 @@ defineExpose({ clearFocusedSearchOnEscape });
 </script>
 
 <template>
-  <div class="space-y-4">
+  <!-- Reserve the dialog's full height so the late-arriving rows cannot resize it. -->
+  <div :class="embedded ? 'flex min-h-[85vh] flex-col gap-4' : 'space-y-4'">
     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
       <div
         v-if="!embedded"
@@ -379,7 +380,7 @@ defineExpose({ clearFocusedSearchOnEscape });
     <Card
       variant="flat"
       :hover="false"
-      class="p-0 overflow-hidden"
+      :class="embedded ? 'p-0 overflow-hidden flex-1' : 'p-0 overflow-hidden'"
     >
       <div class="overflow-x-auto">
         <table class="w-full min-w-[640px] text-sm">

--- a/frontend/src/components/DataTable/LLMPricingPanel.vue
+++ b/frontend/src/components/DataTable/LLMPricingPanel.vue
@@ -14,10 +14,12 @@ import { llmPricingApi } from "@/services/api";
 
 interface Props {
   initialModels?: string[];
+  embedded?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   initialModels: () => [],
+  embedded: false,
 });
 
 const rows = ref<LLMPricingRow[]>([]);
@@ -277,7 +279,10 @@ onBeforeUnmount(() => {
 <template>
   <div class="space-y-4">
     <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-      <div class="min-w-0">
+      <div
+        v-if="!embedded"
+        class="min-w-0"
+      >
         <h2 class="text-xl font-semibold flex items-center gap-2">
           <Coins class="w-5 h-5" />
           LLM Cost Table
@@ -305,7 +310,10 @@ onBeforeUnmount(() => {
           </span>
         </div>
       </div>
-      <div class="flex flex-wrap items-center gap-2 md:flex-nowrap md:justify-end">
+      <div
+        class="flex flex-wrap items-center gap-2 md:flex-nowrap md:justify-end"
+        :class="{ 'md:ml-auto': embedded }"
+      >
         <Button
           variant="outline"
           size="sm"

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -899,6 +899,7 @@ onMounted(async () => {
         v-if="pricingDialogModel"
         :key="pricingDialogModel"
         :initial-models="pricingDialogModels"
+        auto-open-add-dialog
         embedded
       />
     </Dialog>

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -7,6 +7,7 @@ import type { CredentialListItem } from "@/types/credential";
 import type { LLMTraceDetail, LLMTraceListItem, TraceStatsResponse, TraceTimeRange } from "@/types/trace";
 import type { WorkflowListItem } from "@/types/workflow";
 
+import LLMPricingPanel from "@/components/DataTable/LLMPricingPanel.vue";
 import TraceDurationChart, { type TraceSpan } from "@/components/Traces/TraceDurationChart.vue";
 import TraceJsonContent from "@/components/Traces/TraceJsonContent.vue";
 import TracesStatsHeader from "@/components/Traces/TracesStatsHeader.vue";
@@ -82,6 +83,8 @@ const detailLoading = ref(false);
 const detailError = ref("");
 const selectedTrace = ref<LLMTraceDetail | null>(null);
 const selectedTraceIndex = ref(-1);
+const pricingDialogOpen = ref(false);
+const pricingDialogModel = ref<string | null>(null);
 const clearing = ref(false);
 const copiedRequest = ref(false);
 const copiedResponse = ref(false);
@@ -94,6 +97,9 @@ const tracePositionLabel = computed(() =>
   selectedTraceIndex.value >= 0
     ? `${selectedTraceIndex.value + 1} / ${traces.value.length}`
     : "Direct trace",
+);
+const pricingDialogModels = computed(() =>
+  pricingDialogModel.value ? [pricingDialogModel.value] : [],
 );
 
 interface ToolCallEntry {
@@ -552,6 +558,21 @@ function closeDetail(): void {
   }
 }
 
+function openPricingDialog(model: string): void {
+  pricingDialogModel.value = model;
+  pricingDialogOpen.value = true;
+}
+
+function closePricingDialog(): void {
+  pricingDialogOpen.value = false;
+  pricingDialogModel.value = null;
+}
+
+function closeOverlays(): void {
+  closeDetail();
+  closePricingDialog();
+}
+
 async function openTraceFromRoute(): Promise<void> {
   const rawTraceId = route.query.traceId;
   const traceId = Array.isArray(rawTraceId) ? rawTraceId[0] : rawTraceId;
@@ -641,7 +662,7 @@ onMounted(async () => {
   await loadWorkflows();
   await loadAll();
   await openTraceFromRoute();
-  const unsub = onDismissOverlays(closeDetail);
+  const unsub = onDismissOverlays(closeOverlays);
   document.addEventListener("keydown", handleKeyDown);
   onBeforeUnmount(() => {
     unsub();
@@ -720,6 +741,7 @@ onMounted(async () => {
     <TracesStatsHeader
       :stats="stats"
       :loading="statsLoading"
+      @configure-pricing="openPricingDialog"
     />
 
     <div class="space-y-4">
@@ -865,6 +887,21 @@ onMounted(async () => {
         </button>
       </Card>
     </div>
+
+    <Dialog
+      :open="pricingDialogOpen"
+      title="LLM Cost Table"
+      size="6xl"
+      close-on-back
+      @close="closePricingDialog"
+    >
+      <LLMPricingPanel
+        v-if="pricingDialogModel"
+        :key="pricingDialogModel"
+        :initial-models="pricingDialogModels"
+        embedded
+      />
+    </Dialog>
 
     <Dialog
       :open="detailOpen"

--- a/frontend/src/components/Traces/TracesPanel.vue
+++ b/frontend/src/components/Traces/TracesPanel.vue
@@ -28,6 +28,10 @@ interface SelectOption {
   label: string;
 }
 
+interface PricingPanelExposed {
+  clearFocusedSearchOnEscape(): boolean;
+}
+
 const TRACE_SOURCE_LABELS: Record<string, string> = {
   workflow: "Workflow LLM",
   assistant: "AI Assistant",
@@ -85,6 +89,7 @@ const selectedTrace = ref<LLMTraceDetail | null>(null);
 const selectedTraceIndex = ref(-1);
 const pricingDialogOpen = ref(false);
 const pricingDialogModel = ref<string | null>(null);
+const pricingPanelRef = ref<PricingPanelExposed | null>(null);
 const clearing = ref(false);
 const copiedRequest = ref(false);
 const copiedResponse = ref(false);
@@ -568,6 +573,13 @@ function closePricingDialog(): void {
   pricingDialogModel.value = null;
 }
 
+function handlePricingDialogEscape(event: KeyboardEvent): void {
+  if (pricingPanelRef.value?.clearFocusedSearchOnEscape()) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+}
+
 function closeOverlays(): void {
   closeDetail();
   closePricingDialog();
@@ -894,9 +906,11 @@ onMounted(async () => {
       size="6xl"
       close-on-back
       @close="closePricingDialog"
+      @escape="handlePricingDialogEscape"
     >
       <LLMPricingPanel
         v-if="pricingDialogModel"
+        ref="pricingPanelRef"
         :key="pricingDialogModel"
         :initial-models="pricingDialogModels"
         auto-open-add-dialog

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { RouterLink, type RouteLocationRaw } from "vue-router";
 
 import type { TraceStatsResponse } from "@/types/trace";
 
@@ -164,7 +165,14 @@ const callsOverTimeSeries = computed(() => {
 });
 
 const hasCostData = computed(() => costByModelSeries.value.some((v) => v > 0));
-const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) > 0);
+const unpricedModels = computed(() => kpis.value?.unpriced_models ?? []);
+const showUnpriced = computed(() => unpricedModels.value.length > 0);
+const pricingTableRoute = computed<RouteLocationRaw>(() => ({
+  query: {
+    tab: "datatable/llm-pricing",
+    unpricedModel: unpricedModels.value,
+  },
+}));
 </script>
 
 <template>
@@ -278,13 +286,14 @@ const showUnpriced = computed(() => (kpis.value?.unpriced_models?.length ?? 0) >
           :options="costByModelOptions"
           :series="costByModelSeries"
         />
-        <div
+        <RouterLink
           v-if="showUnpriced"
-          class="mt-2 text-[11px] text-muted-foreground break-words"
+          :to="pricingTableRoute"
+          class="mt-2 inline-block max-w-full text-[11px] text-muted-foreground underline decoration-muted-foreground/60 underline-offset-2 transition-colors hover:text-primary hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 rounded-sm break-words"
         >
-          {{ kpis?.unpriced_models.length }} model(s) without pricing:
-          <span class="font-mono">{{ kpis?.unpriced_models.join(", ") }}</span>
-        </div>
+          {{ unpricedModels.length }} model(s) without pricing:
+          <span class="font-mono">{{ unpricedModels.join(", ") }}</span>
+        </RouterLink>
       </Card>
       <Card
         variant="flat"

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { RouterLink, type RouteLocationRaw } from "vue-router";
 
 import type { TraceStatsResponse } from "@/types/trace";
 
@@ -23,6 +22,9 @@ interface ApexDonutTooltipContext {
 }
 
 const props = defineProps<Props>();
+const emit = defineEmits<{
+  (e: "configure-pricing", model: string): void;
+}>();
 const themeStore = useThemeStore();
 
 function fmtNum(value: number): string {
@@ -167,12 +169,6 @@ const callsOverTimeSeries = computed(() => {
 const hasCostData = computed(() => costByModelSeries.value.some((v) => v > 0));
 const unpricedModels = computed(() => kpis.value?.unpriced_models ?? []);
 const showUnpriced = computed(() => unpricedModels.value.length > 0);
-const pricingTableRoute = computed<RouteLocationRaw>(() => ({
-  query: {
-    tab: "datatable/llm-pricing",
-    unpricedModel: unpricedModels.value,
-  },
-}));
 </script>
 
 <template>
@@ -286,14 +282,22 @@ const pricingTableRoute = computed<RouteLocationRaw>(() => ({
           :options="costByModelOptions"
           :series="costByModelSeries"
         />
-        <RouterLink
+        <div
           v-if="showUnpriced"
-          :to="pricingTableRoute"
-          class="mt-2 inline-block max-w-full text-[11px] text-muted-foreground underline decoration-muted-foreground/60 underline-offset-2 transition-colors hover:text-primary hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 rounded-sm break-words"
+          class="mt-2 max-w-full text-[11px] text-muted-foreground break-words"
         >
           {{ unpricedModels.length }} model(s) without pricing:
-          <span class="font-mono">{{ unpricedModels.join(", ") }}</span>
-        </RouterLink>
+          <template
+            v-for="(model, index) in unpricedModels"
+            :key="model"
+          >
+            <a
+              href="#"
+              class="font-mono underline decoration-muted-foreground/60 underline-offset-2 transition-colors hover:text-primary hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 rounded-sm"
+              @click.prevent="emit('configure-pricing', model)"
+            >{{ model }}</a><span v-if="index < unpricedModels.length - 1">, </span>
+          </template>
+        </div>
       </Card>
       <Card
         variant="flat"

--- a/frontend/src/components/Traces/TracesStatsHeader.vue
+++ b/frontend/src/components/Traces/TracesStatsHeader.vue
@@ -284,7 +284,7 @@ const showUnpriced = computed(() => unpricedModels.value.length > 0);
         />
         <div
           v-if="showUnpriced"
-          class="mt-2 max-w-full text-[11px] text-muted-foreground break-words"
+          class="unpriced-models-notice mt-2 max-w-full text-[11px] text-muted-foreground break-words"
         >
           {{ unpricedModels.length }} model(s) without pricing:
           <template
@@ -336,6 +336,13 @@ const showUnpriced = computed(() => unpricedModels.value.length > 0);
   border-color: hsl(var(--border)) !important;
   color: hsl(var(--popover-foreground)) !important;
   box-shadow: 0 12px 30px hsl(var(--background) / 0.3) !important;
+}
+
+.unpriced-models-notice {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .trace-chart-card :deep(.apexcharts-tooltip-title) {

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -1,3 +1,23 @@
+<script lang="ts">
+import { ref as createRef } from "vue";
+
+const dialogStack = createRef<symbol[]>([]);
+
+function syncBodyScrollLock(): void {
+  document.body.style.overflow = dialogStack.value.length > 0 ? "hidden" : "";
+}
+
+function addToDialogStack(dialogId: symbol): void {
+  dialogStack.value = [...dialogStack.value.filter((id) => id !== dialogId), dialogId];
+  syncBodyScrollLock();
+}
+
+function removeFromDialogStack(dialogId: symbol): void {
+  dialogStack.value = dialogStack.value.filter((id) => id !== dialogId);
+  syncBodyScrollLock();
+}
+</script>
+
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, ref, useSlots, watch } from "vue";
 import { Maximize2, Minimize2, X } from "lucide-vue-next";
@@ -31,6 +51,16 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const isFullscreen = ref(props.defaultFullscreen);
+const dialogId = Symbol("dialog");
+const isTopmost = computed(() => {
+  const stack = dialogStack.value;
+  return props.open && stack[stack.length - 1] === dialogId;
+});
+const isBackdropOwner = computed(() => props.open && dialogStack.value[0] === dialogId);
+const dialogZIndex = computed(() => {
+  const stackPosition = Math.max(dialogStack.value.indexOf(dialogId), 0);
+  return 50 + stackPosition * 10;
+});
 
 const sizeClasses = computed(() => {
   if (isFullscreen.value) {
@@ -65,21 +95,19 @@ const { pushDialogHistoryEntry, removeDialogHistoryEntry } = useDialogBackHistor
 });
 
 function handleEscape(event: KeyboardEvent): void {
-  if (event.key === "Escape") {
-    emit("escape", event);
-    if (!props.closeOnEscape) {
-      return;
-    }
-    if (event.defaultPrevented) {
-      return;
-    }
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    if (isFullscreen.value) {
-      isFullscreen.value = false;
-    } else {
-      emit("close");
-    }
+  if (event.key !== "Escape" || !isTopmost.value) {
+    return;
+  }
+  emit("escape", event);
+  if (!props.closeOnEscape || event.defaultPrevented) {
+    return;
+  }
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  if (isFullscreen.value) {
+    isFullscreen.value = false;
+  } else {
+    emit("close");
   }
 }
 
@@ -89,7 +117,7 @@ watch(
   () => props.open,
   (open) => {
     if (open) {
-      document.body.style.overflow = "hidden";
+      addToDialogStack(dialogId);
       isFullscreen.value = props.defaultFullscreen;
       window.addEventListener("keydown", handleEscape, captureOptions);
       pushDialogHistoryEntry();
@@ -97,7 +125,7 @@ watch(
         containerRef.value?.focus();
       });
     } else {
-      document.body.style.overflow = "";
+      removeFromDialogStack(dialogId);
       isFullscreen.value = props.defaultFullscreen;
       window.removeEventListener("keydown", handleEscape, captureOptions);
       removeDialogHistoryEntry();
@@ -108,6 +136,7 @@ watch(
 
 onUnmounted(() => {
   window.removeEventListener("keydown", handleEscape, captureOptions);
+  removeFromDialogStack(dialogId);
   removeDialogHistoryEntry();
 });
 
@@ -126,9 +155,11 @@ function toggleFullscreen(): void {
           'fixed inset-0 z-50 flex items-center justify-center',
           isFullscreen ? 'p-0' : 'p-4 sm:p-6'
         ]"
+        :style="{ zIndex: dialogZIndex }"
         tabindex="0"
       >
         <div
+          v-if="isBackdropOwner"
           class="dialog-backdrop fixed inset-0"
           @click="emit('close')"
         />

--- a/frontend/src/components/ui/Dialog.vue
+++ b/frontend/src/components/ui/Dialog.vue
@@ -1,28 +1,15 @@
-<script lang="ts">
-import { ref as createRef } from "vue";
-
-const dialogStack = createRef<symbol[]>([]);
-
-function syncBodyScrollLock(): void {
-  document.body.style.overflow = dialogStack.value.length > 0 ? "hidden" : "";
-}
-
-function addToDialogStack(dialogId: symbol): void {
-  dialogStack.value = [...dialogStack.value.filter((id) => id !== dialogId), dialogId];
-  syncBodyScrollLock();
-}
-
-function removeFromDialogStack(dialogId: symbol): void {
-  dialogStack.value = dialogStack.value.filter((id) => id !== dialogId);
-  syncBodyScrollLock();
-}
-</script>
-
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, ref, useSlots, watch } from "vue";
 import { Maximize2, Minimize2, X } from "lucide-vue-next";
 
 import { useDialogBackHistory } from "@/composables/useDialogBackHistory";
+import {
+  addToDialogStack,
+  dialogStackPosition,
+  isBottommostDialog,
+  isTopmostDialog,
+  removeFromDialogStack,
+} from "@/composables/useDialogStack";
 
 const slots = useSlots();
 const hasHeaderActions = computed(() => typeof slots["header-actions"] === "function");
@@ -52,15 +39,9 @@ const props = withDefaults(defineProps<Props>(), {
 
 const isFullscreen = ref(props.defaultFullscreen);
 const dialogId = Symbol("dialog");
-const isTopmost = computed(() => {
-  const stack = dialogStack.value;
-  return props.open && stack[stack.length - 1] === dialogId;
-});
-const isBackdropOwner = computed(() => props.open && dialogStack.value[0] === dialogId);
-const dialogZIndex = computed(() => {
-  const stackPosition = Math.max(dialogStack.value.indexOf(dialogId), 0);
-  return 50 + stackPosition * 10;
-});
+const isTopmost = computed(() => props.open && isTopmostDialog(dialogId));
+const isNestedBackdrop = computed(() => props.open && !isBottommostDialog(dialogId));
+const dialogZIndex = computed(() => 50 + dialogStackPosition(dialogId) * 10);
 
 const sizeClasses = computed(() => {
   if (isFullscreen.value) {
@@ -147,7 +128,10 @@ function toggleFullscreen(): void {
 
 <template>
   <Teleport to="body">
-    <Transition name="dialog">
+    <Transition
+      name="dialog"
+      :duration="{ enter: 250, leave: 200 }"
+    >
       <div
         v-if="open"
         ref="containerRef"
@@ -159,8 +143,7 @@ function toggleFullscreen(): void {
         tabindex="0"
       >
         <div
-          v-if="isBackdropOwner"
-          class="dialog-backdrop fixed inset-0"
+          :class="['dialog-backdrop fixed inset-0', isNestedBackdrop ? 'dialog-backdrop-nested' : '']"
           @click="emit('close')"
         />
         <div
@@ -262,8 +245,16 @@ function toggleFullscreen(): void {
 
 <style scoped>
 .dialog-backdrop {
-  background: hsl(0 0% 0% / 0.65);
-  backdrop-filter: blur(12px);
+  --dialog-backdrop-tint: 0.65;
+  --dialog-backdrop-blur: 12px;
+  background: hsl(0 0% 0% / var(--dialog-backdrop-tint));
+  backdrop-filter: blur(var(--dialog-backdrop-blur));
+}
+
+/* A stacked dialog pushes the one under it back rather than dimming the page a second time. */
+.dialog-backdrop-nested {
+  --dialog-backdrop-tint: 0.4;
+  --dialog-backdrop-blur: 8px;
 }
 
 .dialog-content {
@@ -271,7 +262,6 @@ function toggleFullscreen(): void {
     0 0 0 1px hsl(var(--border) / 0.5),
     0 0 1px hsl(0 0% 0% / 0.0125),
     0 0 1px hsl(0 0% 0% / 0.0075);
-  animation: dialog-scale-in 0.25s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .dark .dialog-content {
@@ -289,6 +279,39 @@ function toggleFullscreen(): void {
   to {
     opacity: 1;
     transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes dialog-scale-out {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.98) translateY(4px);
+  }
+}
+
+@keyframes dialog-backdrop-in {
+  from {
+    background-color: hsl(0 0% 0% / 0);
+    backdrop-filter: blur(0px);
+  }
+  to {
+    background-color: hsl(0 0% 0% / var(--dialog-backdrop-tint));
+    backdrop-filter: blur(var(--dialog-backdrop-blur));
+  }
+}
+
+@keyframes dialog-backdrop-out {
+  from {
+    background-color: hsl(0 0% 0% / var(--dialog-backdrop-tint));
+    backdrop-filter: blur(var(--dialog-backdrop-blur));
+  }
+  to {
+    background-color: hsl(0 0% 0% / 0);
+    backdrop-filter: blur(0px);
   }
 }
 
@@ -321,20 +344,20 @@ function toggleFullscreen(): void {
   background: hsl(var(--muted));
 }
 
-.dialog-enter-active {
-  transition: opacity 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+/* Fading the container would make the backdrop its own backdrop root and snap the blur on at the end. */
+.dialog-enter-active .dialog-backdrop {
+  animation: dialog-backdrop-in 0.25s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.dialog-leave-active {
-  transition: opacity 0.2s ease;
+.dialog-leave-active .dialog-backdrop {
+  animation: dialog-backdrop-out 0.2s ease both;
 }
 
-.dialog-enter-from,
-.dialog-leave-to {
-  opacity: 0;
+.dialog-enter-active .dialog-content {
+  animation: dialog-scale-in 0.25s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.dialog-enter-from .dialog-content {
-  transform: scale(0.96) translateY(8px);
+.dialog-leave-active .dialog-content {
+  animation: dialog-scale-out 0.2s ease both;
 }
 </style>

--- a/frontend/src/composables/useDialogStack.ts
+++ b/frontend/src/composables/useDialogStack.ts
@@ -1,0 +1,36 @@
+import { ref } from "vue";
+
+/** Ids of the currently open dialogs, bottom-most first. */
+const dialogStack = ref<symbol[]>([]);
+
+
+function syncBodyScrollLock(): void {
+  document.body.style.overflow = dialogStack.value.length > 0 ? "hidden" : "";
+}
+
+export function addToDialogStack(dialogId: symbol): void {
+  dialogStack.value = [...dialogStack.value.filter((id) => id !== dialogId), dialogId];
+  syncBodyScrollLock();
+}
+
+export function removeFromDialogStack(dialogId: symbol): void {
+  dialogStack.value = dialogStack.value.filter((id) => id !== dialogId);
+  syncBodyScrollLock();
+}
+
+export function isTopmostDialog(dialogId: symbol): boolean {
+  const stack = dialogStack.value;
+  return stack[stack.length - 1] === dialogId;
+}
+
+export function isBottommostDialog(dialogId: symbol): boolean {
+  return dialogStack.value[0] === dialogId;
+}
+
+export function dialogStackPosition(dialogId: symbol): number {
+  return Math.max(dialogStack.value.indexOf(dialogId), 0);
+}
+
+export function hasOpenDialog(): boolean {
+  return dialogStack.value.length > 0;
+}

--- a/frontend/src/composables/useOverlayBackHandler.ts
+++ b/frontend/src/composables/useOverlayBackHandler.ts
@@ -1,5 +1,7 @@
 import { onMounted, onUnmounted } from "vue";
 
+import { hasOpenDialog } from "@/composables/useDialogStack";
+
 export const DISMISS_OVERLAYS_EVENT = "heym:dismiss-overlays";
 
 /**
@@ -24,6 +26,10 @@ export function pushOverlayState(): void {
 export function useOverlayBackHandler(): void {
   function handleKeyDown(event: KeyboardEvent): void {
     if (event.key === "Escape") {
+      // Dialogs dismiss themselves one layer at a time.
+      if (hasOpenDialog()) {
+        return;
+      }
       if (document.body.dataset.heymOverlayEscapeTrap === "true") {
         return;
       }

--- a/frontend/src/docs/content/reference/workflow-analysis.md
+++ b/frontend/src/docs/content/reference/workflow-analysis.md
@@ -48,7 +48,7 @@ The **Improvement areas** section always runs four explicit checks:
 1. **Error coverage** — if the canvas has no [Error Handler](../nodes/error-handler-node.md) node and no error workflow is configured, the report calls this out and recommends adding error handling.
 2. **Time saved** — if no estimated time saved per run is set, the report recommends configuring one so the [Analytics](../tabs/analytics-tab.md) **Time Saved** metric can populate.
 3. **Network nodes** — for nodes that make network calls (such as [HTTP](../nodes/http-node.md) and integration nodes), the report recommends node-specific error handling (retry and/or continue-on-error) on those nodes.
-4. **Alerts** — when the workflow has a trigger or input node (so it runs on its own in production) but no [alerts](../tabs/alerts-tab.md) are configured for it, the report recommends setting up alerts before going to prod.
+4. **Alerts** — when no [alerts](../tabs/alerts-tab.md) are configured for the workflow, the report recommends setting up alerts before going to prod.
 
 ### Run Analyzer from Properties
 

--- a/frontend/src/docs/content/reference/workflow-analysis.md
+++ b/frontend/src/docs/content/reference/workflow-analysis.md
@@ -43,11 +43,12 @@ Both actions first **run the workflow** (when it is valid and runnable) and incl
 
 The generated report covers three sections, in order: **Improvement areas** (concrete suggestions, including a **security** angle whenever the workflow touches credentials, user input, external requests, or data exposure), the workflow's **Purpose**, and **What it does** (a step-by-step walk through the nodes).
 
-The **Improvement areas** section always runs three explicit checks:
+The **Improvement areas** section always runs four explicit checks:
 
 1. **Error coverage** — if the canvas has no [Error Handler](../nodes/error-handler-node.md) node and no error workflow is configured, the report calls this out and recommends adding error handling.
 2. **Time saved** — if no estimated time saved per run is set, the report recommends configuring one so the [Analytics](../tabs/analytics-tab.md) **Time Saved** metric can populate.
 3. **Network nodes** — for nodes that make network calls (such as [HTTP](../nodes/http-node.md) and integration nodes), the report recommends node-specific error handling (retry and/or continue-on-error) on those nodes.
+4. **Alerts** — when the workflow has a trigger or input node (so it runs on its own in production) but no [alerts](../tabs/alerts-tab.md) are configured for it, the report recommends setting up alerts before going to prod.
 
 ### Run Analyzer from Properties
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -150,11 +150,16 @@ function openCredentialsTab(): void {
 }
 
 watch(activeTab, (newTab) => {
-  const query: Record<string, string> = newTab === "workflows" ? {} : { tab: newTab };
-  if (newTab === "traces" && typeof route.query.traceId === "string") {
-    query.traceId = route.query.traceId;
+  const routeTab = Array.isArray(route.query.tab) ? route.query.tab[0] : route.query.tab;
+  const isDataTableSubRoute =
+    newTab === "datatable" && typeof routeTab === "string" && routeTab.startsWith("datatable/");
+  if (!isDataTableSubRoute) {
+    const query: Record<string, string> = newTab === "workflows" ? {} : { tab: newTab };
+    if (newTab === "traces" && typeof route.query.traceId === "string") {
+      query.traceId = route.query.traceId;
+    }
+    router.replace({ query });
   }
-  router.replace({ query });
 
   if (newTab === "workflows") {
     quickDrawerStore.syncPreferencesFromStorage();


### PR DESCRIPTION
## What this does

Three pieces of work landed on this branch. The first is the feature it was opened for, the second and third are fixes for problems that surfaced while it was open.

## Price a trace model in one click

The Traces stats header lists the models it could not price. Those names are now links. Clicking one opens the **LLM Cost Table** in a dialog with **Add Custom Model Pricing** already open and the model name filled in, so pricing a model no longer means a trip to the DataTable tab.

Two stacked dialogs turned out to be something the shared `Dialog` component had never really handled, so a good part of this PR is fixing that properly:

- **Escape unwinds one layer per press.** `useOverlayBackHandler` registers a window keydown listener in the capture phase, so it ran ahead of every dialog, called `dismissAllOverlays()` and then `preventDefault()`, which `Dialog.handleEscape` reads as "someone else handled this". Dialog's own close-on-escape had therefore never run at all, and one press collapsed the whole stack. It now defers while any dialog is open. Escape in a filled search box clears the box first and closes the dialog on the next press.
- **No flash behind the dialog on open.** The backdrop carries `backdrop-filter: blur()` and sat inside a container whose opacity was animated from 0 to 1. An ancestor below opacity 1 makes the element its own backdrop root, so the blur stayed inert for the whole 250ms and snapped on at the exact frame opacity reached 1. The container no longer fades. The backdrop animates its own tint and blur, and the panel its own opacity and transform.
- **Each layer has depth.** A stacked dialog used to float on an unchanged background, because only the bottom-most dialog drew a backdrop. Every layer now dims and blurs what sits under it, the nested one more lightly than the first.
- **The Cost Table dialog opens at its final size.** It opened empty and jumped from 348px to its 612px cap in a single frame when the pricing rows arrived. Being vertically centred, it expanded in both directions at once. Embedded in a dialog, the panel now reserves the full height up front.

The shared dialog stack moved out of `Dialog.vue` into `composables/useDialogStack.ts` so the global Escape handler can read it.

## Alerts

Two changes to the alert wizard. The standalone "Ctrl or Cmd + Enter sends." caption is gone, replaced by a keyboard indicator inside the Fill the form button. The alert drafting prompt now marks `description` as required, so AI generated alerts always carry a natural English sentence describing what the alert watches instead of getting one only sometimes.

`POST /analyze-workflow` also derives an `analysisContext` block into its system prompt, so the error handling, time saved and alerts recommendations only appear when the workflow actually needs them rather than in every report.

## Coding agent pull requests

`update_existing_pr` adopted the token account's most recently updated open pull request whenever the configured branch matched nothing. With several board cards running against one repository under one bot token, every run resolved to whichever PR had been touched last, and an unrelated alerts task pushed its work onto this branch and reused this PR number. Adoption is now tied back to the configured branch: a branch that names a pull request resolves to that PR, and a branch carrying the same task slug is adopted across agent prefixes so one card keeps one pull request. Anything else opens its own PR.

## Tests

`frontend/e2e/tab-traces.spec.ts` covers the layered Escape behaviour and samples the open animation frame by frame: one backdrop per layer, no fading ancestor above a backdrop, and a panel height that stops moving once the rows land. Backend coverage in `test_workflow_analysis_context.py`, `test_alert_ai_draft.py` and `test_coding_agent_pr_publish.py`.

`./check.sh` passes with 3153 backend tests, and the full Playwright suite passes with 137 tests.

## Screenshots

![codex-traces-models-without-pricing-dialog-unpriced-pricing-dialogs.png](https://github.com/heymrun/heym/releases/download/codex-pr-assets/codex-traces-models-without-pricing-dialog-unpriced-pricing-dialogs.png)