### PR TITLE
feat(backend): audit logging for auth and CRUD surfaces

### DIFF
--- a/backend/app/api/alerts.py
+++ b/backend/app/api/alerts.py
@@ -47,6 +47,7 @@ from app.services.alert_access import (
 from app.services.alerts.context import AlertEvaluationContext, AlertObservation
 from app.services.alerts.evaluator import observe
 from app.services.alerts.registry import get_alert_handler
+from app.services.audit_log import audit
 from app.services.llm_trace import LLMTraceContext, record_llm_trace
 
 router = APIRouter()
@@ -283,6 +284,17 @@ async def create_alert(
     await db.commit()
     await db.refresh(alert)
 
+    audit(
+        action="alert.create",
+        actor=current_user,
+        target_type="alert",
+        target_id=alert.id,
+        target_name=alert.name,
+        alert_type=alert.alert_type,
+        scope=alert.scope,
+        enabled=alert.enabled,
+    )
+
     names = await _workflow_names(db, [alert.workflow_id, alert.notify_workflow_id])
     return _to_response(
         alert,
@@ -360,6 +372,14 @@ async def acknowledge_alert_event(
     event.acknowledged_at = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(event)
+    audit(
+        action="alert.event_acknowledge",
+        actor=current_user,
+        target_type="alert_event",
+        target_id=event.id,
+        target_name=row[1],
+        alert_id=event.alert_id,
+    )
     return _event_to_response(event, row[1], row[2])
 
 
@@ -604,6 +624,16 @@ async def update_alert(
     await db.commit()
     await db.refresh(alert)
 
+    audit(
+        action="alert.update",
+        actor=current_user,
+        target_type="alert",
+        target_id=alert.id,
+        target_name=alert.name,
+        fields=",".join(sorted(changes)) or None,
+        enabled=alert.enabled,
+    )
+
     names = await _workflow_names(db, [alert.workflow_id, alert.notify_workflow_id])
     return _to_response(
         alert,
@@ -624,6 +654,14 @@ async def delete_alert(
     alert = await get_owned_alert(db, alert_id, current_user.id)
     if alert is None:
         raise HTTPException(status_code=404, detail="Alert not found")
+    audit(
+        action="alert.delete",
+        actor=current_user,
+        target_type="alert",
+        target_id=alert.id,
+        target_name=alert.name,
+        alert_type=alert.alert_type,
+    )
     await db.delete(alert)
     await db.commit()
 
@@ -737,6 +775,15 @@ async def create_alert_share(
         db.add(share)
         await db.commit()
         await db.refresh(share)
+        audit(
+            action="alert.share_add",
+            actor=current_user,
+            target_type="alert",
+            target_id=alert_id,
+            target_name=alert.name,
+            grantee_id=target.id,
+            grantee_email=target.email,
+        )
 
     return AlertShareEntry(id=share.id, user_id=share.user_id, user_email=target.email)
 
@@ -756,6 +803,14 @@ async def delete_alert_share(
     )
     share = result.scalar_one_or_none()
     if share is not None:
+        audit(
+            action="alert.share_remove",
+            actor=current_user,
+            target_type="alert",
+            target_id=alert_id,
+            target_name=alert.name,
+            grantee_id=user_id,
+        )
         await db.delete(share)
         await db.commit()
 
@@ -807,6 +862,15 @@ async def create_alert_team_share(
         db.add(share)
         await db.commit()
         await db.refresh(share)
+        audit(
+            action="alert.team_share_add",
+            actor=current_user,
+            target_type="alert",
+            target_id=alert_id,
+            target_name=alert.name,
+            team_id=team.id,
+            team_name=team.name,
+        )
 
     return AlertTeamShareEntry(id=share.id, team_id=share.team_id, team_name=team.name)
 
@@ -828,6 +892,14 @@ async def delete_alert_team_share(
     )
     share = result.scalar_one_or_none()
     if share is not None:
+        audit(
+            action="alert.team_share_remove",
+            actor=current_user,
+            target_type="alert",
+            target_id=alert_id,
+            target_name=alert.name,
+            team_id=team_id,
+        )
         await db.delete(share)
         await db.commit()
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -17,6 +17,7 @@ from app.models.schemas import (
     UserResponse,
     UserUpdate,
 )
+from app.services.audit_log import OUTCOME_DENIED, OUTCOME_FAILURE, audit
 from app.services.auth import (
     create_access_token,
     create_refresh_token,
@@ -108,6 +109,12 @@ async def register(
         )
 
     if not settings.allow_register:
+        audit(
+            action="auth.register",
+            outcome=OUTCOME_DENIED,
+            actor_email=user_data.email,
+            reason="registration_disabled",
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Registration is disabled",
@@ -117,6 +124,12 @@ async def register(
     existing_user = result.scalar_one_or_none()
 
     if existing_user:
+        audit(
+            action="auth.register",
+            outcome=OUTCOME_FAILURE,
+            actor_email=user_data.email,
+            reason="email_already_registered",
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Email already registered",
@@ -136,6 +149,7 @@ async def register(
     await store_refresh_token(db, refresh_token, user.id)
     _set_auth_cookies(response, access_token, refresh_token)
 
+    audit(action="auth.register", actor=user)
     return TokenResponse(access_token=access_token, refresh_token=refresh_token)
 
 
@@ -159,6 +173,12 @@ async def login(
     user = result.scalar_one_or_none()
 
     if user is None or not verify_password(user_data.password, user.hashed_password):
+        audit(
+            action="auth.login",
+            outcome=OUTCOME_FAILURE,
+            actor_email=user_data.email,
+            reason="unknown_email" if user is None else "bad_password",
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
@@ -169,6 +189,7 @@ async def login(
     await store_refresh_token(db, refresh_token, user.id)
     _set_auth_cookies(response, access_token, refresh_token)
 
+    audit(action="auth.login", actor=user)
     return TokenResponse(access_token=access_token, refresh_token=refresh_token)
 
 
@@ -209,12 +230,19 @@ async def refresh_tokens(
 
     rotated = await rotate_refresh_token(db, token_data.refresh_token, new_refresh_token, user.id)
     if not rotated:
+        audit(
+            action="auth.token_refresh",
+            outcome=OUTCOME_DENIED,
+            actor=user,
+            reason="refresh_token_replayed_or_revoked",
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token already used or revoked",
         )
 
     _set_auth_cookies(response, new_access_token, new_refresh_token)
+    audit(action="auth.token_refresh", actor=user)
     return TokenResponse(access_token=new_access_token, refresh_token=new_refresh_token)
 
 
@@ -226,9 +254,11 @@ async def logout(
 ) -> None:
     """Clear auth cookies and revoke the refresh token in the database."""
     raw_refresh = request.cookies.get("refresh_token", "")
+    actor_id = verify_refresh_token(raw_refresh) if raw_refresh else None
     if raw_refresh:
         await revoke_refresh_token(db, raw_refresh)
     _clear_auth_cookies(response)
+    audit(action="auth.logout", actor_id=actor_id)
 
 
 @router.get("/me", response_model=UserResponse)
@@ -289,6 +319,12 @@ async def change_password(
     db: AsyncSession = Depends(get_db),
 ) -> None:
     if not verify_password(password_data.current_password, current_user.hashed_password):
+        audit(
+            action="auth.password_change",
+            outcome=OUTCOME_FAILURE,
+            actor=current_user,
+            reason="current_password_incorrect",
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Current password is incorrect",
@@ -296,3 +332,4 @@ async def change_password(
 
     current_user.hashed_password = hash_password(password_data.new_password)
     await db.flush()
+    audit(action="auth.password_change", actor=current_user)

--- a/backend/app/api/boards.py
+++ b/backend/app/api/boards.py
@@ -58,6 +58,7 @@ from app.models.board_schemas import (
     CommentCreateRequest,
 )
 from app.services import board_run_service
+from app.services.audit_log import audit
 from app.services.credential_access import get_accessible_credential
 from app.services.execution_cancellation import ACTIVE_EXECUTION_STALE_AFTER_SECONDS
 from app.services.file_storage import (
@@ -379,6 +380,13 @@ async def create_board(
         )
     await db.commit()
     await db.refresh(board)
+    audit(
+        action="board.create",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+    )
     cred_name = await _mapper_credential_name(db, board)
     return _board_summary(
         board, column_count=len(DEFAULT_COLUMNS), card_count=0, cred_name=cred_name
@@ -455,6 +463,14 @@ async def update_board(
         board.mapper_credential_id = request.mapper_credential_id
     await db.commit()
     await db.refresh(board)
+    audit(
+        action="board.update",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        fields=",".join(sorted(fields_set)) or None,
+    )
     cred_name = await _mapper_credential_name(db, board)
     return _board_summary(board, column_count=0, card_count=0, cred_name=cred_name)
 
@@ -466,6 +482,13 @@ async def delete_board(
     current_user: User = Depends(get_current_user),
 ) -> None:
     board = await _get_owned_board(db, board_id, current_user)
+    audit(
+        action="board.delete",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+    )
     await db.delete(board)
     await db.commit()
 
@@ -492,6 +515,15 @@ async def create_column(
     db.add(column)
     await db.commit()
     await db.refresh(column)
+    audit(
+        action="board.column_create",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        column_id=column.id,
+        column_name=column.name,
+    )
     return BoardColumnResponse(
         id=column.id,
         board_id=column.board_id,
@@ -548,6 +580,16 @@ async def update_column(
             )
     await db.commit()
     await db.refresh(column)
+    audit(
+        action="board.column_update",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        column_id=column.id,
+        column_name=column.name,
+        fields=",".join(sorted(fields_set)) or None,
+    )
     workflows_by_column = await _column_workflow_responses(db, [column.id])
     return BoardColumnResponse(
         id=column.id,
@@ -592,6 +634,15 @@ async def delete_column(
     )
     for position, item in enumerate(remaining):
         item.position = position
+    audit(
+        action="board.column_delete",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        column_id=column_id,
+        column_name=column.name,
+    )
     await db.commit()
 
 
@@ -605,6 +656,15 @@ async def empty_column(
     """Delete every card in a board column."""
     board, _ = await _get_board_for_user(db, board_id, current_user, write=True)
     column = await _get_board_column(db, board, column_id)
+    audit(
+        action="board.column_empty",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        column_id=column.id,
+        column_name=column.name,
+    )
     await db.execute(delete(BoardCard).where(BoardCard.column_id == column.id))
     await db.commit()
 
@@ -662,6 +722,16 @@ async def create_card(
     )
     await db.commit()
     await db.refresh(card)
+    audit(
+        action="board.card_create",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        card_id=card.id,
+        card_title=card.title,
+        column_id=column.id,
+    )
     return _card_response(card)
 
 
@@ -750,6 +820,15 @@ async def update_card(
         await _reindex_cards(db, card.column_id)
     await db.commit()
     await db.refresh(card)
+    audit(
+        action="board.card_update",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        card_id=card.id,
+        card_title=card.title,
+    )
     return _card_response(card)
 
 
@@ -762,6 +841,15 @@ async def delete_card(
 ) -> None:
     board, _ = await _get_board_for_user(db, board_id, current_user, write=True)
     card = await _get_board_card(db, board, card_id)
+    audit(
+        action="board.card_delete",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        card_id=card.id,
+        card_title=card.title,
+    )
     await db.delete(card)
     await db.commit()
 
@@ -883,6 +971,17 @@ async def move_card(
             rerun=False,
             allow_advance=forward,
         )
+    audit(
+        action="board.card_move",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        card_id=card.id,
+        card_title=card.title,
+        from_column=source.name,
+        to_column=target.name,
+    )
     await db.refresh(card)
     return _card_response(card)
 
@@ -927,6 +1026,17 @@ async def run_card_chain(
             status_code=status.HTTP_409_CONFLICT,
             detail="A run is already active or the column has no workflows",
         )
+    audit(
+        action="board.card_run",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        card_id=card.id,
+        card_title=card.title,
+        column_name=column.name,
+        auto_advance=allow_advance,
+    )
     await db.refresh(card)
     return _card_response(card)
 
@@ -1087,6 +1197,16 @@ async def create_board_share(
         share.permission = permission
     await db.commit()
     await db.refresh(share)
+    audit(
+        action="board.share_add",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        grantee_id=target.id,
+        grantee_email=target.email,
+        permission=permission,
+    )
     return BoardShareResponse(
         id=share.id,
         user_id=target.id,
@@ -1112,6 +1232,14 @@ async def delete_board_share(
     ).scalar_one_or_none()
     if share is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+    audit(
+        action="board.share_remove",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        grantee_id=user_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -1172,6 +1300,16 @@ async def create_board_team_share(
         share.permission = permission
     await db.commit()
     await db.refresh(share)
+    audit(
+        action="board.team_share_add",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        team_id=team.id,
+        team_name=team.name,
+        permission=permission,
+    )
     return BoardTeamShareResponse(
         id=share.id,
         team_id=team.id,
@@ -1198,5 +1336,13 @@ async def delete_board_team_share(
     ).scalar_one_or_none()
     if share is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+    audit(
+        action="board.team_share_remove",
+        actor=current_user,
+        target_type="board",
+        target_id=board.id,
+        target_name=board.name,
+        team_id=team_id,
+    )
     await db.delete(share)
     await db.commit()

--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -38,6 +38,7 @@ from app.models.schemas import (
     TeamShareRequest,
     TeamShareResponse,
 )
+from app.services.audit_log import OUTCOME_DENIED, audit
 from app.services.codex_usage_service import fetch_codex_usage
 from app.services.embedding import (
     EMBEDDING_DIMENSIONS,
@@ -866,6 +867,14 @@ async def create_credential(
     masked = get_masked_value(credential.type, credential_data.config)
     header_key = get_header_key(credential.type, credential_data.config)
 
+    audit(
+        action="credential.create",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential.id,
+        target_name=credential.name,
+        credential_type=credential.type.value,
+    )
     return CredentialResponse(
         id=credential.id,
         name=credential.name,
@@ -1250,6 +1259,13 @@ async def get_credential(
         credential = team_result.scalar_one_or_none()
 
     if credential is None:
+        audit(
+            action="credential.detail_view",
+            outcome=OUTCOME_DENIED,
+            actor=current_user,
+            target_type="credential",
+            target_id=credential_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Credential not found",
@@ -1259,6 +1275,14 @@ async def get_credential(
     masked = get_masked_value(credential.type, config)
     header_key = get_header_key(credential.type, config)
 
+    audit(
+        action="credential.detail_view",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential.id,
+        target_name=credential.name,
+        owned=credential.owner_id == current_user.id,
+    )
     return CredentialResponse(
         id=credential.id,
         name=credential.name,
@@ -1331,6 +1355,14 @@ async def update_credential(
     masked = get_masked_value(credential.type, config)
     header_key = get_header_key(credential.type, config)
 
+    audit(
+        action="credential.update",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential.id,
+        target_name=credential.name,
+        config_changed=credential_data.config is not None,
+    )
     return CredentialResponse(
         id=credential.id,
         name=credential.name,
@@ -1357,11 +1389,26 @@ async def delete_credential(
     credential = result.scalar_one_or_none()
 
     if credential is None:
+        audit(
+            action="credential.delete",
+            outcome=OUTCOME_DENIED,
+            actor=current_user,
+            target_type="credential",
+            target_id=credential_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Credential not found",
         )
 
+    audit(
+        action="credential.delete",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential.id,
+        target_name=credential.name,
+        credential_type=credential.type.value,
+    )
     await db.delete(credential)
 
 
@@ -1960,6 +2007,15 @@ async def create_credential_share(
     await db.flush()
     await db.refresh(share)
 
+    audit(
+        action="credential.share_add",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential_id,
+        target_name=credential.name,
+        grantee_id=target_user.id,
+        grantee_email=target_user.email,
+    )
     return CredentialShareResponse(
         id=share.id,
         user_id=target_user.id,
@@ -2003,6 +2059,14 @@ async def delete_credential_share(
             detail="Share not found",
         )
 
+    audit(
+        action="credential.share_remove",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential_id,
+        target_name=credential.name,
+        grantee_id=user_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -2089,6 +2153,15 @@ async def create_credential_team_share(
     await db.flush()
     await db.refresh(share)
     await db.commit()
+    audit(
+        action="credential.team_share_add",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential_id,
+        target_name=credential.name,
+        team_id=team.id,
+        team_name=team.name,
+    )
     return TeamShareResponse(
         id=share.id,
         team_id=team.id,
@@ -2127,5 +2200,13 @@ async def delete_credential_team_share(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Team share not found",
         )
+    audit(
+        action="credential.team_share_remove",
+        actor=current_user,
+        target_type="credential",
+        target_id=credential_id,
+        target_name=credential.name,
+        team_id=team_id,
+    )
     await db.delete(share)
     await db.commit()

--- a/backend/app/api/data_tables.py
+++ b/backend/app/api/data_tables.py
@@ -40,6 +40,7 @@ from app.models.schemas import (
     DataTableTeamShareResponse,
     DataTableUpdate,
 )
+from app.services.audit_log import audit
 from app.services.encryption import decrypt_config
 from app.services.llm_provider import is_reasoning_model
 from app.services.llm_service import execute_llm
@@ -485,6 +486,14 @@ async def create_data_table(
     await db.flush()
     await db.refresh(table)
 
+    audit(
+        action="data_table.create",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table.id,
+        target_name=table.name,
+        columns=len(columns_json),
+    )
     return DataTableResponse(
         id=table.id,
         name=table.name,
@@ -562,6 +571,14 @@ async def update_data_table(
     await db.refresh(table)
     count = await _row_count(table.id, db)
 
+    audit(
+        action="data_table.update",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table.id,
+        target_name=table.name,
+        columns_changed=data.columns is not None,
+    )
     return DataTableResponse(
         id=table.id,
         name=table.name,
@@ -586,6 +603,13 @@ async def delete_data_table(
     table = result.scalar_one_or_none()
     if table is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data table not found")
+    audit(
+        action="data_table.delete",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table.id,
+        target_name=table.name,
+    )
     await db.delete(table)
 
 
@@ -639,6 +663,16 @@ async def clone_data_table(
     await db.flush()
     await db.refresh(new_table)
 
+    audit(
+        action="data_table.clone",
+        actor=current_user,
+        target_type="data_table",
+        target_id=new_table.id,
+        target_name=new_table.name,
+        source_id=source.id,
+        source_name=source.name,
+        rows_copied=row_count,
+    )
     return DataTableResponse(
         id=new_table.id,
         name=new_table.name,
@@ -717,6 +751,14 @@ async def create_row(
     await db.flush()
     await db.refresh(row)
 
+    audit(
+        action="data_table.row_create",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+        row_id=row.id,
+    )
     return DataTableRowResponse(
         id=row.id,
         table_id=row.table_id,
@@ -761,6 +803,15 @@ async def update_row(
     await db.flush()
     await db.refresh(row)
 
+    audit(
+        action="data_table.row_update",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+        row_id=row.id,
+        fields=",".join(sorted(row_data.data)) or None,
+    )
     return DataTableRowResponse(
         id=row.id,
         table_id=row.table_id,
@@ -779,13 +830,21 @@ async def delete_row(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    await _get_data_table_with_access(table_id, current_user.id, db, require_write=True)
+    table = await _get_data_table_with_access(table_id, current_user.id, db, require_write=True)
     result = await db.execute(
         select(DataTableRow).where(DataTableRow.id == row_id, DataTableRow.table_id == table_id)
     )
     row = result.scalar_one_or_none()
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Row not found")
+    audit(
+        action="data_table.row_delete",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+        row_id=row_id,
+    )
     await db.delete(row)
 
 
@@ -796,7 +855,14 @@ async def clear_rows(
     db: AsyncSession = Depends(get_db),
 ) -> None:
     """Delete all rows from a data table."""
-    await _get_data_table_with_access(table_id, current_user.id, db, require_write=True)
+    table = await _get_data_table_with_access(table_id, current_user.id, db, require_write=True)
+    audit(
+        action="data_table.rows_clear",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+    )
     await db.execute(sa_delete(DataTableRow).where(DataTableRow.table_id == table_id))
 
 
@@ -830,6 +896,16 @@ async def bulk_create_rows(
         await db.flush()
         imported += 1
 
+    audit(
+        action="data_table.rows_bulk_create",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+        imported=imported,
+        rejected=len(errors),
+        total=len(rows),
+    )
     return DataTableImportResponse(imported=imported, errors=errors, total=len(rows))
 
 
@@ -881,6 +957,17 @@ async def import_csv(
         await db.flush()
         imported += 1
 
+    audit(
+        action="data_table.import_csv",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+        file_name=file.filename,
+        imported=imported,
+        rejected=len(errors),
+        total=total,
+    )
     return DataTableImportResponse(imported=imported, errors=errors, total=total)
 
 
@@ -909,6 +996,14 @@ async def export_csv(
 
     output.seek(0)
     filename = f"{table.name}.csv".replace(" ", "_")
+    audit(
+        action="data_table.export_csv",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        target_name=table.name,
+        rows=len(rows),
+    )
     return StreamingResponse(
         iter([output.getvalue()]),
         media_type="text/csv",
@@ -997,6 +1092,15 @@ async def create_share(
     await db.flush()
     await db.refresh(share)
 
+    audit(
+        action="data_table.share_add",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        grantee_id=target_user.id,
+        grantee_email=target_user.email,
+        permission=share.permission,
+    )
     return DataTableShareResponse(
         id=share.id,
         user_id=target_user.id,
@@ -1028,6 +1132,13 @@ async def delete_share(
     share = share_result.scalar_one_or_none()
     if share is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share not found")
+    audit(
+        action="data_table.share_remove",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        grantee_id=user_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -1111,6 +1222,15 @@ async def create_team_share(
     await db.flush()
     await db.refresh(share)
     await db.commit()
+    audit(
+        action="data_table.team_share_add",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        team_id=team.id,
+        team_name=team.name,
+        permission=share.permission,
+    )
     return DataTableTeamShareResponse(
         id=share.id,
         team_id=team.id,
@@ -1141,6 +1261,13 @@ async def delete_team_share(
     share = share_result.scalar_one_or_none()
     if share is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team share not found")
+    audit(
+        action="data_table.team_share_remove",
+        actor=current_user,
+        target_type="data_table",
+        target_id=table_id,
+        team_id=team_id,
+    )
     await db.delete(share)
     await db.commit()
 

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -26,6 +26,7 @@ from app.models.schemas import (
     FileTeamSharingResponse,
     GeneratedFileResponse,
 )
+from app.services.audit_log import audit
 from app.services.file_storage import (
     build_download_url,
     create_access_token,
@@ -282,6 +283,13 @@ async def delete_file_endpoint(
     row = await _get_owned_file(db, file_id, user.id)
     if not row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+    audit(
+        action="drive.delete",
+        actor=user,
+        target_type="file",
+        target_id=row.id,
+        target_name=row.filename,
+    )
     await delete_file(db, row)
     await db.commit()
 
@@ -295,6 +303,7 @@ async def delete_all_files_endpoint(
 
     query = select(GeneratedFile).where(GeneratedFile.owner_id == user.id)
     rows = (await db.execute(query)).scalars().all()
+    audit(action="drive.delete_all", actor=user, target_type="file", count=len(rows))
     for row in rows:
         await delete_file(db, row)
     await db.commit()
@@ -317,6 +326,13 @@ async def bulk_delete_files(
         await delete_file(db, row)
         succeeded.append(file_id)
     await db.commit()
+    audit(
+        action="drive.bulk_delete",
+        actor=user,
+        target_type="file",
+        deleted=len(succeeded),
+        failed=len(failed),
+    )
     return BulkFileOperationResponse(succeeded=succeeded, failed=failed)
 
 
@@ -346,6 +362,16 @@ async def upload_file(
     if share_with_my_teams:
         await _set_file_team_sharing(db, file_id=row.id, owner_id=user.id, enabled=True)
     await db.commit()
+    audit(
+        action="drive.upload",
+        actor=user,
+        target_type="file",
+        target_id=row.id,
+        target_name=row.filename,
+        file_size=len(file_bytes),
+        mime=row.mime_type,
+        team_shared=share_with_my_teams,
+    )
     await _refresh_file_response_relations(db, row)
     return _file_to_response(row, base_url)
 
@@ -368,6 +394,15 @@ async def update_file_team_sharing(
         enabled=payload.enabled,
     )
     await db.commit()
+    audit(
+        action="drive.team_sharing_update",
+        actor=user,
+        target_type="file",
+        target_id=file_id,
+        target_name=row.filename,
+        enabled=payload.enabled,
+        shared_team_count=shared_team_count,
+    )
     return FileTeamSharingResponse(
         enabled=shared_team_count > 0,
         shared_team_count=shared_team_count,
@@ -396,6 +431,14 @@ async def bulk_update_file_team_sharing(
         )
         succeeded.append(file_id)
     await db.commit()
+    audit(
+        action="drive.bulk_team_sharing_update",
+        actor=user,
+        target_type="file",
+        enabled=payload.enabled,
+        updated=len(succeeded),
+        failed=len(failed),
+    )
     return BulkFileOperationResponse(succeeded=succeeded, failed=failed)
 
 
@@ -421,6 +464,17 @@ async def create_share(
         max_downloads=payload.max_downloads,
     )
     await db.commit()
+    audit(
+        action="drive.share_create",
+        actor=user,
+        target_type="file",
+        target_id=file_id,
+        target_name=row.filename,
+        share_id=token.id,
+        expires_hours=payload.expires_hours,
+        max_downloads=payload.max_downloads,
+        password_protected=payload.basic_auth_password is not None,
+    )
     return _token_to_response(token, base_url)
 
 
@@ -543,6 +597,14 @@ async def revoke_share(
     if not token:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Share token not found")
 
+    audit(
+        action="drive.share_revoke",
+        actor=user,
+        target_type="file",
+        target_id=file_id,
+        target_name=row.filename,
+        share_id=token_id,
+    )
     await db.delete(token)
     await db.commit()
 
@@ -564,6 +626,14 @@ async def download_authenticated_file(
             status_code=status.HTTP_404_NOT_FOUND, detail="File missing from storage"
         )
 
+    audit(
+        action="drive.download",
+        actor=user,
+        target_type="file",
+        target_id=file_row.id,
+        target_name=file_row.filename,
+        owned=file_row.owner_id == user.id,
+    )
     return FileResponse(
         path=str(disk_path),
         media_type=file_row.mime_type,

--- a/backend/app/api/folders.py
+++ b/backend/app/api/folders.py
@@ -19,6 +19,7 @@ from app.models.schemas import (
     FolderWithContentsResponse,
     WorkflowListResponse,
 )
+from app.services.audit_log import audit
 from app.services.workflow_last_trigger import (
     fetch_last_trigger_source,
     fetch_last_trigger_sources,
@@ -361,6 +362,14 @@ async def create_folder(
     db.add(folder)
     await db.commit()
     await db.refresh(folder)
+    audit(
+        action="folder.create",
+        actor=current_user,
+        target_type="folder",
+        target_id=folder.id,
+        target_name=folder.name,
+        parent_id=folder.parent_id,
+    )
     return folder
 
 
@@ -418,6 +427,14 @@ async def update_folder(
 
     await db.commit()
     await db.refresh(folder)
+    audit(
+        action="folder.update",
+        actor=current_user,
+        target_type="folder",
+        target_id=folder.id,
+        target_name=folder.name,
+        fields=",".join(sorted(data.model_fields_set)) or None,
+    )
     return folder
 
 
@@ -456,6 +473,13 @@ async def delete_folder(
     if not folder:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Folder not found")
 
+    audit(
+        action="folder.delete",
+        actor=current_user,
+        target_type="folder",
+        target_id=folder.id,
+        target_name=folder.name,
+    )
     await db.delete(folder)
     await db.commit()
 
@@ -484,6 +508,15 @@ async def move_workflow_to_folder(
     if not workflow:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found")
 
+    audit(
+        action="folder.workflow_move",
+        actor=current_user,
+        target_type="folder",
+        target_id=folder_id,
+        target_name=folder.name,
+        workflow_id=workflow_id,
+        workflow_name=workflow.name,
+    )
     if workflow.owner_id == current_user.id:
         workflow.folder_id = folder_id
         await db.commit()

--- a/backend/app/api/global_variables.py
+++ b/backend/app/api/global_variables.py
@@ -27,6 +27,7 @@ from app.models.schemas import (
     TeamShareRequest,
     TeamShareResponse,
 )
+from app.services.audit_log import audit
 
 router = APIRouter()
 
@@ -192,6 +193,14 @@ async def create_global_variable(
     await db.flush()
     await db.refresh(variable)
 
+    audit(
+        action="variable.create",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable.id,
+        target_name=variable.name,
+        value_type=variable.value_type,
+    )
     return GlobalVariableResponse(
         id=variable.id,
         name=variable.name,
@@ -353,6 +362,14 @@ async def update_global_variable(
     await db.flush()
     await db.refresh(variable)
 
+    audit(
+        action="variable.update",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable.id,
+        target_name=variable.name,
+        value_changed=data.value is not None,
+    )
     return GlobalVariableResponse(
         id=variable.id,
         name=variable.name,
@@ -381,6 +398,13 @@ async def delete_global_variable(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Variable not found",
         )
+    audit(
+        action="variable.delete",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable.id,
+        target_name=variable.name,
+    )
     await db.delete(variable)
     await db.flush()
 
@@ -398,6 +422,13 @@ async def bulk_delete_global_variables(
         )
     )
     variables = result.scalars().all()
+    audit(
+        action="variable.bulk_delete",
+        actor=current_user,
+        target_type="variable",
+        count=len(variables),
+        requested=len(body.ids),
+    )
     for v in variables:
         await db.delete(v)
     await db.flush()
@@ -498,6 +529,15 @@ async def create_global_variable_share(
     await db.flush()
     await db.refresh(share)
 
+    audit(
+        action="variable.share_add",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable_id,
+        grantee_id=target_user.id,
+        grantee_email=target_user.email,
+    )
+
     return GlobalVariableShareResponse(
         id=share.id,
         user_id=target_user.id,
@@ -540,6 +580,14 @@ async def delete_global_variable_share(
             detail="Share not found",
         )
 
+    audit(
+        action="variable.share_remove",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable_id,
+        target_name=variable.name,
+        grantee_id=user_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -628,6 +676,14 @@ async def create_global_variable_team_share(
     await db.flush()
     await db.refresh(share)
     await db.commit()
+    audit(
+        action="variable.team_share_add",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable_id,
+        team_id=team.id,
+        team_name=team.name,
+    )
     return TeamShareResponse(
         id=share.id,
         team_id=team.id,
@@ -667,5 +723,13 @@ async def delete_global_variable_team_share(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Team share not found",
         )
+    audit(
+        action="variable.team_share_remove",
+        actor=current_user,
+        target_type="variable",
+        target_id=variable_id,
+        target_name=variable.name,
+        team_id=team_id,
+    )
     await db.delete(share)
     await db.commit()

--- a/backend/app/api/teams.py
+++ b/backend/app/api/teams.py
@@ -34,6 +34,7 @@ from app.models.schemas import (
     TeamSharedEntityItem,
     TeamUpdate,
 )
+from app.services.audit_log import OUTCOME_DENIED, audit
 
 router = APIRouter(tags=["teams"])
 
@@ -75,6 +76,14 @@ async def create_team(
     await _ensure_team_member(db, team, current_user.id)
     await db.commit()
     await db.refresh(team)
+
+    audit(
+        action="team.create",
+        actor=current_user,
+        target_type="team",
+        target_id=team.id,
+        target_name=team.name,
+    )
 
     members_result = await db.execute(
         select(TeamMember, User)
@@ -349,6 +358,14 @@ async def update_team(
     await db.commit()
     await db.refresh(team)
 
+    audit(
+        action="team.update",
+        actor=current_user,
+        target_type="team",
+        target_id=team.id,
+        target_name=team.name,
+    )
+
     count_result = await db.execute(
         select(func.count(TeamMember.id)).where(TeamMember.team_id == team.id)
     )
@@ -380,8 +397,24 @@ async def delete_team(
     if not team:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Team not found")
     if team.creator_id != current_user.id:
+        audit(
+            action="team.delete",
+            outcome=OUTCOME_DENIED,
+            actor=current_user,
+            target_type="team",
+            target_id=team.id,
+            target_name=team.name,
+            reason="not_creator",
+        )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only creator can delete")
 
+    audit(
+        action="team.delete",
+        actor=current_user,
+        target_type="team",
+        target_id=team.id,
+        target_name=team.name,
+    )
     await db.delete(team)
     await db.commit()
 
@@ -421,6 +454,15 @@ async def add_team_member(
         )
         db.add(member)
         await db.flush()
+        audit(
+            action="team.member_add",
+            actor=current_user,
+            target_type="team",
+            target_id=team.id,
+            target_name=team.name,
+            member_id=user.id,
+            member_email=user.email,
+        )
 
     await db.commit()
     return await get_team(team.id, db, current_user)
@@ -454,6 +496,14 @@ async def remove_team_member(
     if not member:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Member not found")
 
+    audit(
+        action="team.member_remove",
+        actor=current_user,
+        target_type="team",
+        target_id=team.id,
+        target_name=team.name,
+        member_id=user_id,
+    )
     await db.delete(member)
     await db.commit()
     return await get_team(team.id, db, current_user)

--- a/backend/app/api/vector_stores.py
+++ b/backend/app/api/vector_stores.py
@@ -37,6 +37,7 @@ from app.models.schemas import (
     VectorStoreUpdate,
     VectorStoreUploadResponse,
 )
+from app.services.audit_log import audit
 from app.services.encryption import decrypt_config
 from app.services.file_processor import create_file_processor
 from app.services.upload_limits import read_upload_file_limited
@@ -336,6 +337,14 @@ async def create_vector_store(
     await db.flush()
     await db.refresh(store)
 
+    audit(
+        action="vector_store.create",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=store.id,
+        target_name=store.name,
+        collection=store.collection_name,
+    )
     return VectorStoreResponse(
         id=store.id,
         name=store.name,
@@ -415,6 +424,14 @@ async def update_vector_store(
     await db.flush()
     await db.refresh(store)
 
+    audit(
+        action="vector_store.update",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=store.id,
+        target_name=store.name,
+    )
+
     stats = await _get_store_stats(store, db)
 
     return VectorStoreResponse(
@@ -465,6 +482,14 @@ async def delete_vector_store(
         except Exception:
             pass
 
+    audit(
+        action="vector_store.delete",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=store.id,
+        target_name=store.name,
+        collection_dropped=delete_collection,
+    )
     await db.delete(store)
 
 
@@ -515,6 +540,16 @@ async def clone_vector_store(
     db.add(new_store)
     await db.flush()
     await db.refresh(new_store)
+
+    audit(
+        action="vector_store.clone",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=new_store.id,
+        target_name=new_store.name,
+        source_id=store.id,
+        source_name=store.name,
+    )
 
     stats = await _get_store_stats(new_store, db)
 
@@ -625,6 +660,17 @@ async def upload_file_to_vector_store(
             detail=f"Failed to insert vectors: {e!s}",
         )
 
+    audit(
+        action="vector_store.upload",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=store.id,
+        target_name=store.name,
+        file_name=filename,
+        file_size=file_size,
+        points_inserted=len(point_ids),
+        replaced_duplicates=override_duplicates,
+    )
     return VectorStoreUploadResponse(
         chunks_processed=len(chunks),
         points_inserted=len(point_ids),
@@ -728,6 +774,15 @@ async def create_vector_store_share(
     await db.flush()
     await db.refresh(share)
 
+    audit(
+        action="vector_store.share_add",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=vector_store_id,
+        target_name=store.name,
+        grantee_id=target_user.id,
+        grantee_email=target_user.email,
+    )
     return VectorStoreShareResponse(
         id=share.id,
         user_id=target_user.id,
@@ -775,6 +830,14 @@ async def delete_vector_store_share(
             detail="Share not found",
         )
 
+    audit(
+        action="vector_store.share_remove",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=vector_store_id,
+        target_name=store.name,
+        grantee_id=user_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -863,6 +926,15 @@ async def create_vector_store_team_share(
     await db.flush()
     await db.refresh(share)
     await db.commit()
+    audit(
+        action="vector_store.team_share_add",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=vector_store_id,
+        target_name=store.name,
+        team_id=team.id,
+        team_name=team.name,
+    )
     return TeamShareResponse(
         id=share.id,
         team_id=team.id,
@@ -905,6 +977,14 @@ async def delete_vector_store_team_share(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Team share not found",
         )
+    audit(
+        action="vector_store.team_share_remove",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=vector_store_id,
+        target_name=store.name,
+        team_id=team_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -990,6 +1070,14 @@ async def delete_items_by_source(
 
     config = decrypt_config(credential.encrypted_config)
     service = get_vector_store_service_from_config(config, credential.type)
+    audit(
+        action="vector_store.items_delete_by_source",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=store.id,
+        target_name=store.name,
+        source=source,
+    )
     service.delete_by_source(store.collection_name, source)
 
 
@@ -1027,6 +1115,14 @@ async def delete_item(
 
     config = decrypt_config(credential.encrypted_config)
     service = get_vector_store_service_from_config(config, credential.type)
+    audit(
+        action="vector_store.item_delete",
+        actor=current_user,
+        target_type="vector_store",
+        target_id=store.id,
+        target_name=store.name,
+        point_id=point_id,
+    )
     service.delete_point(store.collection_name, point_id)
 
 

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -67,6 +67,7 @@ from app.models.schemas import (
 )
 from app.services import file_intake_service
 from app.services.active_execution_overview import collect_active_executions_for_user
+from app.services.audit_log import OUTCOME_DENIED, audit
 from app.services.auth import create_workflow_execution_token, decode_token
 from app.services.cache_rate_limit import rate_limiter, response_cache
 from app.services.codex_followup_service import (
@@ -1398,6 +1399,15 @@ async def create_workflow(
         workflow_id=workflow.id,
         dedupe_key=f"{EVENT_WORKFLOW_CREATED}:{workflow.id}",
     )
+    audit(
+        action="workflow.create",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow.id,
+        target_name=workflow.name,
+        kind=getattr(workflow, "kind", "workflow"),
+        nodes=len(workflow.nodes or []),
+    )
     return _build_workflow_response(workflow, current_user.id)
 
 
@@ -1660,6 +1670,16 @@ async def update_workflow(
             workflow_id=workflow.id,
             dedupe_key=f"{EVENT_WORKFLOW_UPDATED}:{workflow.id}:{updated_payload['updated_at']}",
         )
+    audit(
+        action="workflow.update",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow.id,
+        target_name=workflow.name,
+        owned=workflow.owner_id == current_user.id,
+        versioned=should_create_version,
+        nodes=len(workflow.nodes or []),
+    )
     return _build_workflow_response(workflow, current_user.id)
 
 
@@ -1695,10 +1715,28 @@ async def delete_workflow(
         )
 
     if workflow.owner_id != current_user.id:
+        audit(
+            action="workflow.delete",
+            outcome=OUTCOME_DENIED,
+            actor=current_user,
+            target_type="workflow",
+            target_id=workflow.id,
+            target_name=workflow.name,
+            reason="not_owner",
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only the owner can delete this workflow",
         )
+
+    audit(
+        action="workflow.delete",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow.id,
+        target_name=workflow.name,
+        kind=getattr(workflow, "kind", "workflow"),
+    )
 
     # Capture the identity before the row goes away; the event reports a workflow
     # that no longer exists by the time anyone reads it.
@@ -2045,6 +2083,14 @@ async def revert_workflow_to_version(
     await db.flush()
     await db.refresh(workflow)
 
+    audit(
+        action="workflow.version_revert",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow.id,
+        target_name=workflow.name,
+        version_id=version_id,
+    )
     return _build_workflow_response(workflow, current_user.id)
 
 
@@ -2164,6 +2210,15 @@ async def create_workflow_share(
         db.add(share)
         await db.flush()
         await db.refresh(share)
+        audit(
+            action="workflow.share_add",
+            actor=current_user,
+            target_type="workflow",
+            target_id=workflow.id,
+            target_name=workflow.name,
+            grantee_id=target_user.id,
+            grantee_email=target_user.email,
+        )
 
     return WorkflowShareResponse(
         id=share.id,
@@ -2205,6 +2260,14 @@ async def remove_workflow_share(
             detail="Share not found",
         )
 
+    audit(
+        action="workflow.share_remove",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        target_name=workflow.name,
+        grantee_id=user_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -2291,6 +2354,15 @@ async def create_workflow_team_share(
     await db.flush()
     await db.refresh(share)
     await db.commit()
+    audit(
+        action="workflow.team_share_add",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        target_name=workflow.name,
+        team_id=team.id,
+        team_name=team.name,
+    )
     return TeamShareResponse(
         id=share.id,
         team_id=team.id,
@@ -2329,6 +2401,14 @@ async def remove_workflow_team_share(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Team share not found",
         )
+    audit(
+        action="workflow.team_share_remove",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        target_name=workflow.name,
+        team_id=team_id,
+    )
     await db.delete(share)
     await db.commit()
 
@@ -2423,6 +2503,15 @@ async def create_execution_token_endpoint(
     db.add(row)
     await db.commit()
     await db.refresh(row)
+    audit(
+        action="workflow.execution_token_create",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        target_name=workflow.name,
+        jti=jti,
+        expires_at=expires_at,
+    )
     return ExecutionTokenResponse.model_validate(row)
 
 
@@ -2466,6 +2555,13 @@ async def revoke_execution_token_endpoint(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
     row.revoked = True
     await db.commit()
+    audit(
+        action="workflow.execution_token_revoke",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        jti=row.jti,
+    )
 
 
 async def validate_workflow_auth(
@@ -3327,6 +3423,16 @@ async def get_execution_history(
         )
         for h in history
     ]
+    audit(
+        action="workflow.history_view",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        target_name=workflow.name,
+        owned=workflow.owner_id == current_user.id,
+        returned=len(items),
+        total=total,
+    )
     return HistoryListResponse(total=total, items=items)
 
 
@@ -3344,6 +3450,13 @@ async def clear_execution_history(
             detail="Workflow not found",
         )
 
+    audit(
+        action="workflow.history_clear",
+        actor=current_user,
+        target_type="workflow",
+        target_id=workflow_id,
+        target_name=workflow.name,
+    )
     await db.execute(
         ExecutionHistory.__table__.delete().where(ExecutionHistory.workflow_id == workflow_id)
     )

--- a/backend/app/services/audit_log.py
+++ b/backend/app/services/audit_log.py
@@ -1,0 +1,108 @@
+"""Structured audit trail for security-relevant actions.
+
+Records are emitted through the ``winston.audit`` logger as single, self-contained
+lines on stdout, so they reach the Logs tab alongside the access log while staying
+separable from it (``grep "[winston.audit]"``). Nothing is written to the database.
+
+Callers pass identifiers, names, and counts only. ``_redact`` is a safety net for a
+caller mistake, not the primary defence: a secret value must never be handed to
+``audit()`` in the first place.
+
+Client IPs are deliberately absent. Behind a load balancer they are either the
+proxy's own address or a spoofable forwarded header, so they identify the user
+without reliably identifying anything else.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from app.db.models import User
+
+logger = logging.getLogger("winston.audit")
+
+# Any detail key containing one of these loses its value. Over-redaction is
+# deliberate: an unhelpful line beats a leaked credential.
+_SENSITIVE_KEY_PARTS = (
+    "password",
+    "passphrase",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "private_key",
+    "access_key",
+    "authorization",
+    "cookie",
+    "credential_data",
+    "value",
+)
+
+_REDACTED = "***"
+_MAX_VALUE_LEN = 256
+
+OUTCOME_SUCCESS = "success"
+OUTCOME_FAILURE = "failure"
+OUTCOME_DENIED = "denied"
+
+
+def _is_sensitive(key: str) -> bool:
+    lowered = key.lower()
+    return any(part in lowered for part in _SENSITIVE_KEY_PARTS)
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    text = str(value)
+    if len(text) > _MAX_VALUE_LEN:
+        text = text[:_MAX_VALUE_LEN] + "...(truncated)"
+    if text == "" or any(char in text for char in ' ="') or "\n" in text:
+        escaped = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+        return f'"{escaped}"'
+    return text
+
+
+def _render(pairs: list[tuple[str, Any]]) -> str:
+    return " ".join(f"{key}={_format_value(value)}" for key, value in pairs if value is not None)
+
+
+def audit(
+    *,
+    action: str,
+    actor: User | None = None,
+    outcome: str = OUTCOME_SUCCESS,
+    target_type: str | None = None,
+    target_id: uuid.UUID | str | None = None,
+    target_name: str | None = None,
+    actor_id: uuid.UUID | str | None = None,
+    actor_email: str | None = None,
+    **detail: Any,
+) -> None:
+    """Emit one audit line. Never raises, never blocks, never touches the database."""
+    try:
+        resolved_actor_id = actor.id if actor is not None else actor_id
+        resolved_actor_email = actor.email if actor is not None else actor_email
+
+        pairs: list[tuple[str, Any]] = [
+            ("action", action),
+            ("outcome", outcome),
+            ("actor_id", resolved_actor_id),
+            ("actor_email", resolved_actor_email),
+        ]
+        if target_id is not None or target_name is not None:
+            pairs.append(
+                ("target", f"{target_type or 'unknown'}:{target_id}" if target_id else None)
+            )
+            pairs.append(("target_name", target_name))
+        elif target_type is not None:
+            pairs.append(("target_type", target_type))
+
+        for key, value in detail.items():
+            pairs.append((key, _REDACTED if _is_sensitive(key) and value is not None else value))
+
+        logger.info("audit %s", _render(pairs))
+    except Exception:  # pragma: no cover - an audit failure must never break a request
+        logger.warning("audit emit failed for action=%s", action, exc_info=True)

--- a/backend/tests/test_audit_log.py
+++ b/backend/tests/test_audit_log.py
@@ -1,0 +1,274 @@
+"""Audit trail emitted through the winston logger."""
+
+import ast
+import logging
+import pathlib
+import re
+import unittest
+import uuid
+from unittest.mock import MagicMock
+
+from app.services import audit_log
+from app.services.audit_log import OUTCOME_DENIED, OUTCOME_FAILURE, audit
+
+ACTION_PATTERN = re.compile(r"^[a-z_]+\.[a-z_]+$")
+
+# The areas this change was asked to cover. A resource losing every call site
+# should fail here rather than silently stop being audited.
+COVERED_RESOURCES = {
+    "auth",
+    "workflow",
+    "credential",
+    "variable",
+    "vector_store",
+    "alert",
+    "data_table",
+    "board",
+    "drive",
+    "team",
+    "folder",
+}
+
+
+def _audit_actions_in_api() -> set[str]:
+    """Collect the `action=` literal of every audit() call under app/api."""
+    api_dir = pathlib.Path(__file__).resolve().parent.parent / "app" / "api"
+    found: set[str] = set()
+    for path in api_dir.glob("*.py"):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (isinstance(node.func, ast.Name) and node.func.id == "audit"):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg == "action" and isinstance(keyword.value, ast.Constant):
+                    found.add(keyword.value.value)
+    return found
+
+
+def _fake_user(email: str = "burak@example.com") -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    user.email = email
+    return user
+
+
+def _audit_kwargs_in_api() -> set[str]:
+    """Collect every keyword argument name used at an audit() call site."""
+    api_dir = pathlib.Path(__file__).resolve().parent.parent / "app" / "api"
+    found: set[str] = set()
+    for path in api_dir.glob("*.py"):
+        for node in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (isinstance(node.func, ast.Name) and node.func.id == "audit"):
+                continue
+            found.update(kw.arg for kw in node.keywords if kw.arg)
+    return found
+
+
+class AuditLineFormatTests(unittest.TestCase):
+    def _emit(self, **kwargs) -> str:
+        with self.assertLogs("winston.audit", level="INFO") as captured:
+            audit(**kwargs)
+        self.assertEqual(len(captured.records), 1)
+        return captured.records[0].getMessage()
+
+    def test_actor_identity_is_always_present(self) -> None:
+        line = self._emit(action="workflow.delete", actor=_fake_user())
+
+        self.assertIn("actor_id=11111111-1111-1111-1111-111111111111", line)
+        self.assertIn("actor_email=burak@example.com", line)
+
+    def test_action_and_default_outcome(self) -> None:
+        line = self._emit(action="credential.create", actor=_fake_user())
+
+        self.assertIn("action=credential.create", line)
+        self.assertIn("outcome=success", line)
+
+    def test_failure_and_denied_outcomes_are_recorded(self) -> None:
+        failed = self._emit(
+            action="auth.login", outcome=OUTCOME_FAILURE, actor_email="nobody@example.com"
+        )
+        denied = self._emit(action="credential.delete", outcome=OUTCOME_DENIED, actor=_fake_user())
+
+        self.assertIn("outcome=failure", failed)
+        self.assertIn("actor_email=nobody@example.com", failed)
+        self.assertIn("outcome=denied", denied)
+
+    def test_anonymous_actor_omits_identity_rather_than_inventing_one(self) -> None:
+        line = self._emit(action="auth.logout")
+
+        self.assertNotIn("actor_id=", line)
+        self.assertNotIn("actor_email=", line)
+
+    def test_target_is_rendered_as_type_colon_id(self) -> None:
+        target = uuid.UUID("22222222-2222-2222-2222-222222222222")
+        line = self._emit(
+            action="workflow.delete",
+            actor=_fake_user(),
+            target_type="workflow",
+            target_id=target,
+            target_name="Nightly sync",
+        )
+
+        self.assertIn(f"target=workflow:{target}", line)
+        self.assertIn('target_name="Nightly sync"', line)
+
+    def test_record_is_a_single_line(self) -> None:
+        line = self._emit(
+            action="board.card_create",
+            actor=_fake_user(),
+            card_title="line one\nline two",
+        )
+
+        self.assertNotIn("\n", line)
+
+    def test_booleans_render_as_words_not_python_repr(self) -> None:
+        line = self._emit(action="workflow.update", actor=_fake_user(), owned=True)
+
+        self.assertIn("owned=true", line)
+
+    def test_none_details_are_dropped(self) -> None:
+        line = self._emit(action="alert.update", actor=_fake_user(), fields=None)
+
+        self.assertNotIn("fields=", line)
+
+    def test_logger_name_separates_audit_from_access_log(self) -> None:
+        with self.assertLogs("winston.audit", level="INFO") as captured:
+            audit(action="team.create", actor=_fake_user())
+
+        self.assertEqual(captured.records[0].name, "winston.audit")
+
+
+class AuditRedactionTests(unittest.TestCase):
+    """The denylist is a safety net; a secret must never be passed in the first place."""
+
+    def _emit(self, **kwargs) -> str:
+        with self.assertLogs("winston.audit", level="INFO") as captured:
+            audit(**kwargs)
+        return captured.records[0].getMessage()
+
+    def test_secret_shaped_keys_never_reach_the_log(self) -> None:
+        secret = "sk-live-do-not-log-this"
+        for key in (
+            "password",
+            "api_key",
+            "apiKey",
+            "access_token",
+            "refresh_token",
+            "client_secret",
+            "credential_data",
+            "value",
+            "Authorization",
+            "cookie",
+            "private_key",
+            "passphrase",
+        ):
+            with self.subTest(key=key):
+                line = self._emit(action="credential.create", **{key: secret})
+
+                self.assertNotIn(secret, line)
+                self.assertIn("***", line)
+
+    def test_long_values_are_truncated(self) -> None:
+        line = self._emit(action="drive.upload", target_name="x" * 5000)
+
+        self.assertIn("...(truncated)", line)
+        self.assertLess(len(line), 1000)
+
+    def test_safe_details_are_kept_verbatim(self) -> None:
+        line = self._emit(action="data_table.import_csv", imported=42, rejected=0)
+
+        self.assertIn("imported=42", line)
+        self.assertIn("rejected=0", line)
+
+
+class AuditNeverBreaksTheRequestTests(unittest.TestCase):
+    def test_a_detail_that_cannot_be_stringified_does_not_raise(self) -> None:
+        class Hostile:
+            def __str__(self) -> str:
+                raise RuntimeError("boom")
+
+        with self.assertLogs("winston.audit", level="WARNING") as captured:
+            audit(action="workflow.update", detail=Hostile())
+
+        self.assertIn("audit emit failed", captured.records[0].getMessage())
+
+    def test_a_broken_actor_does_not_raise(self) -> None:
+        actor = MagicMock()
+        type(actor).id = property(lambda _: (_ for _ in ()).throw(RuntimeError("boom")))
+
+        with self.assertLogs("winston.audit", level="WARNING"):
+            audit(action="workflow.update", actor=actor)
+
+
+class NoClientIpTests(unittest.TestCase):
+    """Client IPs are deliberately not audited.
+
+    Behind a load balancer the value is either the proxy's address or a spoofable
+    forwarded header, so it identifies the user without identifying the request.
+    These assertions exist so it cannot quietly come back.
+    """
+
+    def test_no_ip_field_is_emitted(self) -> None:
+        with self.assertLogs("winston.audit", level="INFO") as captured:
+            audit(
+                action="auth.login",
+                actor=_fake_user(),
+                target_type="workflow",
+                target_id=uuid.uuid4(),
+            )
+
+        self.assertNotIn("ip=", captured.records[0].getMessage())
+
+    def test_an_ip_passed_as_a_detail_is_still_recorded_by_name(self) -> None:
+        """The helper does not scrub a caller's own field; call sites must not add one."""
+        with self.assertLogs("winston.audit", level="INFO") as captured:
+            audit(action="auth.login", client_ip="203.0.113.7")
+
+        self.assertIn("client_ip=203.0.113.7", captured.records[0].getMessage())
+
+    def test_no_call_site_passes_an_ip(self) -> None:
+        forbidden = {"ip", "client_ip", "remote_addr", "source_ip", "forwarded_for"}
+        offenders = sorted(_audit_kwargs_in_api() & forbidden)
+
+        self.assertEqual(offenders, [])
+
+
+class ActionTaxonomyTests(unittest.TestCase):
+    """Every emitted action name must be `<resource>.<verb>` in snake_case."""
+
+    def test_call_sites_use_the_documented_shape(self) -> None:
+        found = _audit_actions_in_api()
+
+        self.assertTrue(found, "no audit call sites found")
+        for action in sorted(found):
+            with self.subTest(action=action):
+                self.assertRegex(action, ACTION_PATTERN)
+
+    def test_every_covered_area_has_at_least_one_action(self) -> None:
+        prefixes = {action.split(".", 1)[0] for action in _audit_actions_in_api()}
+
+        self.assertEqual(COVERED_RESOURCES - prefixes, set())
+
+
+class LoggerWiringTests(unittest.TestCase):
+    def test_audit_logger_is_a_child_of_winston(self) -> None:
+        """It shares winston's stdout handler but greps apart from the access log."""
+        # app.main creates the "winston" logger at import; create it here so the
+        # hierarchy is the same one production sees regardless of import order.
+        logging.getLogger("winston")
+
+        self.assertEqual(audit_log.logger.name, "winston.audit")
+        self.assertEqual(logging.getLogger("winston.audit").parent.name, "winston")
+
+    def test_records_propagate_to_the_root_handler(self) -> None:
+        """basicConfig installs the stdout handler on root; propagation carries us there."""
+        self.assertTrue(audit_log.logger.propagate)
+        self.assertEqual(audit_log.logger.handlers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_execution_tokens.py
+++ b/backend/tests/test_execution_tokens.py
@@ -75,7 +75,9 @@ class ExecutionTokenEndpointTests(unittest.IsolatedAsyncioTestCase):
         return SimpleNamespace(id=uuid.uuid4())
 
     def _workflow(self, owner_id: uuid.UUID | None = None) -> SimpleNamespace:
-        return SimpleNamespace(id=uuid.uuid4(), owner_id=owner_id or uuid.uuid4())
+        return SimpleNamespace(
+            id=uuid.uuid4(), owner_id=owner_id or uuid.uuid4(), name="Nightly sync"
+        )
 
     async def test_create_inserts_row_and_returns_token(self) -> None:
         user = self._user()
@@ -175,7 +177,7 @@ class ExecutionTokenEndpointTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_revoke_sets_revoked_true(self) -> None:
         user = self._user()
-        token_row = SimpleNamespace(id=uuid.uuid4(), revoked=False)
+        token_row = SimpleNamespace(id=uuid.uuid4(), jti=uuid.uuid4(), revoked=False)
         db = AsyncMock()
         db.execute = AsyncMock(return_value=_ScalarResult(token_row))
         db.commit = AsyncMock()

--- a/frontend/src/docs/content/reference/audit.md
+++ b/frontend/src/docs/content/reference/audit.md
@@ -1,0 +1,127 @@
+# Audit Logging
+
+Heym writes an audit line for every security-relevant action: who did it, what they did it to, and whether it succeeded. Lines go to the backend's standard output through the `winston.audit` logger, alongside the request access log, and can be read from the **Logs** tab or with `docker logs`.
+
+Audit logging is **always on**. There is nothing to enable and no environment variable to set.
+
+## Line Format
+
+One action produces exactly one self-contained line:
+
+```
+2026-08-25 14:02:11 INFO [winston.audit] audit action=credential.delete outcome=success actor_id=8f2c1b04-3d5a-4f21-9c7e-1a2b3c4d5e6f actor_email=alex@example.com target=credential:3a91d7e2-55c8-4b19-b0a1-9e8d7c6b5a43 target_name="OpenAI Prod" credential_type=openai
+```
+
+Every line carries these fields:
+
+| Field | Description |
+|-------|-------------|
+| `action` | What happened, as `resource.verb` — see the table below. |
+| `outcome` | `success`, `failure`, or `denied`. |
+| `actor_id` | UUID of the user who performed the action. Absent only when nobody was authenticated. |
+| `actor_email` | Email of that user. On a failed login this is the address that was tried, not a confirmed account. |
+| `target` | The object acted on, as `type:uuid`. |
+| `target_name` | Human-readable name of that object, quoted when it contains spaces. |
+
+Action-specific fields follow — for example `credential_type`, `imported`, `grantee_email`, `team_name`. Values containing a space, quote, or `=` are quoted; values longer than 256 characters are cut with a `...(truncated)` marker.
+
+## Reading the Log
+
+The audit logger is a child of the request logger, so both reach the same stream while staying separable:
+
+```bash
+# Only audit lines, no access-log noise
+docker logs heym-backend 2>&1 | grep '\[winston.audit\]'
+
+# Everything one user did
+docker logs heym-backend 2>&1 | grep 'actor_email=alex@example.com'
+
+# Failed logins and refused access
+docker logs heym-backend 2>&1 | grep -E 'outcome=(failure|denied)'
+
+# Everything that touched one credential
+docker logs heym-backend 2>&1 | grep 'target=credential:3a91d7e2-55c8-4b19-b0a1-9e8d7c6b5a43'
+```
+
+In the app, the **Logs** tab reads the same container output. It is gated by `DOCKER_LOGS_ENABLED` and the `DOCKER_LOGS_ALLOWED_EMAILS` allowlist.
+
+## What Is Logged
+
+Every state change is logged. Reads are logged only where reading is itself the sensitive act — viewing a workflow's run history, opening a credential, downloading a file. Ordinary list and detail reads are not audited; the access log already records that a request happened, and auditing every `GET` would bury the lines that matter.
+
+### Authentication
+
+| Action | Notes |
+|--------|-------|
+| `auth.register` | `outcome=denied` when registration is disabled, `failure` when the email is taken. |
+| `auth.login` | `outcome=failure` records the attempted address and whether the email was unknown or the password wrong. |
+| `auth.logout` | The actor is resolved from the refresh cookie, so a logout without one is logged with no identity. |
+| `auth.token_refresh` | `outcome=denied` with `reason=refresh_token_replayed_or_revoked` — a token-theft signal worth alerting on. |
+| `auth.password_change` | `outcome=failure` when the current password was wrong. |
+
+### Workflows
+
+`workflow.create` · `workflow.update` · `workflow.delete` · `workflow.version_revert` · `workflow.history_view` · `workflow.history_clear` · `workflow.share_add` · `workflow.share_remove` · `workflow.team_share_add` · `workflow.team_share_remove` · `workflow.execution_token_create` · `workflow.execution_token_revoke`
+
+`workflow.history_view` records `owned=false` when a collaborator reads someone else's run history. `workflow.delete` records `outcome=denied` with `reason=not_owner` when a collaborator tries to delete.
+
+### Credentials
+
+`credential.create` · `credential.update` · `credential.delete` · `credential.detail_view` · `credential.share_add` · `credential.share_remove` · `credential.team_share_add` · `credential.team_share_remove`
+
+`credential.detail_view` is audited because opening a credential decrypts it. A miss logs `outcome=denied`, which is what a credential-id enumeration attempt looks like.
+
+### Other resources
+
+| Resource | Actions |
+|----------|---------|
+| Variables | `variable.create` · `update` · `delete` · `bulk_delete` · `share_add` · `share_remove` · `team_share_add` · `team_share_remove` |
+| Vector stores | `vector_store.create` · `update` · `delete` · `clone` · `upload` · `item_delete` · `items_delete_by_source` · `share_add` · `share_remove` · `team_share_add` · `team_share_remove` |
+| Alerts | `alert.create` · `update` · `delete` · `event_acknowledge` · `share_add` · `share_remove` · `team_share_add` · `team_share_remove` |
+| Data tables | `data_table.create` · `update` · `delete` · `clone` · `row_create` · `row_update` · `row_delete` · `rows_clear` · `rows_bulk_create` · `import_csv` · `export_csv` · `share_add` · `share_remove` · `team_share_add` · `team_share_remove` |
+| Boards | `board.create` · `update` · `delete` · `column_create` · `column_update` · `column_delete` · `column_empty` · `card_create` · `card_update` · `card_delete` · `card_move` · `card_run` · `share_add` · `share_remove` · `team_share_add` · `team_share_remove` |
+| Drive | `drive.upload` · `download` · `delete` · `delete_all` · `bulk_delete` · `share_create` · `share_revoke` · `team_sharing_update` · `bulk_team_sharing_update` |
+| Teams | `team.create` · `update` · `delete` · `member_add` · `member_remove` |
+| Folders | `folder.create` · `update` · `delete` · `workflow_move` |
+
+Bulk operations are logged once per request with a count, not once per row. A CSV import of 5,000 rows produces one `data_table.import_csv` line carrying `imported`, `rejected`, and `total`.
+
+## Secrets Are Never Logged
+
+An audit line records identifiers, names, and counts. It never records a credential's contents, a variable's value, a password, or a token.
+
+Two things enforce this. Call sites are written to pass only safe fields, and the audit helper redacts as a backstop: any field whose name contains `password`, `secret`, `token`, `api_key`, `value`, `authorization`, `cookie`, or similar is replaced with `***` before the line is built. Over-redaction is deliberate — an unhelpful line is better than a leaked credential.
+
+Where a secret is genuinely relevant to the record, only its shape is logged. A file share records `password_protected=true`, never the password.
+
+## Retention
+
+**Audit lines live only as long as the container's log output.** They are not written to the database. Recreating the backend container discards its logs.
+
+If you need audit history that survives a redeploy, ship the container's stdout somewhere durable — a log driver, a sidecar collector, or your platform's log aggregation — the same way you would for any other container log.
+
+## For Contributors
+
+Emitting an audit line takes one call:
+
+```python
+from app.services.audit_log import audit
+
+audit(
+    action="credential.delete",
+    actor=current_user,
+    target_type="credential",
+    target_id=credential.id,
+    target_name=credential.name,
+)
+```
+
+The helper is synchronous, touches no database, and swallows its own errors, so an audit call cannot fail or slow a request.
+
+Three rules when adding one:
+
+1. **Name the action `resource.verb` in snake_case.** `backend/tests/test_audit_log.py` walks every `audit()` call under `app/api/` and fails the build on a name that does not match, and on a covered resource that has lost all of its call sites.
+
+2. **Only read attributes that are certainly present.** The helper's `try/except` protects its own body, not the expressions you pass to it — an `AttributeError` in `target_name=workflow.name` is raised at the call site, before `audit()` runs, and will break the request. Read ORM columns and locals, not optional or lazily-loaded attributes.
+
+3. **Log the deletion before the delete.** After `db.delete(row)` the name and id you want to record may be gone. Place the call above it.

--- a/frontend/src/docs/manifest.ts
+++ b/frontend/src/docs/manifest.ts
@@ -130,6 +130,7 @@ export const DOCS_MANIFEST: Record<string, DocCategory> = {
       { slug: "edit-history", title: "Edit History" },
       { slug: "user-settings", title: "Settings" },
       { slug: "opentelemetry", title: "OpenTelemetry Tracing" },
+      { slug: "audit", title: "Audit Logging" },
       { slug: "download-import", title: "Download & Import" },
       { slug: "portal", title: "Portal" },
       { slug: "file-generation", title: "File Generation" },


### PR DESCRIPTION
## Why

Heym had no audit trail. `WinstonLoggingMiddleware` logged method, path, status and duration, but no identity — so `DELETE /api/workflows/{id}` was visible while *who* deleted it was not. The only real audit trail was `FileUploadAudit`, scoped to file intake. `heym_events` writes workflow CRUD but has 7-day retention, collapses on `dedupe_key`, and exists to feed `heymTrigger`.

Every area below had zero audit coverage before this PR.

## What

`backend/app/services/audit_log.py` — one **synchronous** `audit()` helper emitting a single self-contained line:

```
2026-08-25 14:02:11 INFO [winston.audit] audit action=credential.delete outcome=success actor_id=8f2c1b04-… actor_email=alex@example.com target=credential:3a91d7e2-… target_name="OpenAI Prod" credential_type=openai
```

`winston.audit` is a child of `winston`, so records reach the same stdout the **Logs** tab reads while staying separable from access-log noise:

```bash
docker logs heym-backend 2>&1 | grep '\[winston.audit\]'
docker logs heym-backend 2>&1 | grep -E 'outcome=(failure|denied)'
```

**112 call sites / 101 distinct actions** across 11 routers:

| Router | Calls | | Router | Calls |
|---|---|---|---|---|
| `boards` | 16 | | `credentials` | 10 |
| `workflows` | 15 | | `files` (Drive) | 9 |
| `data_tables` | 15 | | `alerts` | 8 |
| `vector_stores` | 11 | | `global_variables` | 8 |
| `auth` | 10 | | `teams` | 6 |
| | | | `folders` | 4 |

## Design decisions

**Log line only, no `audit_log` table.** The format is one self-contained line per action, so it is already suitable for a log pipeline. Adding durable storage later is a change inside `audit()`, not at 112 call sites.

**Explicit call inside each endpoint, not middleware.** A middleware deriving the action from path + method cannot know the target's name, cannot distinguish `outcome=denied` from a 404, and would misclassify paths like `/{workflow_id}/history/{entry_id}/stream`.

**Mutations plus sensitive reads.** Every state change is logged. Reads are logged only where reading is itself the sensitive act — `workflow.history_view`, `credential.detail_view` (opening a credential decrypts it), `drive.download`. Auditing every `GET` would bury the lines that matter under polling traffic.

**Failures are logged.** Failed logins, replayed refresh tokens (`reason=refresh_token_replayed_or_revoked` — a token-theft signal), and refused access record `outcome=failure|denied`. A miss on `credential.detail_view` is what id enumeration looks like.

**Bulk operations log once with a count.** A 5,000-row CSV import produces one `data_table.import_csv` line carrying `imported`, `rejected`, `total`.

**No client IP.** Behind a load balancer the value is either the proxy's address or a spoofable forwarded header. `NoClientIpTests` walks every `audit()` call and fails the build on an `ip`/`client_ip`/`remote_addr`/`source_ip`/`forwarded_for` keyword so it cannot creep back. The pre-existing access log is untouched — `backend/app/main.py` has a zero diff in this PR.

## Secrets

Call sites pass identifiers, names and counts. The helper redacts as a backstop: any field whose name contains `password`, `secret`, `token`, `api_key`, `value`, `authorization`, `cookie` and similar becomes `***`. Over-redaction is deliberate. Where a secret is relevant, only its shape is logged — a file share records `password_protected=true`, never the password.

## Two traps, both covered by tests

**`audit()`'s `try/except` protects its body, not the arguments passed to it.** An `AttributeError` in `target_name=workflow.name` is raised at the call site *before* `audit()` runs and will break the request. This is not theoretical — it broke two tests in `test_execution_tokens.py` whose `SimpleNamespace` fixtures lacked `.name` and `.jti`, attributes the real `Workflow` and `WorkflowExecutionToken` rows always carry. Fixtures updated; the rule is documented for future call sites.

**Action names drift.** `test_audit_log.py` walks every `audit()` call under `app/api/` with `ast` and fails on a name that is not `resource.verb`, and on a covered resource that has lost all of its call sites.

## Docs

`frontend/src/docs/content/reference/audit.md` + `manifest.ts` entry, same shelf as `opentelemetry.md`. The action list was cross-checked programmatically against the call sites: **101/101 matched, zero drift in either direction.**

No release tour entry — backend-only, no new user-visible surface.

## Verification

- `./check.sh`: **3480/3483 pass**. The 3 failures are `test_mcp_stdio_sandbox.py` and are **pre-existing on clean `main`** (verified by stashing; a local `.env` sets `HEYM_MCP_STDIO_SANDBOX=subprocess` while the tests expect `auto`). Unrelated to this PR.
- `test_audit_log.py`: 21 tests, 113 subtests, all passing.
- Frontend `eslint` + `vue-tsc --noEmit`: clean.
- Redaction verified end to end against the real logger, not only in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)