### PR TITLE
refactor: use shared node icons on the canvas and palette

### DIFF
--- a/frontend/src/components/Nodes/BaseNode.vue
+++ b/frontend/src/components/Nodes/BaseNode.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { Handle, Position, useVueFlow } from "@vue-flow/core";
-import { AlertTriangle, Ban, BarChart3, Bot, Brain, Braces, Bug, CalendarClock, Clock, Code2, Database, FileJson, FileText, FolderOpen, GitBranch, GitMerge, Globe, Github, HardDrive, Inbox, ListTodo, Loader2, Mail, MessageSquare, MonitorPlay, Pin, Play, Plug, Puzzle, Rabbit, Radio, RefreshCw, Repeat, Search, Send, Server, Settings2, Sheet, ShieldAlert, Shuffle, Sparkles, StickyNote, Table2, Terminal, Type, Upload, Variable, XCircle } from "lucide-vue-next";
-import HeymIcon from "@/components/Nodes/HeymIcon.vue";
+import { AlertTriangle, Brain, Loader2, Pin, RefreshCw, Sparkles } from "lucide-vue-next";
 
 import type { NodeData, NodeType } from "@/types/workflow";
 
 import PluginIcon from "@/components/Panels/PluginIcon.vue";
-import { isTileFillingIcon, nodeIconColorClass } from "@/lib/nodeIcons";
+import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -22,69 +21,6 @@ const props = defineProps<Props>();
 const emit = defineEmits<{
   (e: "openAgentMemory", nodeId: string): void;
 }>();
-
-const icons = {
-  chartOutput: BarChart3,
-  textInput: Type,
-  cron: CalendarClock,
-  telegramTrigger: MessageSquare,
-  websocketTrigger: Radio,
-  fileUploadTrigger: Upload,
-  llm: Brain,
-  agent: Bot,
-  codex: Terminal,
-  opencodeGo: Terminal,
-  condition: GitBranch,
-  switch: Shuffle,
-  execute: Play,
-  output: FileJson,
-  wait: Clock,
-  http: Globe,
-  websocketSend: Send,
-  sticky: StickyNote,
-  merge: GitMerge,
-  set: Settings2,
-  converter: Repeat,
-  code: Code2,
-  jsonOutputMapper: Braces,
-  telegram: MessageSquare,
-  slack: MessageSquare,
-  slackTrigger: MessageSquare,
-  discord: MessageSquare,
-  discordTrigger: MessageSquare,
-  imapTrigger: Inbox,
-  heym: HeymIcon,
-  heymTrigger: HeymIcon,
-  sendEmail: Mail,
-  errorHandler: AlertTriangle,
-  variable: Variable,
-  loop: Repeat,
-  disableNode: Ban,
-  redis: Database,
-  rag: Search,
-  grist: Table2,
-  github: Github,
-  jira: ListTodo,
-  linear: ListTodo,
-  googleSheets: Sheet,
-  googleDrive: FolderOpen,
-  bigquery: Database,
-  supabase: Database,
-  clickhouse: Database,
-  notion: FileText,
-  sentry: ShieldAlert,
-  throwError: XCircle,
-  rabbitmq: Rabbit,
-  crawler: Bug,
-  consoleLog: Terminal,
-  playwright: MonitorPlay,
-  dataTable: Table2,
-  drive: HardDrive,
-  s3: Server,
-  mcpCall: Plug,
-  plugin: Puzzle,
-  pluginTrigger: Puzzle,
-};
 
 const nodeColorMap = {
   chartOutput: "node-output",
@@ -296,7 +232,7 @@ const batchRuntimeBadgeClass = computed(() => {
   return "text-node-llm bg-node-llm/10";
 });
 
-const Icon = computed(() => icons[props.type]);
+const Icon = computed(() => nodeIcons[props.type]);
 
 const RESERVED_NAMES = new Set([
   "headers",

--- a/frontend/src/components/Panels/NodePanel.vue
+++ b/frontend/src/components/Panels/NodePanel.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, watch, nextTick, ref } from "vue";
-import { AlertTriangle, Ban, BarChart3, Bot, Brain, Braces, Bug, CalendarClock, Clock, Code2, Database, FileJson, FileText, FolderOpen, GitBranch, GitMerge, Globe, Github, HardDrive, Inbox, LayoutTemplate, ListTodo, Mail, MessageSquare, MonitorPlay, Play, Plug, Puzzle, Rabbit, Radio, Repeat, Search, Send, Server, Settings2, Sheet, ShieldAlert, Shuffle, StickyNote, Table2, Terminal, Type, Upload, Variable, X, XCircle } from "lucide-vue-next";
-import HeymIcon from "@/components/Nodes/HeymIcon.vue";
+import { LayoutTemplate, Puzzle, X } from "lucide-vue-next";
 
 import type { NodeTemplate } from "@/features/templates/types/template.types";
 import type { NodeType, PluginSummary, WorkflowEdge, WorkflowNode } from "@/types/workflow";
@@ -211,69 +210,6 @@ function scrollToSelectedNode(): void {
     }
   });
 }
