### PR TITLE
feat(frontend): summarize execution timeline health

### DIFF
--- a/frontend/src/components/Panels/ExecutionTimeline.vue
+++ b/frontend/src/components/Panels/ExecutionTimeline.vue
@@ -13,6 +13,7 @@ import {
   buildTimelineModel,
   formatTimelineMs,
   getTimelineRowKey,
+  summarizeTimelineModel,
 } from "@/components/Panels/executionTimeline";
 
 interface Props {
@@ -109,6 +110,9 @@ const fullTimelineModel = computed(() =>
     props.subAgentLabelToParentId,
     { nowMs: timelineNowMs.value },
   ),
+);
+const timelineSummary = computed(() =>
+  summarizeTimelineModel(fullTimelineModel.value.rows, fullTimelineModel.value.timeWindow),
 );
 
 const rows = computed(() => fullTimelineModel.value.rows);
@@ -219,6 +223,29 @@ function showAllRows(): void {
 
 <template>
   <div class="border-t bg-muted/5 select-none overflow-hidden">
+    <div class="flex items-center gap-3 px-2 py-1.5 border-b border-border/20 bg-background/40 text-[10px] text-muted-foreground">
+      <span class="font-medium text-foreground/80">Execution summary</span>
+      <span>{{ formatTimelineMs(timelineSummary.totalDurationMs) }}</span>
+      <span>{{ timelineSummary.spanCount }} spans</span>
+      <span
+        v-if="timelineSummary.failedSpanCount > 0"
+        class="text-destructive"
+      >
+        {{ timelineSummary.failedSpanCount }} failed
+      </span>
+      <span
+        v-if="timelineSummary.retryCount > 0"
+        class="text-amber-600"
+      >
+        {{ timelineSummary.retryCount }} retries
+      </span>
+      <span
+        v-if="timelineSummary.failedSpanCount === 0 && timelineSummary.retryCount === 0"
+        class="text-emerald-600"
+      >
+        Healthy
+      </span>
+    </div>
     <div class="flex h-5 border-b border-border/30 overflow-hidden">
       <div class="w-[176px] shrink-0 border-r border-border/20" />
       <div class="flex-1 relative overflow-hidden">

--- a/frontend/src/components/Panels/executionTimeline.test.ts
+++ b/frontend/src/components/Panels/executionTimeline.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { TimelineEntry } from "@/components/Panels/executionTimeline";
-import { buildTimelineModel } from "@/components/Panels/executionTimeline";
+import {
+  buildTimelineModel,
+  summarizeTimelineModel,
+} from "@/components/Panels/executionTimeline";
 
 function entry(
   partial: Partial<TimelineEntry> &
@@ -138,5 +141,49 @@ describe("buildTimelineModel HITL wait spans", () => {
     expect(rows[0].spans).toHaveLength(2);
     expect(rows[0].spans[1].isHitlWait).toBe(true);
     expect(rows[0].spans[1].durationMs).toBe(3000);
+  });
+});
+
+describe("summarizeTimelineModel", () => {
+  it("returns a neutral summary for an empty execution", () => {
+    const model = buildTimelineModel([], 0, new Map());
+
+    expect(summarizeTimelineModel(model.rows, model.timeWindow)).toEqual({
+      totalDurationMs: 1,
+      spanCount: 0,
+      failedSpanCount: 0,
+      retryCount: 0,
+    });
+  });
+
+  it("summarizes failures and retries across all rows", () => {
+    const results: TimelineEntry[] = [
+      entry({
+        node_id: "llm-1",
+        node_label: "LLM",
+        node_type: "llm",
+        status: "error",
+        execution_time_ms: 120,
+        retryFailedAttempts: 2,
+        metadata: { started_at_ms: 100, ended_at_ms: 220 },
+      }),
+      entry({
+        node_id: "agent-1",
+        node_label: "Agent",
+        node_type: "agent",
+        status: "success",
+        execution_time_ms: 80,
+        retryFailedAttempts: 1,
+        metadata: { started_at_ms: 220, ended_at_ms: 300 },
+      }),
+    ];
+
+    const model = buildTimelineModel(results, 200, new Map());
+    expect(summarizeTimelineModel(model.rows, model.timeWindow)).toEqual({
+      totalDurationMs: 200,
+      spanCount: 2,
+      failedSpanCount: 1,
+      retryCount: 3,
+    });
   });
 });

--- a/frontend/src/components/Panels/executionTimeline.ts
+++ b/frontend/src/components/Panels/executionTimeline.ts
@@ -64,6 +64,13 @@ export interface SpanRow {
   spans: SpanItem[];
 }
 
+export interface TimelineSummary {
+  totalDurationMs: number;
+  spanCount: number;
+  failedSpanCount: number;
+  retryCount: number;
+}
+
 interface RawSpanItem {
   key: string;
   nodeId: string;
@@ -460,4 +467,18 @@ export function buildTimelineModel(
     });
 
   return { rows, timeWindow };
+}
+
+/** Return a compact health summary for the complete execution timeline. */
+export function summarizeTimelineModel(
+  rows: SpanRow[],
+  timeWindow: TimeWindow,
+): TimelineSummary {
+  const spans = rows.flatMap((row) => row.spans);
+  return {
+    totalDurationMs: timeWindow.totalMs,
+    spanCount: spans.length,
+    failedSpanCount: spans.filter((span) => span.status === "error").length,
+    retryCount: spans.reduce((total, span) => total + span.retryFailedAttempts, 0),
+  };
 }


### PR DESCRIPTION
## What changed
- Add a compact execution summary above the timeline with duration, span count, failures, retries, and a healthy state.
- Keep the summary derived from the complete timeline model so hiding rows does not change run health metrics.
- Add unit coverage for healthy/empty and failed/retried executions.

## Validation
- 
px vitest run src/components/Panels/executionTimeline.test.ts (5 passed)
- 
px vue-tsc --noEmit
- 
px eslint src/components/Panels/ExecutionTimeline.vue src/components/Panels/executionTimeline.ts src/components/Panels/executionTimeline.test.ts
- 
px vite build
- git diff --check

This is intentionally scoped to the execution timeline UX and does not change backend behavior or execution semantics.