### PR TITLE
impl/playwright-copy-refresh-operations

### DIFF
--- a/backend/app/api/playwright.py
+++ b/backend/app/api/playwright.py
@@ -58,6 +58,7 @@ Each step must have an "action" field. Supported actions (do not use "aiStep"):
 - type: requires "selector" and "text"
 - fill: requires "selector" and "value"
 - wait: optional "timeout" (ms, default 2000)
+- refresh: reloads the current page; optional "timeout" (ms) for the reload navigation
 - hover: requires "selector"
 - selectOption: requires "selector" and "value"
 - scrollDown: optional "amount" (pixels, default 300); optional "timeout" for post-scroll wait
@@ -233,6 +234,7 @@ async def ai_step(
                                         "type",
                                         "fill",
                                         "wait",
+                                        "refresh",
                                         "hover",
                                         "selectOption",
                                         "scrollDown",

--- a/backend/app/services/playwright_code_generator.py
+++ b/backend/app/services/playwright_code_generator.py
@@ -447,6 +447,9 @@ def _generate_step_lines(
         url_val = _expr_to_python(url, '"https://example.com"')
         goto_args = f"{url_val}" + (f", {to_kw}" if to_kw else "")
         lines.append(f"page.goto({goto_args})")
+    elif action == "refresh":
+        reload_args = f"({to_kw})" if to_kw else "()"
+        lines.append(f"page.reload{reload_args}")
     elif action == "click":
         sel_val = _expr_to_python(selector, '"button"')
         lines.append(f"_pw_click_loc = page.locator({sel_val})")
@@ -609,6 +612,10 @@ def _generate_step_lines(
                 "        page.mouse.wheel(0, -_amt)",
                 "        page.wait_for_timeout(1000)",
                 "        _step_done = True",
+                "    elif _a == 'refresh':",
+                "        _rtmo = _s.get('timeout')",
+                "        page.reload(timeout=int(_rtmo)) if _rtmo is not None else page.reload()",
+                "        _step_done = True",
                 "    elif _a == 'navigate':",
                 "        _nurl = str(_s.get('url', '') or '')",
                 "        if not _nurl:",
@@ -729,7 +736,7 @@ def _generate_step_lines(
                 "                if _attempt == 1:",
                 "                    raise",
                 "    if not _step_done and _a not in (",
-                "        'wait', 'scrollDown', 'scrollUp', 'screenshot', 'navigate',",
+                "        'wait', 'scrollDown', 'scrollUp', 'screenshot', 'navigate', 'refresh',",
                 "        'getText', 'getAttribute', 'getHTML', 'getVisibleTextOnPage',",
                 "    ):",
                 "        raise RuntimeError(f'AI step {_i} ({_a}) failed and auto heal disabled')",

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -3237,8 +3237,9 @@ This returns: `["news/my-article.html", "blog/another-post.html", ...]`
   - `playwrightAuthFallbackSteps`: Array of step definitions that run only if cookie/storageState restore did not authenticate the page
 
 **Step structure** (each item in `playwrightSteps` or `playwrightAuthFallbackSteps`):
-- `action`: One of `navigate`, `click`, `type`, `fill`, `wait`, `screenshot`, `getText`, `getAttribute`, `getHTML`, `getVisibleTextOnPage`, `hover`, `selectOption`, `scrollDown`, `scrollUp`, `aiStep`
+- `action`: One of `navigate`, `refresh`, `click`, `type`, `fill`, `wait`, `screenshot`, `getText`, `getAttribute`, `getHTML`, `getVisibleTextOnPage`, `hover`, `selectOption`, `scrollDown`, `scrollUp`, `aiStep`
 - `url`: For navigate - URL (supports expressions like `$userInput.body.url`)
+- `refresh`: Reloads the current page (no url/selector); optional `timeout` ms for the reload navigation
 - `selector`: For click/type/fill/getText/getAttribute/getHTML/hover/selectOption - CSS selector (supports expressions). Not used for `getVisibleTextOnPage` (full-page visible text from `document.body.innerText`; optional `timeout` ms waits before capture).
 - `amount`: For scrollDown/scrollUp - pixels to scroll (default 300). A 1000ms wait is automatically added after each scroll to allow content to load.
 - `text`: For type - text to type (supports expressions)
@@ -3246,7 +3247,7 @@ This returns: `["news/my-article.html", "blog/another-post.html", ...]`
 - `attribute`: For getAttribute - attribute name (e.g. `href`, `data-id`)
 - `timeout`: Optional step timeout in ms
 - `outputKey`: For getText/getAttribute/getHTML/getVisibleTextOnPage/screenshot - key to store result in `$nodeLabel.results.outputKey`
-- For `aiStep`: `instructions` (what to do), `credentialId`, `model`, `logStepsToConsole`, `saveStepsForFuture`, `autoHealMode`, `sendScreenshot`, `aiStepTimeout` (optional, ms, default 30000) - LLM analyzes page HTML and returns the same action set as manual steps (including `navigate`, `getText`, `getHTML`, `getAttribute`, `getVisibleTextOnPage`, etc.; not nested `aiStep`). `autoHealMode`: if a selector-based step fails 2x, ask LLM for an alternative locator (heal supports click/type/fill/hover/selectOption only).
+- For `aiStep`: `instructions` (what to do), `credentialId`, `model`, `logStepsToConsole`, `saveStepsForFuture`, `autoHealMode`, `sendScreenshot`, `aiStepTimeout` (optional, ms, default 30000) - LLM analyzes page HTML and returns the same action set as manual steps (including `navigate`, `refresh`, `getText`, `getHTML`, `getAttribute`, `getVisibleTextOnPage`, etc.; not nested `aiStep`). `autoHealMode`: if a selector-based step fails 2x, ask LLM for an alternative locator (heal supports click/type/fill/hover/selectOption only).
 
 **Output properties**:
 - `$nodeLabel.status`: "ok" on success

--- a/backend/tests/test_playwright_refresh_step.py
+++ b/backend/tests/test_playwright_refresh_step.py
@@ -1,0 +1,47 @@
+"""The refresh step must reload the current page, in manual and AI step flows."""
+
+import unittest
+
+from app.services.playwright_code_generator import generate_playwright_code
+
+
+class PlaywrightRefreshStepTests(unittest.TestCase):
+    def test_refresh_step_reloads_page(self) -> None:
+        code = generate_playwright_code([{"action": "refresh"}])
+        compile(code, "<generated>", "exec")
+        self.assertIn("page.reload()", code)
+
+    def test_refresh_step_uses_step_timeout(self) -> None:
+        code = generate_playwright_code([{"action": "refresh", "timeout": 15000}])
+        compile(code, "<generated>", "exec")
+        self.assertIn("page.reload(timeout=15000)", code)
+
+    def test_refresh_step_needs_no_selector_or_url(self) -> None:
+        code = generate_playwright_code(
+            [{"action": "navigate", "url": "https://example.com"}, {"action": "refresh"}]
+        )
+        compile(code, "<generated>", "exec")
+        self.assertIn("page.goto('https://example.com')", code)
+        self.assertIn("page.reload()", code)
+
+    def test_ai_step_loop_handles_refresh(self) -> None:
+        code = generate_playwright_code(
+            [
+                {
+                    "action": "aiStep",
+                    "instructions": "reload the page",
+                    "credentialId": "cred-1",
+                    "model": "gpt-4o-mini",
+                }
+            ]
+        )
+        compile(code, "<generated>", "exec")
+        self.assertIn("elif _a == 'refresh':", code)
+        self.assertIn(
+            "page.reload(timeout=int(_rtmo)) if _rtmo is not None else page.reload()", code
+        )
+        self.assertIn("'navigate', 'refresh',", code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/Panels/propertiesPanel/nodes/PlaywrightNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/PlaywrightNodeProperties.vue
@@ -27,6 +27,7 @@ const {
   getPlaywrightSteps,
   savedStepKey,
   addPlaywrightStep,
+  duplicatePlaywrightStep,
   removePlaywrightStep,
   movePlaywrightStepUp,
   movePlaywrightStepDown,
@@ -235,12 +236,41 @@ with sync_playwright() as p:
             class="space-y-2 p-3 border rounded-md bg-muted/30"
           >
             <div class="flex items-center justify-between gap-2">
-              <span class="text-xs font-medium">Step {{ index + 1 }}</span>
-              <div class="flex items-center gap-1">
+              <span class="text-xs font-medium shrink-0 whitespace-nowrap">Step {{ index + 1 }}</span>
+              <div class="flex items-center gap-1 shrink-0">
                 <Button
                   variant="outline"
                   size="sm"
-                  class="h-7 w-7 p-0 shrink-0 text-base font-semibold leading-none text-muted-foreground hover:text-foreground"
+                  class="!h-7 !min-h-0 !w-7 !p-0 shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Copy step"
+                  title="Copy step to the end"
+                  @click="duplicatePlaywrightStep(section.key, index)"
+                >
+                  <svg
+                    class="h-3.5 w-3.5 shrink-0"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <rect
+                      x="8"
+                      y="8"
+                      width="14"
+                      height="14"
+                      rx="2"
+                      ry="2"
+                    />
+                    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+                  </svg>
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  class="!h-7 !min-h-0 !w-7 !p-0 shrink-0 text-base font-semibold leading-none text-muted-foreground hover:text-foreground"
                   aria-label="Move step up"
                   :disabled="index === 0"
                   @click="movePlaywrightStepUp(section.key, index)"
@@ -250,7 +280,7 @@ with sync_playwright() as p:
                 <Button
                   variant="outline"
                   size="sm"
-                  class="h-7 w-7 p-0 shrink-0 text-base font-semibold leading-none text-muted-foreground hover:text-foreground"
+                  class="!h-7 !min-h-0 !w-7 !p-0 shrink-0 text-base font-semibold leading-none text-muted-foreground hover:text-foreground"
                   aria-label="Move step down"
                   :disabled="index >= getPlaywrightSteps(section.key).length - 1"
                   @click="movePlaywrightStepDown(section.key, index)"
@@ -260,7 +290,7 @@ with sync_playwright() as p:
                 <Button
                   variant="ghost"
                   size="sm"
-                  class="h-7 gap-1.5 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  class="!h-7 !min-h-0 !px-2 gap-1 shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
                   aria-label="Remove step"
                   @click="removePlaywrightStep(section.key, index)"
                 >
@@ -425,6 +455,22 @@ with sync_playwright() as p:
                   min="0"
                   @update:model-value="updatePlaywrightStep(section.key, index, 'timeout', $event ? parseInt($event as string) : 4000)"
                 />
+              </div>
+            </template>
+
+            <template v-if="step.action === 'refresh'">
+              <div class="space-y-1">
+                <Label class="text-xs">Reload timeout (ms, optional)</Label>
+                <Input
+                  type="number"
+                  :model-value="step.timeout || ''"
+                  placeholder="30000"
+                  min="0"
+                  @update:model-value="updatePlaywrightStep(section.key, index, 'timeout', $event ? parseInt($event as string) : undefined)"
+                />
+                <p class="text-xs text-muted-foreground">
+                  Reloads the current page. Leave empty to use the node timeout.
+                </p>
               </div>
             </template>
 

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -6762,6 +6762,7 @@ export function usePropertiesPanelController() {
 
   const playwrightStepActionOptions: { value: PlaywrightStepAction; label: string }[] = [
     { value: "navigate", label: "Navigate" },
+    { value: "refresh", label: "Refresh" },
     { value: "click", label: "Click" },
     { value: "type", label: "Type" },
     { value: "fill", label: "Fill" },
@@ -6899,6 +6900,14 @@ export function usePropertiesPanelController() {
     return `${stepListKey}-${stepIndex}-${savedStepIndex}`;
   }
 
+  function scrollToLastPlaywrightStep(stepListKey: PlaywrightStepListKey): void {
+    nextTick(() => {
+      const els = document.querySelectorAll(`[data-playwright-step="${stepListKey}"]`);
+      const last = els[els.length - 1];
+      if (last) last.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+  }
+
   function addPlaywrightStep(stepListKey: PlaywrightStepListKey = "playwrightSteps"): void {
     const node = workflowStore.selectedNode;
     if (!node) return;
@@ -6906,11 +6915,23 @@ export function usePropertiesPanelController() {
     const steps = getPlaywrightSteps(stepListKey);
     steps.push({ action: "navigate", url: "https://example.com" });
     updateNodeData(stepListKey, steps);
-    nextTick(() => {
-      const els = document.querySelectorAll(`[data-playwright-step="${stepListKey}"]`);
-      const last = els[els.length - 1];
-      if (last) last.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    });
+    scrollToLastPlaywrightStep(stepListKey);
+  }
+
+  function duplicatePlaywrightStep(
+    stepListKey: PlaywrightStepListKey,
+    index: number,
+  ): void {
+    const node = workflowStore.selectedNode;
+    if (!node) return;
+
+    const steps = getPlaywrightSteps(stepListKey);
+    const source = steps[index];
+    if (!source) return;
+
+    steps.push(JSON.parse(JSON.stringify(source)) as PlaywrightStep);
+    updateNodeData(stepListKey, steps);
+    scrollToLastPlaywrightStep(stepListKey);
   }
 
   function removePlaywrightStep(
@@ -9516,6 +9537,7 @@ export function usePropertiesPanelController() {
     getPlaywrightSteps,
     savedStepKey,
     addPlaywrightStep,
+    duplicatePlaywrightStep,
     removePlaywrightStep,
     movePlaywrightStepUp,
     movePlaywrightStepDown,

--- a/frontend/src/docs/content/nodes/playwright-node.md
+++ b/frontend/src/docs/content/nodes/playwright-node.md
@@ -30,6 +30,7 @@ The **Playwright** node automates browser interactions with configurable steps. 
 ## Step Types
 
 - **navigate** – Go to URL
+- **refresh** – Reload the current page (optional step `timeout` in ms for the reload navigation)
 - **click** – Click element by selector
 - **type** – Type text into input (character-by-character)
 - **fill** – Fill input value
@@ -46,7 +47,7 @@ The **Playwright** node automates browser interactions with configurable steps. 
 
 ## AI Step
 
-The **aiStep** action uses an LLM to analyze the page HTML (and optionally a screenshot) and generate Playwright actions from natural-language instructions. The API accepts the same action names as manual steps (including `navigate`, `getText`, `getHTML`, `getAttribute`, `getVisibleTextOnPage`, `screenshot`, scrolls, etc.). **Auto heal** only replaces failed selector-based steps with alternatives for click, type, fill, hover, and selectOption.
+The **aiStep** action uses an LLM to analyze the page HTML (and optionally a screenshot) and generate Playwright actions from natural-language instructions. The API accepts the same action names as manual steps (including `navigate`, `refresh`, `getText`, `getHTML`, `getAttribute`, `getVisibleTextOnPage`, `screenshot`, scrolls, etc.). **Auto heal** only replaces failed selector-based steps with alternatives for click, type, fill, hover, and selectOption.
 
 | Option | Description |
 |--------|-------------|

--- a/frontend/src/docs/content/reference/features.md
+++ b/frontend/src/docs/content/reference/features.md
@@ -360,7 +360,7 @@ Pairs with [HTTP](../nodes/http-node.md), [Playwright](../nodes/playwright-node.
 
 #### [Playwright](../nodes/playwright-node.md)
 
-The Playwright node automates browser interactions with configurable steps (navigate, click, type, screenshot, extract, aiStep) or **Run Code** mode for custom Playwright Python (sandboxed; off by default via `HEYM_PLAYWRIGHT_CUSTOM_CODE_ENABLED`). It supports headless mode, an optional setting that reduces common Playwright automation signals, timeouts, optional network capture (responses, cookies, localStorage, sessionStorage), cookie/storageState auth bootstrap from [Global Variables](./global-variables.md) expressions such as `$global.authState`, fallback login steps when auth restore fails, and an AI step with Auto Heal when selectors fail. Use it for web scraping, form filling, and browser-based workflows.
+The Playwright node automates browser interactions with configurable steps (navigate, refresh, click, type, screenshot, extract, aiStep) or **Run Code** mode for custom Playwright Python (sandboxed; off by default via `HEYM_PLAYWRIGHT_CUSTOM_CODE_ENABLED`). It supports headless mode, an optional setting that reduces common Playwright automation signals, timeouts, optional network capture (responses, cookies, localStorage, sessionStorage), cookie/storageState auth bootstrap from [Global Variables](./global-variables.md) expressions such as `$global.authState`, fallback login steps when auth restore fails, and an AI step with Auto Heal when selectors fail. Use it for web scraping, form filling, and browser-based workflows.
 
 See also [Crawler](../nodes/crawler-node.md), [HTTP](../nodes/http-node.md), and [Execution History](./execution-history.md) for browser automation and debugging.
 

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -351,6 +351,7 @@ export interface CrawlerSelector {
 
 export type PlaywrightStepAction =
   | "navigate"
+  | "refresh"
   | "click"
   | "type"
   | "fill"


### PR DESCRIPTION
Add 'refresh' action to Playwright steps and copy button added.

- Introduced a new 'refresh' action for reloading the current page, with an optional timeout parameter.
- Updated relevant documentation and interfaces to include the new action.
- Enhanced the frontend components to support the 'refresh' action in the properties panel and step definitions.