-
-const icons = {
-  textInput: Type,
-  cron: CalendarClock,
-  telegramTrigger: MessageSquare,
-  websocketTrigger: Radio,
-  fileUploadTrigger: Upload,
-  llm: Brain,
-  agent: Bot,
-  codex: Terminal,
-  opencodeGo: Terminal,
-  condition: GitBranch,
-  switch: Shuffle,
-  execute: Play,
-  output: FileJson,
-  wait: Clock,
-  http: Globe,
-  websocketSend: Send,
-  sticky: StickyNote,
-  merge: GitMerge,
-  set: Settings2,
-  converter: Repeat,
-  code: Code2,
-  jsonOutputMapper: Braces,
-  telegram: MessageSquare,
-  slack: MessageSquare,
-  slackTrigger: MessageSquare,
-  discord: MessageSquare,
-  discordTrigger: MessageSquare,
-  imapTrigger: Inbox,
-  heym: HeymIcon,
-  heymTrigger: HeymIcon,
-  sendEmail: Mail,
-  errorHandler: AlertTriangle,
-  variable: Variable,
-  loop: Repeat,
-  disableNode: Ban,
-  redis: Database,
-  rag: Search,
-  grist: Table2,
-  github: Github,
-  jira: ListTodo,
-  linear: ListTodo,
-  googleSheets: Sheet,
-  googleDrive: FolderOpen,
-  bigquery: Database,
-  supabase: Database,
-  clickhouse: Database,
-  notion: FileText,
-  sentry: ShieldAlert,
-  throwError: XCircle,
-  rabbitmq: Rabbit,
-  crawler: Bug,
-  consoleLog: Terminal,
-  playwright: MonitorPlay,
-  dataTable: Table2,
-  drive: HardDrive,
-  s3: Server,
-  mcpCall: Plug,
-  chartOutput: BarChart3,
-  plugin: Puzzle,
-  pluginTrigger: Puzzle,
-};
 
 const allNodeTypes = Object.values(NODE_DEFINITIONS);
 
@@ -680,7 +616,7 @@ function handleDoubleClick(type: NodeType, extraData?: Record<string, unknown>):
             }"
           >
             <component
-              :is="icons[node.type]"
+              :is="nodeIcons[node.type]"
               :class="isTileFillingIcon(node.type) ? 'w-full h-full' : 'w-5 h-5'"
             />
           </div>

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -12,8 +12,7 @@ import {
   type Ref,
 } from "vue";
 import { useRouter } from "vue-router";
