### PR TITLE
Preserve existing agent model assignments in canvas AI chat

### DIFF
--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -2603,7 +2603,11 @@ function applyWorkflowChanges(showMessage = true): void {
       }
     }
     if (isPlaceholderOrInvalidModel(model)) {
-      data.model = existingAgent?.data?.model || effectiveModel || "";
+      if (mergedNode.type === "agent" && existingAgent) {
+        data.model = existingAgent.data?.model ?? "";
+      } else {
+        data.model = effectiveModel || "";
+      }
     }
 
     const fb = data.fallbackCredentialId as string | undefined;

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -2593,6 +2593,9 @@ function applyWorkflowChanges(showMessage = true): void {
     const credId = data.credentialId as string | undefined;
     const model = data.model as string | undefined;
 
+    const existingAgent =
+      mergedNode.type === "agent" ? findMatchingExistingAgentNode(mergedNode) : undefined;
+
     if (isPlaceholderOrInvalidCredential(credId)) {
       data.credentialId = effectiveCredentialId || "";
       if (!effectiveCredentialId) {
@@ -2600,7 +2603,7 @@ function applyWorkflowChanges(showMessage = true): void {
       }
     }
     if (isPlaceholderOrInvalidModel(model)) {
-      data.model = effectiveModel || "";
+      data.model = existingAgent?.data?.model || effectiveModel || "";
     }
 
     const fb = data.fallbackCredentialId as string | undefined;


### PR DESCRIPTION
## Change Summary

Fixed the canvas AI assistant (Ctrl+I / chat input) so sending a chat message no longer overwrites the model assignment of existing agent nodes.

The root cause was in `applyWorkflowChanges` (`frontend/src/components/Panels/DebugPanel.vue`), where the fallback `existingAgent?.data?.model || effectiveModel` filled in the currently selected chat model whenever the AI returned an agent with an empty/placeholder model. Because the `||` fallback ignored an existing agent that legitimately had no explicit model (model resolved via its credential), every existing agent got stamped with the chat's selected model.

The fix branches on whether the incoming agent matches an existing canvas agent (by id or label): matched agents keep their existing `data.model` untouched (empty stays empty), and only newly created agents fall back to the selected model. Non-agent LLM nodes retain their previous behavior.

Validation: `SECRET_KEY=... ENCRYPTION_KEY=... ./check.sh` passes — frontend lint + typecheck clean, backend Ruff format/check clean, and all 3184 backend tests pass.

## Screenshots

> ⚠️ This pull request changes UI/frontend files, but the coding agent did not capture a screenshot. Add one manually if a visual review is needed.