### PR TITLE
Preserve existing LLM node model when applying AI workflow changes

### DIFF
--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -2490,8 +2490,10 @@ function isMarkdownSkillFile(file: AgentSkillFile): boolean {
   return file.path.toLowerCase().endsWith(".md");
 }
 
-function findMatchingExistingAgentNode(node: WorkflowNode): WorkflowNode | undefined {
-  const byId = workflowStore.nodes.find((existingNode) => existingNode.type === "agent" && existingNode.id === node.id);
+function findMatchingExistingNode(node: WorkflowNode): WorkflowNode | undefined {
+  const byId = workflowStore.nodes.find(
+    (existingNode) => existingNode.type === node.type && existingNode.id === node.id,
+  );
   if (byId) {
     return byId;
   }
@@ -2502,7 +2504,7 @@ function findMatchingExistingAgentNode(node: WorkflowNode): WorkflowNode | undef
   }
 
   return workflowStore.nodes.find(
-    (existingNode) => existingNode.type === "agent" && existingNode.data?.label === label,
+    (existingNode) => existingNode.type === node.type && existingNode.data?.label === label,
   );
 }
 
@@ -2529,7 +2531,7 @@ function preserveAgentSkillFiles(node: WorkflowNode): WorkflowNode {
     return node;
   }
 
-  const existingNode = findMatchingExistingAgentNode(node);
+  const existingNode = findMatchingExistingNode(node);
   if (!existingNode || existingNode.type !== "agent") {
     return node;
   }
@@ -2600,7 +2602,8 @@ function applyWorkflowChanges(showMessage = true): void {
       }
     }
     if (isPlaceholderOrInvalidModel(model)) {
-      data.model = effectiveModel || "";
+      const existingNode = findMatchingExistingNode(mergedNode);
+      data.model = existingNode?.data?.model || effectiveModel || "";
     }
 
     const fb = data.fallbackCredentialId as string | undefined;


### PR DESCRIPTION
## Change Summary

Extended the model-preservation logic in `applyWorkflowChanges` (`frontend/src/components/Panels/DebugPanel.vue`) so it covers LLM nodes in addition to agent nodes.

Previously, when the AI (Ctrl+I chat) returned a node whose model was empty or invalid, the code always filled in the currently selected chat model (`effectiveModel`), overwriting an existing node's configured model. Now, for both agent and LLM nodes, an incoming node that matches an existing canvas node (matched by id, then by label) keeps that existing node's model; only newly created nodes fall back to the chat-selected model.

To share the matching logic across node types, `findMatchingExistingAgentNode` was generalized into `findMatchingExistingNode`, which matches by node type instead of hard-coding `"agent"`.

Verified with `./check.sh` (frontend lint + typecheck, backend ruff, and 3184 backend tests all pass).

## Screenshots

> ⚠️ This pull request changes UI/frontend files, but the coding agent did not capture a screenshot. Add one manually if a visual review is needed.