-import { AlertTriangle, Ban, BarChart3, Bot, Braces, Brain, Bug, CalendarClock, Clock, Code2, Database, FileJson, FileText, FolderOpen, GitBranch, GitMerge, Github, Globe, HardDrive, Inbox, ListTodo, Mail, MessageSquare, MonitorPlay, Play, Plug, Puzzle, Rabbit, Radio, Repeat, Search, Send, Server, Settings2, Sheet, ShieldAlert, Shuffle, StickyNote, Table2, Terminal, Type, Upload, Variable, XCircle } from "lucide-vue-next";
-import HeymIcon from "@/components/Nodes/HeymIcon.vue";
+
 import type { ClickHouseColumn, CredentialListItem, LLMModel, NotionDataSourceItem, NotionPageItem } from "@/types/credential";
 import type { AgentMCPConnection, AgentSkill, AgentSkillFile, ExecuteInputMapping, GuardrailCategory, InputField, MappingField, MCPTransportType, OutputSchemaField, PlaywrightStep, PlaywrightStepAction, WorkflowListItem } from "@/types/workflow";
 import {
@@ -30,6 +29,7 @@ import { getJiraExpressionFields, type JiraExpressionFieldKey } from "@/lib/jira
 import { getLinearExpressionFields, type LinearExpressionFieldKey } from "@/lib/linearExpressionFields";
 import { getNotionExpressionFields, type NotionExpressionFieldKey } from "@/lib/notionExpressionFields";
 import { getSentryExpressionFields, type SentryExpressionFieldKey } from "@/lib/sentryExpressionFields";
+import { nodeIcons } from "@/lib/nodeIcons";
 import { parseWebhookJson, stringifyWebhookJson } from "@/lib/webhookBody";
 import { configApi, credentialsApi, dataTablesApi, filesApi, gristApi, mcpApi, workflowApi } from "@/services/api";
 import type { MCPFetchToolItem } from "@/services/api";
@@ -93,69 +93,6 @@ interface CodexExpressionField {
 }
 
 export function usePropertiesPanelController() {
-  const nodeIcons: Record<NodeType, ReturnType<typeof Type>> = {
-    chartOutput: BarChart3,
-    textInput: Type,
-    cron: CalendarClock,
-    websocketTrigger: Radio,
-    fileUploadTrigger: Upload,
-    llm: Brain,
-    agent: Bot,
-    codex: Terminal,
-    opencodeGo: Terminal,
-    condition: GitBranch,
-    switch: Shuffle,
-    execute: Play,
-    output: FileJson,
-    wait: Clock,
-    http: Globe,
-    websocketSend: Send,
-    sticky: StickyNote,
-    merge: GitMerge,
-    set: Settings2,
-    converter: Repeat,
-    code: Code2,
-    jsonOutputMapper: Braces,
-    telegramTrigger: MessageSquare,
-    telegram: MessageSquare,
-    slack: MessageSquare,
-    slackTrigger: MessageSquare,
-    discord: MessageSquare,
-    discordTrigger: MessageSquare,
-    imapTrigger: Inbox,
-    heym: HeymIcon,
-    heymTrigger: HeymIcon,
-    sendEmail: Mail,
-    errorHandler: AlertTriangle,
-    variable: Variable,
-    loop: Repeat,
-    disableNode: Ban,
-    redis: Database,
-    rag: Search,
-    grist: Table2,
-    github: Github,
-    jira: ListTodo,
-    linear: ListTodo,
-    googleSheets: Sheet,
-    googleDrive: FolderOpen,
-    bigquery: Database,
-    supabase: Database,
-    clickhouse: Database,
-    notion: FileText,
-    sentry: ShieldAlert,
-    throwError: XCircle,
-    rabbitmq: Rabbit,
-    crawler: Bug,
-    consoleLog: Terminal,
-    playwright: MonitorPlay,
-    dataTable: Table2,
-    drive: HardDrive,
-    s3: Server,
-    mcpCall: Plug,
-    plugin: Puzzle,
-    pluginTrigger: Puzzle,
-  };
-
   const nodeColorMap: Record<NodeType, string> = {
     chartOutput: "node-output",
     textInput: "node-input",

--- a/frontend/src/lib/nodeIcons.test.ts
+++ b/frontend/src/lib/nodeIcons.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { NODE_DEFINITIONS } from "@/types/node";
+
+import { nodeIconColorClass, nodeIcons } from "./nodeIcons";
+
+describe("nodeIcons", () => {
+  it("has an icon and color class for every node definition", () => {
+    for (const type of Object.keys(NODE_DEFINITIONS) as Array<keyof typeof NODE_DEFINITIONS>) {
+      expect(nodeIcons[type]).toBeTruthy();
+      expect(nodeIconColorClass[type]).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
The node palette already used `lib/nodeIcons.ts` for template rows, then kept a second Lucide map for builtin cards. A new node type could get the right icon in one place and the wrong one in the other.

Builtin cards now use the shared map. The duplicate local map is gone. A small test checks every node definition has an icon and a color class.