### PR TITLE
impl/sso

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <strong>Build, visualize, and run intelligent AI workflows without writing code.</strong><br/>
-  Drag-and-drop canvas · LLM & Agent nodes · RAG pipelines · Multi-agent orchestration · MCP support
+  Drag-and-drop canvas · LLM & Agent nodes · RAG pipelines · Multi-agent orchestration · MCP support · OIDC SSO login
 </p>
 
 <p align="center">
@@ -190,6 +190,7 @@ Turn a workflow into a chat experience so users can invoke the orchestration wit
 - **Guardrails** — Content filtering, NSFW protection, and multilingual safety checks on LLM and Agent nodes
 - **Built-In RAG** — Insert documents and run semantic search against managed vector stores (Qdrant or built-in Postgres/pgvector) in two nodes
 - **MCP Support** — Connect Agent nodes to any MCP server as a client; expose your workflows as an MCP server for Claude, Cursor, and other clients
+- **OIDC SSO Login**: Let teams sign in through Keycloak, Okta, Entra ID, Auth0, Google, or any OpenID Connect provider
 - **Portal** — Turn any workflow into a public chat UI at `/chat/{slug}` with streaming responses and file uploads
 - **Webhook SSE Streaming** — Generate ready-to-run cURL commands for `/execute` or `/execute/stream`, with per-node start messages and live node event output in the terminal
 - **Live Execution Canvas** — Open any running production execution from History or a Kanban card and watch the existing run continue node by node on the animated canvas with incremental Debug logs
@@ -631,7 +632,7 @@ Input ──→ HTTP ──→ Output
 | **State Management** | Pinia |
 | **Backend** | Python 3.11+ + FastAPI + UV |
 | **Database** | PG 16 + SQLAlchemy 2.0 (async) |
-| **Auth** | JWT (access + refresh) + bcrypt |
+| **Auth** | JWT (access + refresh), bcrypt, optional OpenID Connect SSO login |
 
 ---
 

--- a/backend/alembic/versions/115_add_sso_settings.py
+++ b/backend/alembic/versions/115_add_sso_settings.py
@@ -1,0 +1,78 @@
+"""add sso_settings and user SSO identity columns
+
+Revision ID: 115_add_sso_settings
+Revises: 114_add_workflow_http_method
+Create Date: 2026-08-26 10:00:00.000000
+
+"""
+
+import secrets
+from typing import Sequence, Union
+
+import bcrypt
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "115_add_sso_settings"
+down_revision: Union[str, None] = "114_add_workflow_http_method"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sso_settings",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("issuer", sa.String(512), nullable=False, server_default=""),
+        sa.Column("client_id", sa.String(255), nullable=False, server_default=""),
+        sa.Column("encrypted_client_secret", sa.Text(), nullable=True),
+        sa.Column("scopes", sa.String(255), nullable=False, server_default="openid email profile"),
+        sa.Column("button_label", sa.String(64), nullable=False, server_default="Sign in with SSO"),
+        sa.Column("auto_provision_users", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("allowed_email_domains", sa.String(512), nullable=False, server_default=""),
+        sa.Column(
+            "password_login_disabled", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("last_test_ok", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("last_test_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_by_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+    )
+
+    op.add_column("users", sa.Column("sso_issuer", sa.String(512), nullable=True))
+    op.add_column("users", sa.Column("sso_subject", sa.String(255), nullable=True))
+    op.create_index("ix_users_sso_identity", "users", ["sso_issuer", "sso_subject"], unique=True)
+
+    # SSO-provisioned accounts have no password.
+    op.alter_column("users", "hashed_password", existing_type=sa.String(255), nullable=True)
+
+
+def downgrade() -> None:
+    # NOT NULL cannot be restored while SSO-provisioned rows hold NULL. Give them a valid
+    # bcrypt hash of a random secret nobody holds: those accounts simply cannot log in with
+    # a password, which is the truthful state. Deleting the users instead would be data loss.
+    placeholder = bcrypt.hashpw(secrets.token_bytes(32), bcrypt.gensalt()).decode()
+    op.execute(
+        sa.text("UPDATE users SET hashed_password = :h WHERE hashed_password IS NULL").bindparams(
+            h=placeholder
+        )
+    )
+    op.alter_column("users", "hashed_password", existing_type=sa.String(255), nullable=False)
+
+    op.drop_index("ix_users_sso_identity", table_name="users")
+    op.drop_column("users", "sso_subject")
+    op.drop_column("users", "sso_issuer")
+    op.drop_table("sso_settings")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -30,6 +30,7 @@ from app.services.auth import (
 )
 from app.services.auth_rate_limiter import login_limiter, register_limiter
 from app.services.credential_access import get_accessible_credential
+from app.services.sso_settings import get_sso_settings, password_login_blocked
 
 router = APIRouter()
 
@@ -167,6 +168,19 @@ async def login(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Too many login attempts. Try again later.",
             headers={"Retry-After": str(retry_after)},
+        )
+
+    sso_row = await get_sso_settings(db)
+    if password_login_blocked(sso_row, user_data.email):
+        audit(
+            action="auth.login",
+            outcome=OUTCOME_DENIED,
+            actor_email=user_data.email,
+            reason="password_login_disabled",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password sign-in is disabled on this instance. Use SSO.",
         )
 
     result = await db.execute(select(User).where(User.email == user_data.email))

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -121,6 +121,21 @@ async def register(
             detail="Registration is disabled",
         )
 
+    # Registration mints a password, so it is a password surface too. Leaving it open would
+    # make "disable password sign-in" bypassable by anyone who can reach /register.
+    sso_row = await get_sso_settings(db)
+    if password_login_blocked(sso_row, user_data.email):
+        audit(
+            action="auth.register",
+            outcome=OUTCOME_DENIED,
+            actor_email=user_data.email,
+            reason="password_login_disabled",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password sign-in is disabled on this instance. Use SSO.",
+        )
+
     result = await db.execute(select(User).where(User.email == user_data.email))
     existing_user = result.scalar_one_or_none()
 

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -9,6 +9,7 @@ from app.config import settings
 from app.db.models import User
 from app.db.session import get_db
 from app.services.auth import verify_access_token
+from app.services.instance_admin import is_instance_admin
 
 
 def get_client_ip(request: Request) -> str:
@@ -127,3 +128,12 @@ async def get_current_user_optional(
     user = result.scalar_one_or_none()
 
     return user
+
+
+def require_instance_admin(current_user: User) -> None:
+    """Raise 403 unless the caller is an instance administrator."""
+    if not is_instance_admin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not allowed to manage instance settings.",
+        )

--- a/backend/app/api/oauth.py
+++ b/backend/app/api/oauth.py
@@ -19,6 +19,7 @@ from app.db.session import get_db
 from app.services.auth import verify_password
 from app.services.auth_rate_limiter import oauth_register_limiter
 from app.services.oauth_tokens import hash_oauth_token
+from app.services.sso_settings import get_sso_settings, password_login_blocked
 
 router = APIRouter()
 
@@ -540,7 +541,13 @@ async def authorize_post(
     user_result = await db.execute(select(User).where(User.email == email))
     user = user_result.scalar_one_or_none()
 
-    if user is None or not verify_password(password, user.hashed_password):
+    # The same gate as /api/auth/login. Closing only that one would make the setting a lie.
+    sso_row = await get_sso_settings(db)
+    if (
+        password_login_blocked(sso_row, email)
+        or user is None
+        or not verify_password(password, user.hashed_password)
+    ):
         new_csrf = _generate_csrf_token(client_id)
         return HTMLResponse(
             _render_consent_page(

--- a/backend/app/api/sso_admin.py
+++ b/backend/app/api/sso_admin.py
@@ -76,7 +76,7 @@ async def update_sso_config(
     await db.refresh(row)
 
     audit(
-        action="sso.settings.update",
+        action="sso_settings.update",
         actor=current_user,
         target_type="sso_settings",
         enabled=row.enabled,
@@ -104,7 +104,7 @@ async def test_sso_connection(
         row.last_test_at = datetime.now(timezone.utc)
         await db.flush()
         audit(
-            action="sso.settings.test",
+            action="sso_settings.test",
             actor=current_user,
             outcome=OUTCOME_FAILURE,
             reason=str(exc),
@@ -114,7 +114,7 @@ async def test_sso_connection(
     row.last_test_ok = True
     row.last_test_at = datetime.now(timezone.utc)
     await db.flush()
-    audit(action="sso.settings.test", actor=current_user)
+    audit(action="sso_settings.test", actor=current_user)
     return SsoTestResponse(
         ok=True,
         issuer=discovery.issuer,

--- a/backend/app/api/sso_admin.py
+++ b/backend/app/api/sso_admin.py
@@ -1,0 +1,125 @@
+"""Admin-only OIDC configuration."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_instance_admin
+from app.db.models import SsoSettings, User
+from app.db.session import get_db
+from app.models.schemas import SsoSettingsResponse, SsoSettingsUpdate, SsoTestResponse
+from app.services.audit_log import OUTCOME_FAILURE, audit
+from app.services.oidc_client import fetch_discovery
+from app.services.sso_settings import callback_url, encrypt_client_secret, get_sso_settings
+
+router = APIRouter()
+
+
+def apply_settings_update(row: SsoSettings, update: SsoSettingsUpdate) -> None:
+    """Apply a partial update to the settings row, enforcing the lockout preconditions."""
+    for field in ("issuer", "client_id", "scopes"):
+        value = getattr(update, field)
+        if value is not None and value.strip() != getattr(row, field):
+            setattr(row, field, value.strip())
+            # The recorded test result belongs to the old connection details.
+            row.last_test_ok = False
+
+    if update.client_secret:
+        row.encrypted_client_secret = encrypt_client_secret(update.client_secret)
+        row.last_test_ok = False
+
+    if update.enabled is not None:
+        row.enabled = update.enabled
+    if update.button_label is not None:
+        row.button_label = update.button_label.strip() or "Sign in with SSO"
+    if update.auto_provision_users is not None:
+        row.auto_provision_users = update.auto_provision_users
+    if update.allowed_email_domains is not None:
+        row.allowed_email_domains = update.allowed_email_domains.strip()
+
+    if update.password_login_disabled is not None:
+        if update.password_login_disabled and not (row.enabled and row.last_test_ok):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Password login can only be disabled once SSO is enabled and a "
+                    "connection test has passed."
+                ),
+            )
+        row.password_login_disabled = update.password_login_disabled
+
+
+@router.get("", response_model=SsoSettingsResponse)
+async def get_sso_config(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SsoSettingsResponse:
+    require_instance_admin(current_user)
+    row = await get_sso_settings(db)
+    return SsoSettingsResponse.from_row(row, redirect_uri=callback_url(request))
+
+
+@router.put("", response_model=SsoSettingsResponse)
+async def update_sso_config(
+    update: SsoSettingsUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SsoSettingsResponse:
+    require_instance_admin(current_user)
+    row = await get_sso_settings(db)
+    apply_settings_update(row, update)
+    row.updated_by_id = current_user.id
+    await db.flush()
+    await db.refresh(row)
+
+    audit(
+        action="sso.settings.update",
+        actor=current_user,
+        target_type="sso_settings",
+        enabled=row.enabled,
+        password_login_disabled=row.password_login_disabled,
+    )
+    return SsoSettingsResponse.from_row(row, redirect_uri=callback_url(request))
+
+
+@router.post("/test", response_model=SsoTestResponse)
+async def test_sso_connection(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SsoTestResponse:
+    require_instance_admin(current_user)
+    row = await get_sso_settings(db)
+    if not row.issuer:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Set an issuer URL first"
+        )
+
+    try:
+        discovery = await fetch_discovery(row.issuer, use_cache=False)
+    except Exception as exc:  # noqa: BLE001 - any network failure surfaces to the admin as text
+        row.last_test_ok = False
+        row.last_test_at = datetime.now(timezone.utc)
+        await db.flush()
+        audit(
+            action="sso.settings.test",
+            actor=current_user,
+            outcome=OUTCOME_FAILURE,
+            reason=str(exc),
+        )
+        return SsoTestResponse(ok=False, error=str(exc))
+
+    row.last_test_ok = True
+    row.last_test_at = datetime.now(timezone.utc)
+    await db.flush()
+    audit(action="sso.settings.test", actor=current_user)
+    return SsoTestResponse(
+        ok=True,
+        issuer=discovery.issuer,
+        authorization_endpoint=discovery.authorization_endpoint,
+        token_endpoint=discovery.token_endpoint,
+        jwks_uri=discovery.jwks_uri,
+        userinfo_endpoint=discovery.userinfo_endpoint,
+    )

--- a/backend/app/api/sso_admin.py
+++ b/backend/app/api/sso_admin.py
@@ -3,20 +3,47 @@
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user, require_instance_admin
 from app.db.models import SsoSettings, User
 from app.db.session import get_db
-from app.models.schemas import SsoSettingsResponse, SsoSettingsUpdate, SsoTestResponse
+from app.models.schemas import (
+    SsoSettingsResponse,
+    SsoSettingsUpdate,
+    SsoTestRequest,
+    SsoTestResponse,
+)
 from app.services.audit_log import OUTCOME_FAILURE, audit
+from app.services.instance_admin import admin_emails
 from app.services.oidc_client import fetch_discovery
 from app.services.sso_settings import callback_url, encrypt_client_secret, get_sso_settings
 
 router = APIRouter()
 
 
-def apply_settings_update(row: SsoSettings, update: SsoSettingsUpdate) -> None:
+async def break_glass_available(db: AsyncSession) -> bool:
+    """Whether any instance admin could still sign in with a password.
+
+    An admin whose account was provisioned through SSO has no password hash, so the
+    break-glass exemption would not actually let them back in. Without at least one such
+    account, disabling password sign-in can strand the instance behind a provider outage.
+    """
+    emails = admin_emails()
+    if not emails:
+        return False
+    result = await db.execute(
+        select(func.count())
+        .select_from(User)
+        .where(func.lower(User.email).in_(emails), User.hashed_password.is_not(None))
+    )
+    return (result.scalar() or 0) > 0
+
+
+def apply_settings_update(
+    row: SsoSettings, update: SsoSettingsUpdate, *, break_glass_ready: bool = True
+) -> None:
     """Apply a partial update to the settings row, enforcing the lockout preconditions."""
     for field in ("issuer", "client_id", "scopes"):
         value = getattr(update, field)
@@ -47,6 +74,15 @@ def apply_settings_update(row: SsoSettings, update: SsoSettingsUpdate) -> None:
                     "connection test has passed."
                 ),
             )
+        if update.password_login_disabled and not break_glass_ready:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "No account in HEYM_ADMIN_EMAILS has a password, so nobody could get "
+                    "back in if the identity provider became unreachable. Give one of them "
+                    "a password first."
+                ),
+            )
         row.password_login_disabled = update.password_login_disabled
 
 
@@ -58,7 +94,11 @@ async def get_sso_config(
 ) -> SsoSettingsResponse:
     require_instance_admin(current_user)
     row = await get_sso_settings(db)
-    return SsoSettingsResponse.from_row(row, redirect_uri=callback_url(request))
+    return SsoSettingsResponse.from_row(
+        row,
+        redirect_uri=callback_url(request),
+        break_glass_ready=await break_glass_available(db),
+    )
 
 
 @router.put("", response_model=SsoSettingsResponse)
@@ -70,7 +110,8 @@ async def update_sso_config(
 ) -> SsoSettingsResponse:
     require_instance_admin(current_user)
     row = await get_sso_settings(db)
-    apply_settings_update(row, update)
+    ready = await break_glass_available(db)
+    apply_settings_update(row, update, break_glass_ready=ready)
     row.updated_by_id = current_user.id
     await db.flush()
     await db.refresh(row)
@@ -82,27 +123,33 @@ async def update_sso_config(
         enabled=row.enabled,
         password_login_disabled=row.password_login_disabled,
     )
-    return SsoSettingsResponse.from_row(row, redirect_uri=callback_url(request))
+    return SsoSettingsResponse.from_row(
+        row, redirect_uri=callback_url(request), break_glass_ready=ready
+    )
 
 
 @router.post("/test", response_model=SsoTestResponse)
 async def test_sso_connection(
+    body: SsoTestRequest | None = None,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> SsoTestResponse:
     require_instance_admin(current_user)
     row = await get_sso_settings(db)
-    if not row.issuer:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Set an issuer URL first"
-        )
+    # Testing before saving is the normal way round: the admin pastes an issuer and wants
+    # to know it resolves before committing it.
+    issuer = ((body.issuer if body else None) or row.issuer or "").strip()
+    if not issuer:
+        return SsoTestResponse(ok=False, error="Enter an issuer URL first")
+    records_result = issuer == row.issuer
 
     try:
-        discovery = await fetch_discovery(row.issuer, use_cache=False)
+        discovery = await fetch_discovery(issuer, use_cache=False)
     except Exception as exc:  # noqa: BLE001 - any network failure surfaces to the admin as text
-        row.last_test_ok = False
-        row.last_test_at = datetime.now(timezone.utc)
-        await db.flush()
+        if records_result:
+            row.last_test_ok = False
+            row.last_test_at = datetime.now(timezone.utc)
+            await db.flush()
         audit(
             action="sso_settings.test",
             actor=current_user,
@@ -111,9 +158,10 @@ async def test_sso_connection(
         )
         return SsoTestResponse(ok=False, error=str(exc))
 
-    row.last_test_ok = True
-    row.last_test_at = datetime.now(timezone.utc)
-    await db.flush()
+    if records_result:
+        row.last_test_ok = True
+        row.last_test_at = datetime.now(timezone.utc)
+        await db.flush()
     audit(action="sso_settings.test", actor=current_user)
     return SsoTestResponse(
         ok=True,

--- a/backend/app/api/sso_auth.py
+++ b/backend/app/api/sso_auth.py
@@ -2,19 +2,39 @@
 
 import secrets
 from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
 
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.auth import _set_auth_cookies
 from app.api.deps import get_client_ip
 from app.config import settings
+from app.db.models import SsoSettings, User
 from app.db.session import get_db
 from app.models.schemas import SsoStatusResponse
+from app.services.audit_log import OUTCOME_DENIED, OUTCOME_FAILURE, audit
+from app.services.auth import create_access_token, create_refresh_token, store_refresh_token
 from app.services.auth_rate_limiter import login_limiter
-from app.services.oidc_client import build_authorization_url, fetch_discovery, make_pkce_pair
-from app.services.sso_settings import callback_url, decrypt_client_secret, get_sso_settings
+from app.services.oidc_client import (
+    OidcError,
+    build_authorization_url,
+    exchange_code,
+    fetch_discovery,
+    fetch_userinfo,
+    get_signing_key,
+    make_pkce_pair,
+    verify_id_token,
+)
+from app.services.sso_settings import (
+    callback_url,
+    decrypt_client_secret,
+    email_domain_allowed,
+    get_sso_settings,
+)
 
 router = APIRouter()
 
@@ -125,4 +145,135 @@ async def sso_login(
         max_age=_TX_TTL_MINUTES * 60,
         path=_TX_COOKIE_PATH,
     )
+    return response
+
+
+class SsoLoginError(Exception):
+    """A login was refused for a reason the login screen may name."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+async def resolve_sso_user(db: AsyncSession, row: SsoSettings, issuer: str, claims: dict) -> User:
+    """Find, claim, or provision the Heym account for a verified set of ID token claims."""
+    subject = str(claims.get("sub") or "")
+    result = await db.execute(
+        select(User).where(User.sso_issuer == issuer, User.sso_subject == subject)
+    )
+    matched = result.scalar_one_or_none()
+    if matched is not None:
+        return matched
+
+    email = str(claims.get("email") or "").strip().lower()
+    if not email:
+        raise SsoLoginError("email_missing")
+    # An address the provider will not vouch for must not claim an account, and must not
+    # create one either: that is a direct account-takeover path.
+    if claims.get("email_verified") is not True:
+        raise SsoLoginError("email_not_verified")
+    if not email_domain_allowed(email, row.allowed_email_domains):
+        raise SsoLoginError("domain_not_allowed")
+
+    result = await db.execute(select(User).where(User.email == email))
+    existing = result.scalar_one_or_none()
+    if existing is not None:
+        existing.sso_issuer = issuer
+        existing.sso_subject = subject
+        return existing
+
+    if not row.auto_provision_users:
+        raise SsoLoginError("provisioning_disabled")
+
+    user = User(
+        email=email,
+        hashed_password=None,
+        name=str(claims.get("name") or claims.get("preferred_username") or email),
+        sso_issuer=issuer,
+        sso_subject=subject,
+    )
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+
+@router.get("/callback")
+async def sso_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    def failure(reason: str) -> RedirectResponse:
+        # The provider's own error text is never echoed: it is an XSS surface and leaks
+        # configuration detail to anyone who can reach the login page.
+        response = RedirectResponse(
+            url=f"/login?{urlencode({'sso_error': reason})}", status_code=302
+        )
+        response.delete_cookie(_TX_COOKIE, path=_TX_COOKIE_PATH)
+        return response
+
+    transaction = _decode_transaction(request.cookies.get(_TX_COOKIE))
+    if transaction is None or not state or transaction.get("state") != state:
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason="state_mismatch")
+        return failure("state_mismatch")
+    if error or not code:
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason="provider_error")
+        return failure("token_exchange_failed")
+
+    row = await get_sso_settings(db)
+    if not (row.enabled and row.issuer and row.client_id):
+        return failure("sso_disabled")
+
+    try:
+        discovery = await fetch_discovery(row.issuer)
+        tokens = await exchange_code(
+            discovery,
+            client_id=row.client_id,
+            client_secret=decrypt_client_secret(row.encrypted_client_secret),
+            code=code,
+            redirect_uri=callback_url(request),
+            code_verifier=str(transaction["code_verifier"]),
+        )
+        signing_key = get_signing_key(discovery, tokens["id_token"])
+        claims = verify_id_token(
+            tokens["id_token"],
+            signing_key=signing_key,
+            discovery=discovery,
+            client_id=row.client_id,
+            expected_nonce=str(transaction["nonce"]),
+        )
+    except OidcError as exc:
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason=str(exc))
+        return failure("invalid_token")
+    except Exception as exc:  # noqa: BLE001 - network failures reach the browser as one code
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason=str(exc))
+        return failure("token_exchange_failed")
+
+    if not claims.get("email") and tokens.get("access_token"):
+        claims = {**(await fetch_userinfo(discovery, tokens["access_token"])), **claims}
+
+    try:
+        user = await resolve_sso_user(db, row, discovery.issuer, claims)
+    except SsoLoginError as rejection:
+        audit(
+            action="auth.sso_login",
+            outcome=OUTCOME_DENIED,
+            actor_email=str(claims.get("email") or ""),
+            reason=rejection.code,
+        )
+        return failure(rejection.code)
+
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
+    await store_refresh_token(db, refresh_token, user.id)
+
+    response = RedirectResponse(url=safe_next_path(transaction.get("next")), status_code=302)
+    _set_auth_cookies(response, access_token, refresh_token)
+    response.delete_cookie(_TX_COOKIE, path=_TX_COOKIE_PATH)
+
+    audit(action="auth.sso_login", actor=user)
     return response

--- a/backend/app/api/sso_auth.py
+++ b/backend/app/api/sso_auth.py
@@ -1,0 +1,128 @@
+"""Public SSO login: status, initiation, and callback."""
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_client_ip
+from app.config import settings
+from app.db.session import get_db
+from app.models.schemas import SsoStatusResponse
+from app.services.auth_rate_limiter import login_limiter
+from app.services.oidc_client import build_authorization_url, fetch_discovery, make_pkce_pair
+from app.services.sso_settings import callback_url, decrypt_client_secret, get_sso_settings
+
+router = APIRouter()
+
+_TX_COOKIE = "sso_tx"
+_TX_COOKIE_PATH = "/api/auth/sso/"
+_TX_TTL_MINUTES = 10
+_TX_TYPE = "sso_tx"
+
+
+def safe_next_path(candidate: str | None) -> str:
+    """Reduce a post-login target to a same-origin path.
+
+    An unchecked value turns the callback into an open redirect, so anything that is not a
+    single-slash relative path is discarded rather than repaired.
+    """
+    if not candidate or not candidate.startswith("/"):
+        return "/"
+    if candidate.startswith("//") or candidate.startswith("/\\"):
+        return "/"
+    return candidate
+
+
+def _encode_transaction(state: str, nonce: str, code_verifier: str, next_path: str) -> str:
+    """Sign the in-flight login state for the browser cookie.
+
+    The PKCE verifier lives here and never in the ``state`` parameter: ``state`` round-trips
+    through the provider, and a signed JWT is not an encrypted one.
+    """
+    payload = {
+        "type": _TX_TYPE,
+        "state": state,
+        "nonce": nonce,
+        "code_verifier": code_verifier,
+        "next": next_path,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_TX_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
+
+
+def _decode_transaction(token: str | None) -> dict | None:
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    except jwt.PyJWTError:
+        return None
+    return payload if payload.get("type") == _TX_TYPE else None
+
+
+@router.get("/status", response_model=SsoStatusResponse)
+async def sso_status(db: AsyncSession = Depends(get_db)) -> SsoStatusResponse:
+    """What the login screen needs. The issuer and client id are not disclosed here."""
+    row = await get_sso_settings(db)
+    configured = bool(row.enabled and row.issuer and row.client_id)
+    return SsoStatusResponse(
+        enabled=configured,
+        button_label=row.button_label,
+        password_login_enabled=not (configured and row.password_login_disabled),
+    )
+
+
+@router.get("/login")
+async def sso_login(
+    request: Request,
+    next: str | None = None,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    allowed, retry_after = login_limiter.is_allowed(get_client_ip(request))
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many login attempts. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    row = await get_sso_settings(db)
+    if not (row.enabled and row.issuer and row.client_id):
+        return RedirectResponse(url="/login?sso_error=sso_disabled", status_code=302)
+    if not decrypt_client_secret(row.encrypted_client_secret):
+        return RedirectResponse(url="/login?sso_error=sso_disabled", status_code=302)
+
+    try:
+        discovery = await fetch_discovery(row.issuer)
+    except Exception:  # noqa: BLE001 - the browser gets one error code, never provider text
+        return RedirectResponse(url="/login?sso_error=token_exchange_failed", status_code=302)
+
+    state = secrets.token_urlsafe(32)
+    nonce = secrets.token_urlsafe(32)
+    code_verifier, code_challenge = make_pkce_pair()
+
+    auth_url = build_authorization_url(
+        discovery,
+        client_id=row.client_id,
+        redirect_uri=callback_url(request),
+        scopes=row.scopes,
+        state=state,
+        nonce=nonce,
+        code_challenge=code_challenge,
+    )
+
+    response = RedirectResponse(url=auth_url, status_code=302)
+    response.set_cookie(
+        key=_TX_COOKIE,
+        value=_encode_transaction(state, nonce, code_verifier, safe_next_path(next)),
+        httponly=True,
+        samesite="lax",
+        secure=request.url.scheme == "https",
+        max_age=_TX_TTL_MINUTES * 60,
+        path=_TX_COOKIE_PATH,
+    )
+    return response

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -68,6 +68,10 @@ class Settings(BaseSettings):
     docker_logs_allowed_emails: str = ""
     plugins_enabled: bool = Field(default=False, validation_alias="HEYM_PLUGINS_ENABLED")
     plugin_admin_emails: str = Field(default="", validation_alias="HEYM_PLUGIN_ADMIN_EMAILS")
+    # Instance administrators. Comma-separated emails. These accounts configure SSO and
+    # may always sign in with a password, which is the break-glass path when SSO is
+    # misconfigured. An empty value grants nobody.
+    admin_emails: str = Field(default="", validation_alias="HEYM_ADMIN_EMAILS")
     plugins_dir: str = Field(default="data/plugins", validation_alias="HEYM_PLUGINS_DIR")
     # Custom Playwright code runs arbitrary Python in the backend process. It is OFF by
     # default; an operator must opt in explicitly. Step-based Playwright nodes are unaffected.

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -75,10 +75,15 @@ class WebhookBodyMode(str, PyEnum):
 
 class User(Base):
     __tablename__ = "users"
+    __table_args__ = (Index("ix_users_sso_identity", "sso_issuer", "sso_subject", unique=True),)
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
-    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    hashed_password: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Identity as asserted by the external OIDC provider. (issuer, subject) is the
+    # authoritative account key; it survives an email change at the provider.
+    sso_issuer: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    sso_subject: Mapped[str | None] = mapped_column(String(255), nullable=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     user_rules: Mapped[str | None] = mapped_column(Text, nullable=True)
     mcp_api_key: Mapped[str | None] = mapped_column(
@@ -2276,3 +2281,37 @@ class AlertTeamShare(Base):
 
     alert: Mapped["Alert"] = relationship("Alert")
     team: Mapped["Team"] = relationship("Team")
+
+
+# The SSO configuration is instance-wide, so the table holds exactly one row addressed
+# by this constant. Upserting a fixed key removes the read-then-insert race.
+SSO_SETTINGS_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+class SsoSettings(Base):
+    __tablename__ = "sso_settings"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=lambda: SSO_SETTINGS_ID
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    issuer: Mapped[str] = mapped_column(String(512), default="", nullable=False)
+    client_id: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    encrypted_client_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scopes: Mapped[str] = mapped_column(String(255), default="openid email profile", nullable=False)
+    # The provider's name lives in data, never in code.
+    button_label: Mapped[str] = mapped_column(
+        String(64), default="Sign in with SSO", nullable=False
+    )
+    auto_provision_users: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    allowed_email_domains: Mapped[str] = mapped_column(String(512), default="", nullable=False)
+    password_login_disabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    last_test_ok: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    last_test_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    updated_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,6 +52,7 @@ from app.api import (
     schedules,
     skill_builder,
     slack,
+    sso_admin,
     teams,
     telegram,
     templates,
@@ -308,6 +309,7 @@ app.add_middleware(HeymIdentityMiddleware)
 
 app.include_router(oauth.router, tags=["OAuth"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
+app.include_router(sso_admin.router, prefix="/api/admin/sso", tags=["SSO Admin"])
 app.include_router(workflows.router, prefix="/api/workflows", tags=["Workflows"])
 app.include_router(agent_memory.router, prefix="/api/workflows", tags=["Agent Memory"])
 app.include_router(playwright.router, prefix="/api/playwright", tags=["Playwright"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,6 +53,7 @@ from app.api import (
     skill_builder,
     slack,
     sso_admin,
+    sso_auth,
     teams,
     telegram,
     templates,
@@ -309,6 +310,7 @@ app.add_middleware(HeymIdentityMiddleware)
 
 app.include_router(oauth.router, tags=["OAuth"])
 app.include_router(auth.router, prefix="/api/auth", tags=["Authentication"])
+app.include_router(sso_auth.router, prefix="/api/auth/sso", tags=["SSO"])
 app.include_router(sso_admin.router, prefix="/api/admin/sso", tags=["SSO Admin"])
 app.include_router(workflows.router, prefix="/api/workflows", tags=["Workflows"])
 app.include_router(agent_memory.router, prefix="/api/workflows", tags=["Agent Memory"])

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, EmailStr, Field, computed_field, field_validator
 
@@ -1816,3 +1816,66 @@ class AnalysisNoteResponse(BaseModel):
 class AnalysisNoteSaveRequest(BaseModel):
     content: str
     base_revision: int
+
+
+class SsoSettingsUpdate(BaseModel):
+    enabled: bool | None = None
+    issuer: str | None = None
+    client_id: str | None = None
+    # Empty string means "leave the stored secret alone", which is what the masked
+    # editor field posts back when the admin does not retype it.
+    client_secret: str | None = None
+    scopes: str | None = None
+    button_label: str | None = None
+    auto_provision_users: bool | None = None
+    allowed_email_domains: str | None = None
+    password_login_disabled: bool | None = None
+
+
+class SsoSettingsResponse(BaseModel):
+    enabled: bool
+    issuer: str
+    client_id: str
+    client_secret_set: bool
+    scopes: str
+    button_label: str
+    auto_provision_users: bool
+    allowed_email_domains: str
+    password_login_disabled: bool
+    last_test_ok: bool
+    last_test_at: datetime | None
+    redirect_uri: str
+
+    @classmethod
+    def from_row(cls, row: Any, *, redirect_uri: str) -> "SsoSettingsResponse":
+        """Build the admin payload. The client secret is reported, never returned."""
+        return cls(
+            enabled=row.enabled,
+            issuer=row.issuer,
+            client_id=row.client_id,
+            client_secret_set=bool(row.encrypted_client_secret),
+            scopes=row.scopes,
+            button_label=row.button_label,
+            auto_provision_users=row.auto_provision_users,
+            allowed_email_domains=row.allowed_email_domains,
+            password_login_disabled=row.password_login_disabled,
+            last_test_ok=row.last_test_ok,
+            last_test_at=row.last_test_at,
+            redirect_uri=redirect_uri,
+        )
+
+
+class SsoTestResponse(BaseModel):
+    ok: bool
+    issuer: str | None = None
+    authorization_endpoint: str | None = None
+    token_endpoint: str | None = None
+    jwks_uri: str | None = None
+    userinfo_endpoint: str | None = None
+    error: str | None = None
+
+
+class SsoStatusResponse(BaseModel):
+    enabled: bool
+    button_label: str
+    password_login_enabled: bool

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -4,9 +4,10 @@ from decimal import Decimal
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, EmailStr, Field, computed_field, field_validator
 
 from app.config import settings
+from app.services.instance_admin import is_admin_email
 
 
 def _validate_password_strength(value: str) -> str:
@@ -67,6 +68,12 @@ class UserResponse(BaseModel):
     preferred_credential_id: uuid.UUID | None = None
     preferred_model: str | None = None
     created_at: datetime
+
+    @computed_field
+    @property
+    def is_admin(self) -> bool:
+        """Whether this account administers the instance. Derived, never stored."""
+        return is_admin_email(self.email)
 
     class Config:
         from_attributes = True

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1845,9 +1845,14 @@ class SsoSettingsResponse(BaseModel):
     last_test_ok: bool
     last_test_at: datetime | None
     redirect_uri: str
+    # Whether at least one instance admin could still sign in with a password if the
+    # identity provider became unreachable.
+    break_glass_ready: bool = False
 
     @classmethod
-    def from_row(cls, row: Any, *, redirect_uri: str) -> "SsoSettingsResponse":
+    def from_row(
+        cls, row: Any, *, redirect_uri: str, break_glass_ready: bool = False
+    ) -> "SsoSettingsResponse":
         """Build the admin payload. The client secret is reported, never returned."""
         return cls(
             enabled=row.enabled,
@@ -1862,7 +1867,15 @@ class SsoSettingsResponse(BaseModel):
             last_test_ok=row.last_test_ok,
             last_test_at=row.last_test_at,
             redirect_uri=redirect_uri,
+            break_glass_ready=break_glass_ready,
         )
+
+
+class SsoTestRequest(BaseModel):
+    # Lets an administrator test a connection before saving it. When this differs from the
+    # stored issuer the result is reported but not recorded, because `last_test_ok` licenses
+    # the stored configuration, not a draft one.
+    issuer: str | None = None
 
 
 class SsoTestResponse(BaseModel):

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -18,7 +18,11 @@ def hash_password(password: str) -> str:
     return hashed.decode("utf-8")
 
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
+def verify_password(plain_password: str, hashed_password: str | None) -> bool:
+    # SSO-provisioned accounts store no hash. bcrypt raises on an empty salt, so the
+    # absence of a password must be answered here rather than at each call site.
+    if not hashed_password:
+        return False
     password_bytes = plain_password.encode("utf-8")
     hashed_bytes = hashed_password.encode("utf-8")
     return bcrypt.checkpw(password_bytes, hashed_bytes)

--- a/backend/app/services/instance_admin.py
+++ b/backend/app/services/instance_admin.py
@@ -9,9 +9,14 @@ class _HasEmail(Protocol):
     email: str
 
 
+def admin_emails() -> set[str]:
+    """The configured instance administrators, lowercased. Empty means nobody."""
+    return {e.strip().lower() for e in settings.admin_emails.split(",") if e.strip()}
+
+
 def is_admin_email(email: str) -> bool:
     """Return True when this address is listed in HEYM_ADMIN_EMAILS."""
-    allowed = {e.strip().lower() for e in settings.admin_emails.split(",") if e.strip()}
+    allowed = admin_emails()
     return bool(allowed) and email.strip().lower() in allowed
 
 

--- a/backend/app/services/instance_admin.py
+++ b/backend/app/services/instance_admin.py
@@ -1,0 +1,20 @@
+"""Who administers this instance. Identity comes from the environment, not the database."""
+
+from typing import Protocol
+
+from app.config import settings
+
+
+class _HasEmail(Protocol):
+    email: str
+
+
+def is_admin_email(email: str) -> bool:
+    """Return True when this address is listed in HEYM_ADMIN_EMAILS."""
+    allowed = {e.strip().lower() for e in settings.admin_emails.split(",") if e.strip()}
+    return bool(allowed) and email.strip().lower() in allowed
+
+
+def is_instance_admin(user: _HasEmail) -> bool:
+    """Return True when the user is listed in HEYM_ADMIN_EMAILS."""
+    return is_admin_email(user.email)

--- a/backend/app/services/oidc_client.py
+++ b/backend/app/services/oidc_client.py
@@ -1,0 +1,126 @@
+"""A minimal OpenID Connect relying-party client.
+
+Every endpoint is derived from the provider's discovery document, so no provider is named
+here. The module knows nothing about Heym's users or database.
+"""
+
+import base64
+import hashlib
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+# Asymmetric signatures only. A symmetric algorithm would let anyone holding the client
+# secret mint an ID token, and `none` would let anyone at all.
+_ALLOWED_SIGNING_ALGORITHMS = ("RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256")
+_DISCOVERY_TTL_SECONDS = 300
+_HTTP_TIMEOUT_SECONDS = 10.0
+_MAX_RESPONSE_BYTES = 512 * 1024
+
+_discovery_cache: dict[str, tuple[float, "OidcDiscovery"]] = {}
+
+
+class OidcError(Exception):
+    """A provider response could not be used."""
+
+
+@dataclass(frozen=True)
+class OidcDiscovery:
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+    userinfo_endpoint: str | None
+    signing_algorithms: list[str]
+    token_auth_method: str
+
+
+def parse_discovery_document(document: dict[str, Any]) -> OidcDiscovery:
+    """Validate a discovery document and reduce it to the fields the flow needs."""
+    required = ("issuer", "authorization_endpoint", "token_endpoint", "jwks_uri")
+    missing = [key for key in required if not document.get(key)]
+    if missing:
+        raise OidcError(f"Discovery document is missing: {', '.join(missing)}")
+
+    advertised = document.get("id_token_signing_alg_values_supported") or ["RS256"]
+    algorithms = [alg for alg in advertised if alg in _ALLOWED_SIGNING_ALGORITHMS]
+    if not algorithms:
+        raise OidcError("Provider offers no supported ID token signing algorithm")
+
+    methods = document.get("token_endpoint_auth_methods_supported") or ["client_secret_post"]
+    auth_method = "client_secret_post" if "client_secret_post" in methods else "client_secret_basic"
+
+    return OidcDiscovery(
+        issuer=str(document["issuer"]),
+        authorization_endpoint=str(document["authorization_endpoint"]),
+        token_endpoint=str(document["token_endpoint"]),
+        jwks_uri=str(document["jwks_uri"]),
+        userinfo_endpoint=(
+            str(document["userinfo_endpoint"]) if document.get("userinfo_endpoint") else None
+        ),
+        signing_algorithms=algorithms,
+        token_auth_method=auth_method,
+    )
+
+
+def discovery_url(issuer: str) -> str:
+    """Return the well-known discovery URL for an issuer."""
+    if not issuer.startswith(("http://", "https://")):
+        raise OidcError("Issuer must be an http or https URL")
+    return issuer.rstrip("/") + "/.well-known/openid-configuration"
+
+
+async def fetch_discovery(issuer: str, *, use_cache: bool = True) -> OidcDiscovery:
+    """Fetch and cache the provider's discovery document."""
+    cached = _discovery_cache.get(issuer)
+    if use_cache and cached and cached[0] > time.monotonic():
+        return cached[1]
+
+    url = discovery_url(issuer)
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client:
+        response = await client.get(url)
+    if response.status_code != 200:
+        raise OidcError(f"Discovery request failed with HTTP {response.status_code}")
+    if len(response.content) > _MAX_RESPONSE_BYTES:
+        raise OidcError("Discovery document is implausibly large")
+
+    discovery = parse_discovery_document(response.json())
+    _discovery_cache[issuer] = (time.monotonic() + _DISCOVERY_TTL_SECONDS, discovery)
+    return discovery
+
+
+def make_pkce_pair() -> tuple[str, str]:
+    """Return a fresh (code_verifier, code_challenge) pair using S256."""
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def build_authorization_url(
+    discovery: OidcDiscovery,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    scopes: str,
+    state: str,
+    nonce: str,
+    code_challenge: str,
+) -> str:
+    """Build the authorization-code request URL. The verifier is never included."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scopes,
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    separator = "&" if "?" in discovery.authorization_endpoint else "?"
+    return f"{discovery.authorization_endpoint}{separator}{urlencode(params)}"

--- a/backend/app/services/oidc_client.py
+++ b/backend/app/services/oidc_client.py
@@ -13,6 +13,8 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
+import jwt
+from jwt import PyJWKClient
 
 # Asymmetric signatures only. A symmetric algorithm would let anyone holding the client
 # secret mint an ID token, and `none` would let anyone at all.
@@ -124,3 +126,89 @@ def build_authorization_url(
     }
     separator = "&" if "?" in discovery.authorization_endpoint else "?"
     return f"{discovery.authorization_endpoint}{separator}{urlencode(params)}"
+
+
+async def exchange_code(
+    discovery: OidcDiscovery,
+    *,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    """Trade an authorization code for tokens, using the provider's advertised auth method."""
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": code_verifier,
+        "client_id": client_id,
+    }
+    auth: tuple[str, str] | None = None
+    if discovery.token_auth_method == "client_secret_basic":
+        auth = (client_id, client_secret)
+    else:
+        form["client_secret"] = client_secret
+
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client:
+        response = await client.post(discovery.token_endpoint, data=form, auth=auth)
+
+    if response.status_code != 200:
+        raise OidcError(f"Token exchange failed with HTTP {response.status_code}")
+    payload = response.json()
+    if not payload.get("id_token"):
+        raise OidcError("Token response contained no id_token")
+    return dict(payload)
+
+
+def get_signing_key(discovery: OidcDiscovery, id_token: str) -> Any:
+    """Resolve the provider's signing key for this token. PyJWKClient caches the key set."""
+    try:
+        return PyJWKClient(discovery.jwks_uri).get_signing_key_from_jwt(id_token).key
+    except Exception as exc:  # noqa: BLE001 - any JWKS failure is one failure to the caller
+        raise OidcError(f"Could not resolve the provider signing key: {exc}") from exc
+
+
+def verify_id_token(
+    id_token: str,
+    *,
+    signing_key: Any,
+    discovery: OidcDiscovery,
+    client_id: str,
+    expected_nonce: str,
+) -> dict[str, Any]:
+    """Verify signature, audience, issuer, expiry, and nonce, then return the claims."""
+    try:
+        claims = jwt.decode(
+            id_token,
+            signing_key,
+            algorithms=discovery.signing_algorithms,
+            audience=client_id,
+            issuer=discovery.issuer,
+            options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+        )
+    except jwt.PyJWTError as exc:
+        raise OidcError(f"ID token rejected: {exc}") from exc
+
+    if not claims.get("sub"):
+        raise OidcError("ID token carries no subject")
+    # The nonce ties this token to the login this browser started; without it a token
+    # captured from another session would be replayable here.
+    if claims.get("nonce") != expected_nonce:
+        raise OidcError("ID token nonce does not match this login attempt")
+    return dict(claims)
+
+
+async def fetch_userinfo(discovery: OidcDiscovery, access_token: str) -> dict[str, Any]:
+    """Fetch userinfo claims. Used only when the ID token carries no email."""
+    if not discovery.userinfo_endpoint:
+        return {}
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client:
+        response = await client.get(
+            discovery.userinfo_endpoint,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    if response.status_code != 200:
+        return {}
+    return dict(response.json())

--- a/backend/app/services/sso_settings.py
+++ b/backend/app/services/sso_settings.py
@@ -1,0 +1,75 @@
+"""Instance-wide SSO configuration: the singleton row, its secret, and its allowlist."""
+
+from types import SimpleNamespace
+
+from fastapi import Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import SSO_SETTINGS_ID, SsoSettings
+from app.services.encryption import decrypt_config, encrypt_config
+from app.services.instance_admin import is_instance_admin
+from app.services.public_url import resolve_public_origin
+
+CALLBACK_PATH = "/api/auth/sso/callback"
+
+
+def callback_url(request: Request) -> str:
+    """The redirect URI the provider must allowlist. Derived, never typed by the admin."""
+    return resolve_public_origin(request).rstrip("/") + CALLBACK_PATH
+
+
+def encrypt_client_secret(secret: str) -> str:
+    """Encrypt the OIDC client secret for storage.
+
+    The secret is replayed to the provider's token endpoint, so it cannot be hashed the
+    way ``secret_tokens.py`` treats secrets that Heym itself verifies.
+    """
+    return encrypt_config({"client_secret": secret})
+
+
+def decrypt_client_secret(stored: str | None) -> str:
+    """Return the plaintext client secret, or an empty string when none is stored."""
+    if not stored:
+        return ""
+    return str(decrypt_config(stored).get("client_secret", ""))
+
+
+def email_domain_allowed(email: str, allowed_domains: str) -> bool:
+    """Return True when the address is inside the configured domain allowlist.
+
+    An empty allowlist permits every domain. Matching is on the whole domain label, so
+    ``notheym.local`` does not satisfy an allowlist of ``heym.local``.
+    """
+    allowed = {d.strip().lower() for d in allowed_domains.split(",") if d.strip()}
+    if not allowed:
+        return True
+    _, separator, domain = email.strip().lower().rpartition("@")
+    if not separator:
+        return False
+    return domain in allowed
+
+
+async def get_sso_settings(db: AsyncSession) -> SsoSettings:
+    """Return the singleton settings row, creating the default row on first access."""
+    result = await db.execute(select(SsoSettings).where(SsoSettings.id == SSO_SETTINGS_ID))
+    row = result.scalar_one_or_none()
+    if row is None:
+        row = SsoSettings(id=SSO_SETTINGS_ID)
+        db.add(row)
+        await db.flush()
+        await db.refresh(row)
+    return row
+
+
+def password_login_blocked(row: SsoSettings, email: str) -> bool:
+    """Return True when this address may not use a password on this instance.
+
+    Instance admins are always exempt. That is the break-glass path: whoever can edit the
+    environment file can already recover the instance, so the guarantee belongs in code
+    rather than in an operator's memory. It lives here, beside the settings it reads, so
+    that every password surface can reach it without importing from the API layer.
+    """
+    if not (row.enabled and row.issuer and row.client_id and row.password_login_disabled):
+        return False
+    return not is_instance_admin(SimpleNamespace(email=email))

--- a/backend/tests/test_advisory_sso.py
+++ b/backend/tests/test_advisory_sso.py
@@ -1,8 +1,18 @@
 """SSO security invariants: credentials at rest, and both password surfaces."""
 
 import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
+from fastapi import HTTPException
+
+from app.api.auth import login
+from app.models.schemas import UserLogin
 from app.services.auth import hash_password, verify_password
+from app.services.sso_settings import encrypt_client_secret, password_login_blocked
+
+_ADMINS = "app.services.instance_admin.settings.admin_emails"
 
 
 class NullPasswordHashTests(unittest.TestCase):
@@ -16,3 +26,102 @@ class NullPasswordHashTests(unittest.TestCase):
     def test_real_hash_still_verifies(self) -> None:
         self.assertTrue(verify_password("hunter2", hash_password("hunter2")))
         self.assertFalse(verify_password("hunter3", hash_password("hunter2")))
+
+
+def _row(**overrides: object) -> SimpleNamespace:
+    base = dict(
+        enabled=True,
+        issuer="https://idp.example",
+        client_id="heym",
+        password_login_disabled=True,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class PasswordLoginGateTests(unittest.TestCase):
+    def test_blocked_when_disabled_and_sso_is_live(self) -> None:
+        with patch(_ADMINS, "grace@heym.local"):
+            self.assertTrue(password_login_blocked(_row(), "ada@heym.local"))
+
+    def test_break_glass_admin_is_never_blocked(self) -> None:
+        """Whoever can edit the env file can already recover the instance; say so in code."""
+        with patch(_ADMINS, "grace@heym.local"):
+            self.assertFalse(password_login_blocked(_row(), "GRACE@heym.local"))
+
+    def test_not_blocked_when_the_toggle_is_off(self) -> None:
+        with patch(_ADMINS, ""):
+            self.assertFalse(password_login_blocked(_row(password_login_disabled=False), "ada@x"))
+
+    def test_not_blocked_when_sso_is_disabled(self) -> None:
+        """A stale toggle on a disabled provider must not lock everyone out."""
+        with patch(_ADMINS, ""):
+            self.assertFalse(password_login_blocked(_row(enabled=False), "ada@heym.local"))
+
+    def test_not_blocked_when_the_issuer_is_blank(self) -> None:
+        with patch(_ADMINS, ""):
+            self.assertFalse(password_login_blocked(_row(issuer=""), "ada@heym.local"))
+
+
+class _ScalarResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+class _Request:
+    client = SimpleNamespace(host="203.0.113.7")
+    headers: dict[str, str] = {}
+
+
+class LoginEndpointGateTests(unittest.IsolatedAsyncioTestCase):
+    """The gate is only worth having if the endpoint actually consults it."""
+
+    async def _login(self, email: str, sso_row: SimpleNamespace) -> object:
+        user = SimpleNamespace(
+            id=uuid.uuid4(), email=email, name="Test", hashed_password=hash_password("hunter2")
+        )
+        db = AsyncMock()
+        db.execute.return_value = _ScalarResult(user)
+        with (
+            patch("app.api.auth.get_sso_settings", AsyncMock(return_value=sso_row)),
+            patch("app.api.auth.login_limiter") as limiter,
+            patch("app.api.auth.store_refresh_token", AsyncMock()),
+        ):
+            limiter.is_allowed.return_value = (True, 0)
+            return await login(
+                UserLogin(email=email, password="hunter2"),
+                _Request(),
+                SimpleNamespace(set_cookie=lambda **_: None),
+                db=db,
+            )
+
+    async def test_password_login_is_refused_when_disabled(self) -> None:
+        with patch(_ADMINS, "grace@heym.example"):
+            with self.assertRaises(HTTPException) as ctx:
+                await self._login("ada@heym.example", _row())
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    async def test_break_glass_admin_still_gets_a_token(self) -> None:
+        with patch(_ADMINS, "grace@heym.example"):
+            result = await self._login("grace@heym.example", _row())
+
+        self.assertTrue(result.access_token)
+
+    async def test_normal_user_still_gets_a_token_when_the_toggle_is_off(self) -> None:
+        with patch(_ADMINS, ""):
+            result = await self._login("ada@heym.example", _row(password_login_disabled=False))
+
+        self.assertTrue(result.access_token)
+
+
+class ClientSecretAtRestTests(unittest.TestCase):
+    def test_the_stored_column_never_holds_the_plaintext(self) -> None:
+        """A database reader must not walk away with a working client secret."""
+        stored = encrypt_client_secret("heym-local-secret-change-me")
+
+        self.assertNotIn("heym-local-secret-change-me", stored)
+        self.assertNotIn("heym-local-secret", stored)

--- a/backend/tests/test_advisory_sso.py
+++ b/backend/tests/test_advisory_sso.py
@@ -7,8 +7,8 @@ from unittest.mock import AsyncMock, patch
 
 from fastapi import HTTPException
 
-from app.api.auth import login
-from app.models.schemas import UserLogin
+from app.api.auth import login, register
+from app.models.schemas import UserCreate, UserLogin
 from app.services.auth import hash_password, verify_password
 from app.services.sso_settings import encrypt_client_secret, password_login_blocked
 
@@ -125,3 +125,44 @@ class ClientSecretAtRestTests(unittest.TestCase):
 
         self.assertNotIn("heym-local-secret-change-me", stored)
         self.assertNotIn("heym-local-secret", stored)
+
+
+class RegisterEndpointGateTests(unittest.IsolatedAsyncioTestCase):
+    """Registration mints a password, so the same gate has to cover it."""
+
+    async def _register(self, email: str, sso_row: SimpleNamespace) -> object:
+        db = AsyncMock()
+        db.execute.return_value = _ScalarResult(None)
+        with (
+            patch("app.api.auth.get_sso_settings", AsyncMock(return_value=sso_row)),
+            patch("app.api.auth.register_limiter") as limiter,
+            patch("app.api.auth.store_refresh_token", AsyncMock()),
+        ):
+            limiter.is_allowed.return_value = (True, 0)
+            return await register(
+                UserCreate(email=email, password="Passw0rd!x", name="Test"),
+                _Request(),
+                SimpleNamespace(set_cookie=lambda **_: None),
+                db=db,
+            )
+
+    async def test_registration_is_refused_when_password_login_is_disabled(self) -> None:
+        with patch(_ADMINS, "grace@heym.example"):
+            with self.assertRaises(HTTPException) as ctx:
+                await self._register("newcomer@heym.example", _row())
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    async def test_an_admin_may_still_bootstrap_a_break_glass_account(self) -> None:
+        with patch(_ADMINS, "grace@heym.example"):
+            result = await self._register("grace@heym.example", _row())
+
+        self.assertTrue(result.access_token)
+
+    async def test_registration_is_open_when_the_toggle_is_off(self) -> None:
+        with patch(_ADMINS, ""):
+            result = await self._register(
+                "newcomer@heym.example", _row(password_login_disabled=False)
+            )
+
+        self.assertTrue(result.access_token)

--- a/backend/tests/test_advisory_sso.py
+++ b/backend/tests/test_advisory_sso.py
@@ -1,0 +1,18 @@
+"""SSO security invariants: credentials at rest, and both password surfaces."""
+
+import unittest
+
+from app.services.auth import hash_password, verify_password
+
+
+class NullPasswordHashTests(unittest.TestCase):
+    def test_none_hash_returns_false_instead_of_raising(self) -> None:
+        """SSO-provisioned users have no password; bcrypt raises on an empty salt."""
+        self.assertFalse(verify_password("anything", None))
+
+    def test_empty_hash_returns_false_instead_of_raising(self) -> None:
+        self.assertFalse(verify_password("anything", ""))
+
+    def test_real_hash_still_verifies(self) -> None:
+        self.assertTrue(verify_password("hunter2", hash_password("hunter2")))
+        self.assertFalse(verify_password("hunter3", hash_password("hunter2")))

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -15,7 +15,7 @@ class AlembicMigrationGraphTest(unittest.TestCase):
         self.script = ScriptDirectory.from_config(config)
 
     def test_revision_graph_has_one_head(self) -> None:
-        self.assertEqual(self.script.get_heads(), ["114_add_workflow_http_method"])
+        self.assertEqual(self.script.get_heads(), ["115_add_sso_settings"])
 
     def test_folder_icon_revision_follows_oauth_token_hashes(self) -> None:
         folder_icon_revision = self.script.get_revision("112_add_folder_icon")

--- a/backend/tests/test_oauth_api.py
+++ b/backend/tests/test_oauth_api.py
@@ -25,6 +25,11 @@ from app.db.models import OAuthAccessToken, OAuthAuthorizationCode
 from app.services.oauth_tokens import hash_oauth_token
 
 
+def _sso_settings_row() -> SimpleNamespace:
+    """An instance with SSO switched off, so password sign-in stays open."""
+    return SimpleNamespace(enabled=False, issuer="", client_id="", password_login_disabled=False)
+
+
 def _pkce_challenge(verifier: str) -> str:
     digest = hashlib.sha256(verifier.encode()).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
@@ -152,6 +157,8 @@ class OAuthEndpointFlowTests(unittest.IsolatedAsyncioTestCase):
             side_effect=[
                 _query_result(client),
                 _query_result(user),
+                # The consent form now consults the SSO settings before accepting a password.
+                _query_result(_sso_settings_row()),
             ]
         )
 

--- a/backend/tests/test_sso_admin_api.py
+++ b/backend/tests/test_sso_admin_api.py
@@ -168,3 +168,51 @@ class SettingsResponseTests(unittest.TestCase):
         payload = SsoSettingsResponse.from_row(_row(), redirect_uri="http://localhost:4017/cb")
 
         self.assertFalse(payload.client_secret_set)
+
+
+class BreakGlassGuardTests(unittest.TestCase):
+    """An exemption nobody can use is not an exemption."""
+
+    def test_disabling_is_refused_when_no_admin_has_a_password(self) -> None:
+        row = _row(enabled=True, last_test_ok=True)
+
+        with self.assertRaises(HTTPException) as ctx:
+            apply_settings_update(
+                row, SsoSettingsUpdate(password_login_disabled=True), break_glass_ready=False
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("HEYM_ADMIN_EMAILS", ctx.exception.detail)
+        self.assertFalse(row.password_login_disabled)
+
+    def test_disabling_is_allowed_once_an_admin_has_a_password(self) -> None:
+        row = _row(enabled=True, last_test_ok=True)
+
+        apply_settings_update(
+            row, SsoSettingsUpdate(password_login_disabled=True), break_glass_ready=True
+        )
+
+        self.assertTrue(row.password_login_disabled)
+
+    def test_re_enabling_password_login_is_never_blocked(self) -> None:
+        """Recovering must not need the very thing that is missing."""
+        row = _row(enabled=True, last_test_ok=True, password_login_disabled=True)
+
+        apply_settings_update(
+            row, SsoSettingsUpdate(password_login_disabled=False), break_glass_ready=False
+        )
+
+        self.assertFalse(row.password_login_disabled)
+
+
+class TestConnectionRecordingTests(unittest.TestCase):
+    def test_response_reports_break_glass_readiness(self) -> None:
+        ready = SsoSettingsResponse.from_row(
+            _row(), redirect_uri="http://localhost:4017/cb", break_glass_ready=True
+        )
+        blocked = SsoSettingsResponse.from_row(
+            _row(), redirect_uri="http://localhost:4017/cb", break_glass_ready=False
+        )
+
+        self.assertTrue(ready.break_glass_ready)
+        self.assertFalse(blocked.break_glass_ready)

--- a/backend/tests/test_sso_admin_api.py
+++ b/backend/tests/test_sso_admin_api.py
@@ -1,0 +1,82 @@
+"""Instance admin identity and the /api/admin/sso surface."""
+
+import unittest
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.api.deps import require_instance_admin
+from app.models.schemas import UserResponse
+from app.services.instance_admin import is_instance_admin
+
+_ADMINS = "app.services.instance_admin.settings.admin_emails"
+
+
+def _user(email: str) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), email=email, name="Test")
+
+
+class InstanceAdminTests(unittest.TestCase):
+    def test_listed_email_is_admin_case_insensitively(self) -> None:
+        with patch(_ADMINS, " Ada@Heym.local , grace@heym.local "):
+            self.assertTrue(is_instance_admin(_user("ada@heym.local")))
+            self.assertTrue(is_instance_admin(_user("GRACE@HEYM.LOCAL")))
+
+    def test_unlisted_email_is_not_admin(self) -> None:
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertFalse(is_instance_admin(_user("mallory@heym.local")))
+
+    def test_empty_allowlist_grants_nobody(self) -> None:
+        """An unset allowlist must not mean 'everyone', which would open the config to all."""
+        with patch(_ADMINS, ""):
+            self.assertFalse(is_instance_admin(_user("ada@heym.local")))
+
+    def test_require_instance_admin_raises_403_for_non_admin(self) -> None:
+        with patch(_ADMINS, "ada@heym.local"):
+            with self.assertRaises(HTTPException) as ctx:
+                require_instance_admin(_user("mallory@heym.local"))
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_require_instance_admin_passes_for_admin(self) -> None:
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertIsNone(require_instance_admin(_user("ada@heym.local")))
+
+
+class UserResponseAdminFlagTests(unittest.TestCase):
+    def test_flag_is_derived_from_the_allowlist(self) -> None:
+        """A computed field cannot be forgotten by a serializer that builds the payload."""
+        row = SimpleNamespace(
+            id=uuid.uuid4(),
+            email="ada@heym.local",
+            name="Ada",
+            user_rules=None,
+            tts_credential_id=None,
+            tts_voice_id=None,
+            preferred_credential_id=None,
+            preferred_model=None,
+            created_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertTrue(UserResponse.model_validate(row).is_admin)
+        with patch(_ADMINS, "grace@heym.local"):
+            self.assertFalse(UserResponse.model_validate(row).is_admin)
+
+    def test_flag_is_present_in_the_serialized_payload(self) -> None:
+        row = SimpleNamespace(
+            id=uuid.uuid4(),
+            email="ada@heym.local",
+            name="Ada",
+            user_rules=None,
+            tts_credential_id=None,
+            tts_voice_id=None,
+            preferred_credential_id=None,
+            preferred_model=None,
+            created_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertIs(UserResponse.model_validate(row).model_dump()["is_admin"], True)

--- a/backend/tests/test_sso_admin_api.py
+++ b/backend/tests/test_sso_admin_api.py
@@ -9,8 +9,10 @@ from unittest.mock import patch
 from fastapi import HTTPException
 
 from app.api.deps import require_instance_admin
-from app.models.schemas import UserResponse
+from app.api.sso_admin import apply_settings_update
+from app.models.schemas import SsoSettingsResponse, SsoSettingsUpdate, UserResponse
 from app.services.instance_admin import is_instance_admin
+from app.services.sso_settings import decrypt_client_secret, encrypt_client_secret
 
 _ADMINS = "app.services.instance_admin.settings.admin_emails"
 
@@ -80,3 +82,89 @@ class UserResponseAdminFlagTests(unittest.TestCase):
 
         with patch(_ADMINS, "ada@heym.local"):
             self.assertIs(UserResponse.model_validate(row).model_dump()["is_admin"], True)
+
+
+class _Row(SimpleNamespace):
+    pass
+
+
+def _row(**overrides: object) -> _Row:
+    base = dict(
+        enabled=False,
+        issuer="",
+        client_id="",
+        encrypted_client_secret=None,
+        scopes="openid email profile",
+        button_label="Sign in with SSO",
+        auto_provision_users=True,
+        allowed_email_domains="",
+        password_login_disabled=False,
+        last_test_ok=False,
+        last_test_at=None,
+        updated_by_id=None,
+    )
+    base.update(overrides)
+    return _Row(**base)
+
+
+class SettingsUpdateTests(unittest.TestCase):
+    def test_a_supplied_secret_is_stored_encrypted(self) -> None:
+        row = _row()
+
+        apply_settings_update(row, SsoSettingsUpdate(client_secret="top-secret"))
+
+        self.assertNotIn("top-secret", row.encrypted_client_secret)
+        self.assertEqual(decrypt_client_secret(row.encrypted_client_secret), "top-secret")
+
+    def test_an_empty_secret_preserves_the_stored_one(self) -> None:
+        """The masked editor field posts back empty; it must not erase the real secret."""
+        row = _row(encrypted_client_secret=encrypt_client_secret("original"))
+
+        apply_settings_update(row, SsoSettingsUpdate(client_secret=""))
+
+        self.assertEqual(decrypt_client_secret(row.encrypted_client_secret), "original")
+
+    def test_changing_the_issuer_invalidates_the_recorded_test(self) -> None:
+        """A passing test result must not license the new issuer."""
+        row = _row(issuer="https://old.example", last_test_ok=True)
+
+        apply_settings_update(row, SsoSettingsUpdate(issuer="https://new.example"))
+
+        self.assertFalse(row.last_test_ok)
+
+    def test_password_login_cannot_be_disabled_before_a_passing_test(self) -> None:
+        row = _row(enabled=True, last_test_ok=False)
+
+        with self.assertRaises(HTTPException) as ctx:
+            apply_settings_update(row, SsoSettingsUpdate(password_login_disabled=True))
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_password_login_cannot_be_disabled_while_sso_is_off(self) -> None:
+        row = _row(enabled=False, last_test_ok=True)
+
+        with self.assertRaises(HTTPException):
+            apply_settings_update(row, SsoSettingsUpdate(password_login_disabled=True))
+
+    def test_password_login_may_be_disabled_once_sso_is_enabled_and_tested(self) -> None:
+        row = _row(enabled=True, last_test_ok=True)
+
+        apply_settings_update(row, SsoSettingsUpdate(password_login_disabled=True))
+
+        self.assertTrue(row.password_login_disabled)
+
+
+class SettingsResponseTests(unittest.TestCase):
+    def test_response_reports_the_secret_without_revealing_it(self) -> None:
+        row = _row(issuer="https://idp.example", encrypted_client_secret=encrypt_client_secret("s"))
+
+        payload = SsoSettingsResponse.from_row(row, redirect_uri="http://localhost:4017/cb")
+
+        self.assertTrue(payload.client_secret_set)
+        self.assertNotIn("client_secret", payload.model_dump())
+        self.assertEqual(payload.redirect_uri, "http://localhost:4017/cb")
+
+    def test_absent_secret_reports_false(self) -> None:
+        payload = SsoSettingsResponse.from_row(_row(), redirect_uri="http://localhost:4017/cb")
+
+        self.assertFalse(payload.client_secret_set)

--- a/backend/tests/test_sso_auth_flow.py
+++ b/backend/tests/test_sso_auth_flow.py
@@ -1,8 +1,11 @@
 """SSO login initiation, callback state handling, and account resolution."""
 
 import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
-from app.api.sso_auth import safe_next_path
+from app.api.sso_auth import SsoLoginError, resolve_sso_user, safe_next_path
 
 
 class NextPathTests(unittest.TestCase):
@@ -24,3 +27,116 @@ class NextPathTests(unittest.TestCase):
 
     def test_none_falls_back_to_root(self) -> None:
         self.assertEqual(safe_next_path(None), "/")
+
+
+class _ScalarResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+def _settings_row(**overrides: object) -> SimpleNamespace:
+    base = dict(auto_provision_users=True, allowed_email_domains="")
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _db(*results: object) -> AsyncMock:
+    db = AsyncMock()
+    db.execute.side_effect = [_ScalarResult(r) for r in results]
+    return db
+
+
+_CLAIMS = {
+    "sub": "ada-subject",
+    "email": "ada@heym.local",
+    "email_verified": True,
+    "name": "Ada",
+}
+_ISSUER = "https://idp.example/realms/heym"
+
+
+class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_subject_match_wins_and_skips_the_email_lookup(self) -> None:
+        existing = SimpleNamespace(
+            id=uuid.uuid4(),
+            email="renamed@heym.local",
+            sso_issuer=_ISSUER,
+            sso_subject="ada-subject",
+        )
+        db = _db(existing)
+
+        user = await resolve_sso_user(db, _settings_row(), _ISSUER, _CLAIMS)
+
+        self.assertIs(user, existing)
+        self.assertEqual(db.execute.await_count, 1)
+
+    async def test_verified_email_claims_an_existing_account(self) -> None:
+        existing = SimpleNamespace(
+            id=uuid.uuid4(), email="ada@heym.local", sso_issuer=None, sso_subject=None
+        )
+        db = _db(None, existing)
+
+        user = await resolve_sso_user(db, _settings_row(), _ISSUER, _CLAIMS)
+
+        self.assertIs(user, existing)
+        self.assertEqual(user.sso_issuer, _ISSUER)
+        self.assertEqual(user.sso_subject, "ada-subject")
+
+    async def test_unverified_email_is_rejected(self) -> None:
+        db = _db(None)
+
+        with self.assertRaises(SsoLoginError) as ctx:
+            await resolve_sso_user(
+                db, _settings_row(), _ISSUER, dict(_CLAIMS, email_verified=False)
+            )
+
+        self.assertEqual(ctx.exception.code, "email_not_verified")
+
+    async def test_absent_email_verified_claim_is_rejected(self) -> None:
+        db = _db(None)
+        claims = {k: v for k, v in _CLAIMS.items() if k != "email_verified"}
+
+        with self.assertRaises(SsoLoginError) as ctx:
+            await resolve_sso_user(db, _settings_row(), _ISSUER, claims)
+
+        self.assertEqual(ctx.exception.code, "email_not_verified")
+
+    async def test_missing_email_is_rejected(self) -> None:
+        db = _db(None)
+
+        with self.assertRaises(SsoLoginError) as ctx:
+            await resolve_sso_user(db, _settings_row(), _ISSUER, dict(_CLAIMS, email=""))
+
+        self.assertEqual(ctx.exception.code, "email_missing")
+
+    async def test_disallowed_domain_is_rejected(self) -> None:
+        db = _db(None)
+        row = _settings_row(allowed_email_domains="corp.example")
+
+        with self.assertRaises(SsoLoginError) as ctx:
+            await resolve_sso_user(db, row, _ISSUER, _CLAIMS)
+
+        self.assertEqual(ctx.exception.code, "domain_not_allowed")
+
+    async def test_unknown_email_is_provisioned_when_enabled(self) -> None:
+        db = _db(None, None)
+
+        user = await resolve_sso_user(db, _settings_row(), _ISSUER, _CLAIMS)
+
+        self.assertEqual(user.email, "ada@heym.local")
+        self.assertEqual(user.name, "Ada")
+        self.assertIsNone(user.hashed_password)
+        self.assertEqual(user.sso_subject, "ada-subject")
+        db.add.assert_called_once()
+
+    async def test_unknown_email_is_rejected_when_provisioning_is_off(self) -> None:
+        db = _db(None, None)
+
+        with self.assertRaises(SsoLoginError) as ctx:
+            await resolve_sso_user(db, _settings_row(auto_provision_users=False), _ISSUER, _CLAIMS)
+
+        self.assertEqual(ctx.exception.code, "provisioning_disabled")
+        db.add.assert_not_called()

--- a/backend/tests/test_sso_auth_flow.py
+++ b/backend/tests/test_sso_auth_flow.py
@@ -1,0 +1,26 @@
+"""SSO login initiation, callback state handling, and account resolution."""
+
+import unittest
+
+from app.api.sso_auth import safe_next_path
+
+
+class NextPathTests(unittest.TestCase):
+    def test_a_relative_path_is_kept(self) -> None:
+        self.assertEqual(safe_next_path("/workflows/42"), "/workflows/42")
+
+    def test_an_absolute_url_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path("https://evil.example/phish"), "/")
+
+    def test_a_protocol_relative_url_falls_back_to_root(self) -> None:
+        """//evil.example is a URL, not a path; browsers follow it off-site."""
+        self.assertEqual(safe_next_path("//evil.example"), "/")
+
+    def test_a_backslash_variant_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path("/\\evil.example"), "/")
+
+    def test_a_path_without_a_leading_slash_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path("workflows"), "/")
+
+    def test_none_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path(None), "/")

--- a/backend/tests/test_sso_oidc_client.py
+++ b/backend/tests/test_sso_oidc_client.py
@@ -1,15 +1,20 @@
 """OIDC mechanics: discovery, PKCE, authorization URL, token exchange, ID token checks."""
 
 import base64
+import datetime
 import hashlib
 import unittest
 from urllib.parse import parse_qs, urlparse
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from app.services.oidc_client import (
     OidcError,
     build_authorization_url,
     make_pkce_pair,
     parse_discovery_document,
+    verify_id_token,
 )
 
 _DISCOVERY = {
@@ -125,3 +130,79 @@ class AuthorizationUrlTests(unittest.TestCase):
         )
 
         self.assertNotIn(verifier, url)
+
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_OTHER_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _issue(key: object = _PRIVATE_KEY, **overrides: object) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    claims: dict[str, object] = {
+        "iss": "https://idp.example/realms/heym",
+        "aud": "heym",
+        "sub": "ada-subject",
+        "email": "ada@heym.local",
+        "email_verified": True,
+        "nonce": "nonce-value",
+        "iat": now,
+        "exp": now + datetime.timedelta(minutes=5),
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, key, algorithm="RS256")
+
+
+class IdTokenVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.discovery = parse_discovery_document(_DISCOVERY)
+        self.key = _PRIVATE_KEY.public_key()
+
+    def _verify(self, token: str, nonce: str = "nonce-value") -> dict:
+        return verify_id_token(
+            token,
+            signing_key=self.key,
+            discovery=self.discovery,
+            client_id="heym",
+            expected_nonce=nonce,
+        )
+
+    def test_valid_token_returns_its_claims(self) -> None:
+        claims = self._verify(_issue())
+
+        self.assertEqual(claims["sub"], "ada-subject")
+        self.assertEqual(claims["email"], "ada@heym.local")
+
+    def test_wrong_audience_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(aud="someone-else"))
+
+    def test_wrong_issuer_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(iss="https://evil.example"))
+
+    def test_expired_token_is_rejected(self) -> None:
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        with self.assertRaises(OidcError):
+            self._verify(_issue(exp=past, iat=past))
+
+    def test_token_signed_by_another_key_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(key=_OTHER_KEY))
+
+    def test_nonce_mismatch_is_rejected(self) -> None:
+        """Without this check a replayed token from another login would be accepted."""
+        with self.assertRaises(OidcError):
+            self._verify(_issue(nonce="someone-elses-nonce"))
+
+    def test_missing_nonce_is_rejected(self) -> None:
+        token = _issue()
+        payload = jwt.decode(token, options={"verify_signature": False})
+        payload.pop("nonce")
+        unsigned = jwt.encode(payload, _PRIVATE_KEY, algorithm="RS256")
+
+        with self.assertRaises(OidcError):
+            self._verify(unsigned)
+
+    def test_token_without_a_subject_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(sub=""))

--- a/backend/tests/test_sso_oidc_client.py
+++ b/backend/tests/test_sso_oidc_client.py
@@ -1,0 +1,127 @@
+"""OIDC mechanics: discovery, PKCE, authorization URL, token exchange, ID token checks."""
+
+import base64
+import hashlib
+import unittest
+from urllib.parse import parse_qs, urlparse
+
+from app.services.oidc_client import (
+    OidcError,
+    build_authorization_url,
+    make_pkce_pair,
+    parse_discovery_document,
+)
+
+_DISCOVERY = {
+    "issuer": "https://idp.example/realms/heym",
+    "authorization_endpoint": "https://idp.example/realms/heym/protocol/openid-connect/auth",
+    "token_endpoint": "https://idp.example/realms/heym/protocol/openid-connect/token",
+    "jwks_uri": "https://idp.example/realms/heym/protocol/openid-connect/certs",
+    "userinfo_endpoint": "https://idp.example/realms/heym/protocol/openid-connect/userinfo",
+    "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+    "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+}
+
+
+class DiscoveryParsingTests(unittest.TestCase):
+    def test_parses_a_complete_document(self) -> None:
+        discovery = parse_discovery_document(_DISCOVERY)
+
+        self.assertEqual(discovery.issuer, "https://idp.example/realms/heym")
+        self.assertEqual(discovery.token_auth_method, "client_secret_post")
+        self.assertEqual(discovery.signing_algorithms, ["RS256", "ES256"])
+
+    def test_missing_required_endpoint_is_rejected(self) -> None:
+        broken = {k: v for k, v in _DISCOVERY.items() if k != "jwks_uri"}
+
+        with self.assertRaises(OidcError):
+            parse_discovery_document(broken)
+
+    def test_basic_auth_is_used_when_post_is_unsupported(self) -> None:
+        doc = dict(_DISCOVERY, token_endpoint_auth_methods_supported=["client_secret_basic"])
+
+        self.assertEqual(parse_discovery_document(doc).token_auth_method, "client_secret_basic")
+
+    def test_absent_auth_methods_default_to_post(self) -> None:
+        doc = {k: v for k, v in _DISCOVERY.items() if k != "token_endpoint_auth_methods_supported"}
+
+        self.assertEqual(parse_discovery_document(doc).token_auth_method, "client_secret_post")
+
+    def test_unsupported_signing_algorithms_are_filtered_out(self) -> None:
+        """`none` and symmetric algorithms must never survive into verification."""
+        doc = dict(
+            _DISCOVERY,
+            id_token_signing_alg_values_supported=["none", "HS256", "RS256"],
+        )
+
+        self.assertEqual(parse_discovery_document(doc).signing_algorithms, ["RS256"])
+
+    def test_no_usable_signing_algorithm_is_rejected(self) -> None:
+        doc = dict(_DISCOVERY, id_token_signing_alg_values_supported=["none", "HS256"])
+
+        with self.assertRaises(OidcError):
+            parse_discovery_document(doc)
+
+
+class PkceTests(unittest.TestCase):
+    def test_challenge_is_the_url_safe_sha256_of_the_verifier(self) -> None:
+        verifier, challenge = make_pkce_pair()
+
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        self.assertEqual(challenge, expected)
+
+    def test_verifier_length_is_within_the_rfc_range(self) -> None:
+        verifier, _ = make_pkce_pair()
+
+        self.assertGreaterEqual(len(verifier), 43)
+        self.assertLessEqual(len(verifier), 128)
+
+    def test_pairs_are_not_reused(self) -> None:
+        self.assertNotEqual(make_pkce_pair()[0], make_pkce_pair()[0])
+
+
+class AuthorizationUrlTests(unittest.TestCase):
+    def test_url_carries_pkce_state_nonce_and_scopes(self) -> None:
+        discovery = parse_discovery_document(_DISCOVERY)
+
+        url = build_authorization_url(
+            discovery,
+            client_id="heym",
+            redirect_uri="http://localhost:4017/api/auth/sso/callback",
+            scopes="openid email profile",
+            state="state-value",
+            nonce="nonce-value",
+            code_challenge="challenge-value",
+        )
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        self.assertTrue(url.startswith(discovery.authorization_endpoint))
+        self.assertEqual(params["response_type"], ["code"])
+        self.assertEqual(params["client_id"], ["heym"])
+        self.assertEqual(params["scope"], ["openid email profile"])
+        self.assertEqual(params["state"], ["state-value"])
+        self.assertEqual(params["nonce"], ["nonce-value"])
+        self.assertEqual(params["code_challenge"], ["challenge-value"])
+        self.assertEqual(params["code_challenge_method"], ["S256"])
+
+    def test_the_verifier_never_appears_in_the_url(self) -> None:
+        """PKCE is pointless if the verifier travels through the provider."""
+        discovery = parse_discovery_document(_DISCOVERY)
+        verifier, challenge = make_pkce_pair()
+
+        url = build_authorization_url(
+            discovery,
+            client_id="heym",
+            redirect_uri="http://localhost:4017/api/auth/sso/callback",
+            scopes="openid email profile",
+            state="state-value",
+            nonce="nonce-value",
+            code_challenge=challenge,
+        )
+
+        self.assertNotIn(verifier, url)

--- a/backend/tests/test_sso_settings_service.py
+++ b/backend/tests/test_sso_settings_service.py
@@ -1,0 +1,43 @@
+"""Singleton config access, secret round-trip, and the domain allowlist."""
+
+import unittest
+
+from app.services.sso_settings import (
+    decrypt_client_secret,
+    email_domain_allowed,
+    encrypt_client_secret,
+)
+
+
+class ClientSecretStorageTests(unittest.TestCase):
+    def test_secret_round_trips_through_encryption(self) -> None:
+        stored = encrypt_client_secret("heym-local-secret")
+        self.assertEqual(decrypt_client_secret(stored), "heym-local-secret")
+
+    def test_stored_form_is_not_the_plaintext(self) -> None:
+        stored = encrypt_client_secret("heym-local-secret")
+        self.assertNotIn("heym-local-secret", stored)
+
+    def test_missing_secret_decrypts_to_empty(self) -> None:
+        self.assertEqual(decrypt_client_secret(None), "")
+
+
+class EmailDomainAllowlistTests(unittest.TestCase):
+    def test_empty_allowlist_permits_any_domain(self) -> None:
+        self.assertTrue(email_domain_allowed("ada@anywhere.example", ""))
+
+    def test_listed_domain_is_permitted(self) -> None:
+        self.assertTrue(email_domain_allowed("ada@heym.local", "heym.local, other.example"))
+
+    def test_comparison_ignores_case_and_whitespace(self) -> None:
+        self.assertTrue(email_domain_allowed("Ada@HEYM.Local", "  heym.local  "))
+
+    def test_unlisted_domain_is_rejected(self) -> None:
+        self.assertFalse(email_domain_allowed("mallory@evil.example", "heym.local"))
+
+    def test_suffix_lookalike_is_rejected(self) -> None:
+        """notheym.local must not pass an allowlist of heym.local."""
+        self.assertFalse(email_domain_allowed("mallory@notheym.local", "heym.local"))
+
+    def test_address_without_a_domain_is_rejected(self) -> None:
+        self.assertFalse(email_domain_allowed("nodomain", "heym.local"))

--- a/docs/superpowers/plans/2026-08-26-oidc-sso.md
+++ b/docs/superpowers/plans/2026-08-26-oidc-sso.md
@@ -143,19 +143,30 @@ In `backend/app/config.py`, directly after the `plugin_admin_emails` line:
 - [ ] **Step 4: Add the guard**
 
 The predicate lives in a service so that both routers and other services can reach it
-without importing from the API layer. Create `backend/app/services/instance_admin.py`:
+without importing from the API layer. It takes no `db.models` import, so a schema module can
+use it too. Create `backend/app/services/instance_admin.py`:
 
 ```python
 """Who administers this instance. Identity comes from the environment, not the database."""
 
+from typing import Protocol
+
 from app.config import settings
-from app.db.models import User
 
 
-def is_instance_admin(user: User) -> bool:
-    """Return True when the user is listed in HEYM_ADMIN_EMAILS."""
+class _HasEmail(Protocol):
+    email: str
+
+
+def is_admin_email(email: str) -> bool:
+    """Return True when this address is listed in HEYM_ADMIN_EMAILS."""
     allowed = {e.strip().lower() for e in settings.admin_emails.split(",") if e.strip()}
-    return bool(allowed) and user.email.strip().lower() in allowed
+    return bool(allowed) and email.strip().lower() in allowed
+
+
+def is_instance_admin(user: _HasEmail) -> bool:
+    """Return True when the user is listed in HEYM_ADMIN_EMAILS."""
+    return is_admin_email(user.email)
 ```
 
 Append to `backend/app/api/deps.py`, adding `from app.services.instance_admin import
@@ -173,27 +184,45 @@ def require_instance_admin(current_user: User) -> None:
 
 - [ ] **Step 5: Expose the flag on the user payload**
 
-In `backend/app/models/schemas.py`, add to `UserResponse` immediately before `created_at`:
+Make it a computed field rather than a value some helper has to remember to set. Nothing
+that builds a `UserResponse` can then omit it, and `auth.py` needs no change at all —
+which also leaves the existing tests that patch `UserResponse` wholesale working.
+
+In `backend/app/models/schemas.py`, add `computed_field` to the `pydantic` import, add
+`from app.services.instance_admin import is_admin_email` to the import block, and add this
+to `UserResponse` directly after `created_at`:
 
 ```python
-    is_admin: bool = False
+    @computed_field
+    @property
+    def is_admin(self) -> bool:
+        """Whether this account administers the instance. Derived, never stored."""
+        return is_admin_email(self.email)
 ```
 
-In `backend/app/api/auth.py`, add `from app.services.instance_admin import is_instance_admin`
-to the import block, then add this helper directly above `get_me`:
+Then add these cases to `backend/tests/test_sso_admin_api.py`, importing `UserResponse` and
+`datetime`/`timezone` at the top of the file:
 
 ```python
-def _user_response(user: User) -> UserResponse:
-    """Serialize a user, adding the computed instance-admin flag."""
-    payload = UserResponse.model_validate(user)
-    payload.is_admin = is_instance_admin(user)
-    return payload
-```
+class UserResponseAdminFlagTests(unittest.TestCase):
+    def test_flag_is_derived_from_the_allowlist(self) -> None:
+        """A computed field cannot be forgotten by a serializer that builds the payload."""
+        row = SimpleNamespace(
+            id=uuid.uuid4(),
+            email="ada@heym.local",
+            name="Ada",
+            user_rules=None,
+            tts_credential_id=None,
+            tts_voice_id=None,
+            preferred_credential_id=None,
+            preferred_model=None,
+            created_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
 
-Replace both occurrences of `return UserResponse.model_validate(current_user)` (in `get_me` and `update_me`) with:
-
-```python
-    return _user_response(current_user)
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertTrue(UserResponse.model_validate(row).is_admin)
+        with patch(_ADMINS, "grace@heym.local"):
+            self.assertFalse(UserResponse.model_validate(row).is_admin)
 ```
 
 - [ ] **Step 6: Run tests to verify they pass**
@@ -209,7 +238,7 @@ Expected: 5 passed
 
 ```bash
 git add backend/app/config.py backend/app/api/deps.py backend/app/services/instance_admin.py \
-        backend/app/models/schemas.py backend/app/api/auth.py backend/tests/test_sso_admin_api.py
+        backend/app/models/schemas.py backend/tests/test_sso_admin_api.py
 git commit -m "feat(auth): instance admin allowlist via HEYM_ADMIN_EMAILS"
 ```
 

--- a/docs/superpowers/plans/2026-08-26-oidc-sso.md
+++ b/docs/superpowers/plans/2026-08-26-oidc-sso.md
@@ -1786,7 +1786,7 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-from app.api.sso_auth import SsoLoginRejected, resolve_sso_user
+from app.api.sso_auth import SsoLoginError, resolve_sso_user
 
 
 class _ScalarResult:
@@ -1845,7 +1845,7 @@ class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
     async def test_unverified_email_is_rejected(self) -> None:
         db = _db(None)
 
-        with self.assertRaises(SsoLoginRejected) as ctx:
+        with self.assertRaises(SsoLoginError) as ctx:
             await resolve_sso_user(
                 db, _settings_row(), _ISSUER, dict(_CLAIMS, email_verified=False)
             )
@@ -1856,7 +1856,7 @@ class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
         db = _db(None)
         claims = {k: v for k, v in _CLAIMS.items() if k != "email_verified"}
 
-        with self.assertRaises(SsoLoginRejected) as ctx:
+        with self.assertRaises(SsoLoginError) as ctx:
             await resolve_sso_user(db, _settings_row(), _ISSUER, claims)
 
         self.assertEqual(ctx.exception.code, "email_not_verified")
@@ -1864,7 +1864,7 @@ class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
     async def test_missing_email_is_rejected(self) -> None:
         db = _db(None)
 
-        with self.assertRaises(SsoLoginRejected) as ctx:
+        with self.assertRaises(SsoLoginError) as ctx:
             await resolve_sso_user(db, _settings_row(), _ISSUER, dict(_CLAIMS, email=""))
 
         self.assertEqual(ctx.exception.code, "email_missing")
@@ -1873,7 +1873,7 @@ class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
         db = _db(None)
         row = _settings_row(allowed_email_domains="corp.example")
 
-        with self.assertRaises(SsoLoginRejected) as ctx:
+        with self.assertRaises(SsoLoginError) as ctx:
             await resolve_sso_user(db, row, _ISSUER, _CLAIMS)
 
         self.assertEqual(ctx.exception.code, "domain_not_allowed")
@@ -1892,7 +1892,7 @@ class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
     async def test_unknown_email_is_rejected_when_provisioning_is_off(self) -> None:
         db = _db(None, None)
 
-        with self.assertRaises(SsoLoginRejected) as ctx:
+        with self.assertRaises(SsoLoginError) as ctx:
             await resolve_sso_user(
                 db, _settings_row(auto_provision_users=False), _ISSUER, _CLAIMS
             )
@@ -1908,14 +1908,14 @@ cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-
   uv run pytest tests/test_sso_auth_flow.py -k AccountResolution -v
 ```
 
-Expected: FAIL — `ImportError: cannot import name 'SsoLoginRejected'`
+Expected: FAIL — `ImportError: cannot import name 'SsoLoginError'`
 
 - [ ] **Step 3: Implement resolution and the callback**
 
 Append to `backend/app/api/sso_auth.py`:
 
 ```python
-class SsoLoginRejected(Exception):
+class SsoLoginError(Exception):
     """A login was refused for a reason the login screen may name."""
 
     def __init__(self, code: str) -> None:
@@ -1937,13 +1937,13 @@ async def resolve_sso_user(
 
     email = str(claims.get("email") or "").strip().lower()
     if not email:
-        raise SsoLoginRejected("email_missing")
+        raise SsoLoginError("email_missing")
     # An address the provider will not vouch for must not claim an account, and must not
     # create one either: that is a direct account-takeover path.
     if claims.get("email_verified") is not True:
-        raise SsoLoginRejected("email_not_verified")
+        raise SsoLoginError("email_not_verified")
     if not email_domain_allowed(email, row.allowed_email_domains):
-        raise SsoLoginRejected("domain_not_allowed")
+        raise SsoLoginError("domain_not_allowed")
 
     result = await db.execute(select(User).where(User.email == email))
     existing = result.scalar_one_or_none()
@@ -1953,7 +1953,7 @@ async def resolve_sso_user(
         return existing
 
     if not row.auto_provision_users:
-        raise SsoLoginRejected("provisioning_disabled")
+        raise SsoLoginError("provisioning_disabled")
 
     user = User(
         email=email,
@@ -2025,7 +2025,7 @@ async def sso_callback(
 
     try:
         user = await resolve_sso_user(db, row, discovery.issuer, claims)
-    except SsoLoginRejected as rejection:
+    except SsoLoginError as rejection:
         audit(
             action="auth.sso_login",
             outcome=OUTCOME_DENIED,

--- a/docs/superpowers/plans/2026-08-26-oidc-sso.md
+++ b/docs/superpowers/plans/2026-08-26-oidc-sso.md
@@ -1,0 +1,3043 @@
+# OIDC Single Sign-On Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a Heym instance authenticate users against any external OpenID Connect provider, configured at runtime from an admin-only settings tab, with no provider name or URL in the codebase.
+
+**Architecture:** The admin stores one issuer URL plus client credentials in a singleton `sso_settings` row. A pure OIDC client module derives every endpoint from the provider's discovery document, runs authorization-code-with-PKCE, and verifies the ID token against the provider's JWKS. On success the existing Heym token/cookie machinery issues the session, so nothing downstream of login changes.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 async, Alembic, `httpx`, `pyjwt[crypto]`, `cryptography` (Fernet) — all already in `backend/pyproject.toml`. Frontend: Vue 3 `<script setup>`, TypeScript strict, Tailwind.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-oidc-sso-design.md`
+
+---
+
+## File Structure
+
+**Backend — create**
+
+| File | Responsibility |
+|---|---|
+| `backend/app/services/oidc_client.py` | Pure OIDC mechanics. Discovery fetch + cache, PKCE, authorization URL, token exchange, ID token verification, userinfo. Imports nothing from Heym's domain. |
+| `backend/app/services/sso_settings.py` | Singleton load/upsert, client-secret encryption, email domain allowlist evaluation. |
+| `backend/app/api/sso_admin.py` | `/api/admin/sso` GET, PUT, and `/test`. Admin only. |
+| `backend/app/api/sso_auth.py` | `/api/auth/sso/status`, `/login`, `/callback`. Public. |
+| `backend/alembic/versions/115_add_sso_settings.py` | Table, two user columns, nullable `hashed_password`. |
+| `backend/tests/test_sso_oidc_client.py` | Discovery, PKCE, token exchange, ID token verification. |
+| `backend/tests/test_sso_settings_service.py` | Singleton upsert, secret round-trip, domain allowlist. |
+| `backend/tests/test_sso_admin_api.py` | Admin gate, secret never returned, empty-secret preservation. |
+| `backend/tests/test_sso_auth_flow.py` | Callback: state, provisioning, account resolution, `next` validation. |
+| `backend/tests/test_advisory_sso.py` | Secret at rest, both password surfaces closed, break-glass, null-hash guard. |
+
+**Backend — modify**
+
+| File | Change |
+|---|---|
+| `backend/app/config.py:70` | Add `admin_emails` setting |
+| `backend/app/api/deps.py` | Add `is_instance_admin` and `require_instance_admin` |
+| `backend/app/models/schemas.py:60` | `UserResponse.is_admin` + SSO request/response models |
+| `backend/app/services/auth.py:21` | `verify_password` tolerates a missing hash |
+| `backend/app/db/models.py:76` | User columns; new `SsoSettings` model |
+| `backend/app/api/auth.py` | `_user_response` helper; password-login gate |
+| `backend/app/api/oauth.py:543` | Password-login gate on the MCP consent form |
+| `backend/app/main.py:311` | Register the two new routers |
+| `backend/tests/test_alembic_migrations.py:18` | Head assertion moves to `115_add_sso_settings` |
+
+**Frontend — create**
+
+| File | Responsibility |
+|---|---|
+| `frontend/src/services/sso.ts` | API client |
+| `frontend/src/types/sso.ts` | Shared types |
+| `frontend/src/components/Layout/settings/SsoSettingsTab.vue` | The whole admin form |
+
+**Frontend — modify**
+
+| File | Change |
+|---|---|
+| `frontend/src/types/auth.ts:1` | `User.is_admin` |
+| `frontend/src/components/Layout/UserSettingsDialog.vue` | Tab button + component mount, admin-gated |
+| `frontend/src/views/LoginView.vue` | SSO button, conditional password form, error banner |
+
+---
+
+## Task 1: Instance admin identity
+
+**Files:**
+- Modify: `backend/app/config.py:70`
+- Modify: `backend/app/api/deps.py`
+- Modify: `backend/app/models/schemas.py:60`
+- Modify: `backend/app/api/auth.py:264-312`
+- Test: `backend/tests/test_sso_admin_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_sso_admin_api.py`:
+
+```python
+"""Instance admin identity and the /api/admin/sso surface."""
+
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.api.deps import require_instance_admin
+from app.services.instance_admin import is_instance_admin
+
+_ADMINS = "app.services.instance_admin.settings.admin_emails"
+
+
+def _user(email: str) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), email=email, name="Test")
+
+
+class InstanceAdminTests(unittest.TestCase):
+    def test_listed_email_is_admin_case_insensitively(self) -> None:
+        with patch(_ADMINS, " Ada@Heym.local , grace@heym.local "):
+            self.assertTrue(is_instance_admin(_user("ada@heym.local")))
+            self.assertTrue(is_instance_admin(_user("GRACE@HEYM.LOCAL")))
+
+    def test_unlisted_email_is_not_admin(self) -> None:
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertFalse(is_instance_admin(_user("mallory@heym.local")))
+
+    def test_empty_allowlist_grants_nobody(self) -> None:
+        """An unset allowlist must not mean 'everyone', which would open the config to all."""
+        with patch(_ADMINS, ""):
+            self.assertFalse(is_instance_admin(_user("ada@heym.local")))
+
+    def test_require_instance_admin_raises_403_for_non_admin(self) -> None:
+        with patch(_ADMINS, "ada@heym.local"):
+            with self.assertRaises(HTTPException) as ctx:
+                require_instance_admin(_user("mallory@heym.local"))
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_require_instance_admin_passes_for_admin(self) -> None:
+        with patch(_ADMINS, "ada@heym.local"):
+            self.assertIsNone(require_instance_admin(_user("ada@heym.local")))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_admin_api.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.instance_admin'`
+
+- [ ] **Step 3: Add the setting**
+
+In `backend/app/config.py`, directly after the `plugin_admin_emails` line:
+
+```python
+    # Instance administrators. Comma-separated emails. These accounts configure SSO and
+    # may always sign in with a password, which is the break-glass path when SSO is
+    # misconfigured. An empty value grants nobody.
+    admin_emails: str = Field(default="", validation_alias="HEYM_ADMIN_EMAILS")
+```
+
+- [ ] **Step 4: Add the guard**
+
+The predicate lives in a service so that both routers and other services can reach it
+without importing from the API layer. Create `backend/app/services/instance_admin.py`:
+
+```python
+"""Who administers this instance. Identity comes from the environment, not the database."""
+
+from app.config import settings
+from app.db.models import User
+
+
+def is_instance_admin(user: User) -> bool:
+    """Return True when the user is listed in HEYM_ADMIN_EMAILS."""
+    allowed = {e.strip().lower() for e in settings.admin_emails.split(",") if e.strip()}
+    return bool(allowed) and user.email.strip().lower() in allowed
+```
+
+Append to `backend/app/api/deps.py`, adding `from app.services.instance_admin import
+is_instance_admin` to its import block:
+
+```python
+def require_instance_admin(current_user: User) -> None:
+    """Raise 403 unless the caller is an instance administrator."""
+    if not is_instance_admin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not allowed to manage instance settings.",
+        )
+```
+
+- [ ] **Step 5: Expose the flag on the user payload**
+
+In `backend/app/models/schemas.py`, add to `UserResponse` immediately before `created_at`:
+
+```python
+    is_admin: bool = False
+```
+
+In `backend/app/api/auth.py`, add `from app.services.instance_admin import is_instance_admin`
+to the import block, then add this helper directly above `get_me`:
+
+```python
+def _user_response(user: User) -> UserResponse:
+    """Serialize a user, adding the computed instance-admin flag."""
+    payload = UserResponse.model_validate(user)
+    payload.is_admin = is_instance_admin(user)
+    return payload
+```
+
+Replace both occurrences of `return UserResponse.model_validate(current_user)` (in `get_me` and `update_me`) with:
+
+```python
+    return _user_response(current_user)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_admin_api.py -v
+```
+
+Expected: 5 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/config.py backend/app/api/deps.py backend/app/services/instance_admin.py \
+        backend/app/models/schemas.py backend/app/api/auth.py backend/tests/test_sso_admin_api.py
+git commit -m "feat(auth): instance admin allowlist via HEYM_ADMIN_EMAILS"
+```
+
+---
+
+## Task 2: Password verification tolerates a missing hash
+
+SSO-provisioned accounts have no password. `bcrypt.checkpw` raises `ValueError: invalid salt` on an empty or `None` hash, which would turn a failed login into a 500. One guard at the bottom of the stack covers all three call sites.
+
+**Files:**
+- Modify: `backend/app/services/auth.py:21-24`
+- Test: `backend/tests/test_advisory_sso.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_advisory_sso.py`:
+
+```python
+"""SSO security invariants: credentials at rest, and both password surfaces."""
+
+import unittest
+
+from app.services.auth import hash_password, verify_password
+
+
+class NullPasswordHashTests(unittest.TestCase):
+    def test_none_hash_returns_false_instead_of_raising(self) -> None:
+        """SSO-provisioned users have no password; bcrypt raises on an empty salt."""
+        self.assertFalse(verify_password("anything", None))
+
+    def test_empty_hash_returns_false_instead_of_raising(self) -> None:
+        self.assertFalse(verify_password("anything", ""))
+
+    def test_real_hash_still_verifies(self) -> None:
+        self.assertTrue(verify_password("hunter2", hash_password("hunter2")))
+        self.assertFalse(verify_password("hunter3", hash_password("hunter2")))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_advisory_sso.py -v
+```
+
+Expected: FAIL — `ValueError: invalid salt` on the first two tests
+
+- [ ] **Step 3: Add the guard**
+
+Replace `verify_password` in `backend/app/services/auth.py`:
+
+```python
+def verify_password(plain_password: str, hashed_password: str | None) -> bool:
+    # SSO-provisioned accounts store no hash. bcrypt raises on an empty salt, so the
+    # absence of a password must be answered here rather than at each call site.
+    if not hashed_password:
+        return False
+    password_bytes = plain_password.encode("utf-8")
+    hashed_bytes = hashed_password.encode("utf-8")
+    return bcrypt.checkpw(password_bytes, hashed_bytes)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_advisory_sso.py -v
+```
+
+Expected: 3 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/auth.py backend/tests/test_advisory_sso.py
+git commit -m "fix(auth): verify_password returns False for a missing hash"
+```
+
+---
+
+## Task 3: Schema and migration
+
+**Files:**
+- Modify: `backend/app/db/models.py:76-110`
+- Create: `backend/alembic/versions/115_add_sso_settings.py`
+- Modify: `backend/tests/test_alembic_migrations.py:18`
+
+- [ ] **Step 1: Add the user columns**
+
+In `backend/app/db/models.py`, inside `class User`, change the `hashed_password` line and add two columns after it:
+
+```python
+    hashed_password: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Identity as asserted by the external OIDC provider. (issuer, subject) is the
+    # authoritative account key; it survives an email change at the provider.
+    sso_issuer: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    sso_subject: Mapped[str | None] = mapped_column(String(255), nullable=True)
+```
+
+Add `__table_args__` to `class User`, directly under `__tablename__ = "users"`:
+
+```python
+    __table_args__ = (
+        Index("ix_users_sso_identity", "sso_issuer", "sso_subject", unique=True),
+    )
+```
+
+- [ ] **Step 2: Add the settings model**
+
+Append to `backend/app/db/models.py`:
+
+```python
+# The SSO configuration is instance-wide, so the table holds exactly one row addressed
+# by this constant. Upserting a fixed key removes the read-then-insert race.
+SSO_SETTINGS_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+class SsoSettings(Base):
+    __tablename__ = "sso_settings"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=lambda: SSO_SETTINGS_ID
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    issuer: Mapped[str] = mapped_column(String(512), default="", nullable=False)
+    client_id: Mapped[str] = mapped_column(String(255), default="", nullable=False)
+    encrypted_client_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scopes: Mapped[str] = mapped_column(
+        String(255), default="openid email profile", nullable=False
+    )
+    # The provider's name lives in data, never in code.
+    button_label: Mapped[str] = mapped_column(
+        String(64), default="Sign in with SSO", nullable=False
+    )
+    auto_provision_users: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    allowed_email_domains: Mapped[str] = mapped_column(String(512), default="", nullable=False)
+    password_login_disabled: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False
+    )
+    last_test_ok: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    last_test_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_by_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+```
+
+- [ ] **Step 3: Write the migration**
+
+Create `backend/alembic/versions/115_add_sso_settings.py`:
+
+```python
+"""add sso_settings and user SSO identity columns
+
+Revision ID: 115_add_sso_settings
+Revises: 114_add_workflow_http_method
+Create Date: 2026-08-26 10:00:00.000000
+
+"""
+
+import secrets
+from typing import Sequence, Union
+
+import bcrypt
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "115_add_sso_settings"
+down_revision: Union[str, None] = "114_add_workflow_http_method"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sso_settings",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("issuer", sa.String(512), nullable=False, server_default=""),
+        sa.Column("client_id", sa.String(255), nullable=False, server_default=""),
+        sa.Column("encrypted_client_secret", sa.Text(), nullable=True),
+        sa.Column(
+            "scopes", sa.String(255), nullable=False, server_default="openid email profile"
+        ),
+        sa.Column(
+            "button_label", sa.String(64), nullable=False, server_default="Sign in with SSO"
+        ),
+        sa.Column(
+            "auto_provision_users", sa.Boolean(), nullable=False, server_default=sa.true()
+        ),
+        sa.Column("allowed_email_domains", sa.String(512), nullable=False, server_default=""),
+        sa.Column(
+            "password_login_disabled", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("last_test_ok", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("last_test_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "updated_by_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+    )
+
+    op.add_column("users", sa.Column("sso_issuer", sa.String(512), nullable=True))
+    op.add_column("users", sa.Column("sso_subject", sa.String(255), nullable=True))
+    op.create_index(
+        "ix_users_sso_identity", "users", ["sso_issuer", "sso_subject"], unique=True
+    )
+
+    # SSO-provisioned accounts have no password.
+    op.alter_column("users", "hashed_password", existing_type=sa.String(255), nullable=True)
+
+
+def downgrade() -> None:
+    # NOT NULL cannot be restored while SSO-provisioned rows hold NULL. Give them a valid
+    # bcrypt hash of a random secret nobody holds: those accounts simply cannot log in with
+    # a password, which is the truthful state. Deleting the users instead would be data loss.
+    placeholder = bcrypt.hashpw(secrets.token_bytes(32), bcrypt.gensalt()).decode()
+    op.execute(
+        sa.text("UPDATE users SET hashed_password = :h WHERE hashed_password IS NULL").bindparams(
+            h=placeholder
+        )
+    )
+    op.alter_column("users", "hashed_password", existing_type=sa.String(255), nullable=False)
+
+    op.drop_index("ix_users_sso_identity", table_name="users")
+    op.drop_column("users", "sso_subject")
+    op.drop_column("users", "sso_issuer")
+    op.drop_table("sso_settings")
+```
+
+- [ ] **Step 4: Update the pinned head**
+
+In `backend/tests/test_alembic_migrations.py:18`:
+
+```python
+        self.assertEqual(self.script.get_heads(), ["115_add_sso_settings"])
+```
+
+- [ ] **Step 5: Apply and verify**
+
+```bash
+cd backend && uv run alembic upgrade head && uv run alembic heads
+```
+
+Expected: `115_add_sso_settings (head)`
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_alembic_migrations.py -v
+```
+
+Expected: all passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/db/models.py backend/alembic/versions/115_add_sso_settings.py \
+        backend/tests/test_alembic_migrations.py
+git commit -m "feat(db): sso_settings table and user SSO identity columns"
+```
+
+---
+
+## Task 4: SSO settings service
+
+**Files:**
+- Create: `backend/app/services/sso_settings.py`
+- Test: `backend/tests/test_sso_settings_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_sso_settings_service.py`:
+
+```python
+"""Singleton config access, secret round-trip, and the domain allowlist."""
+
+import unittest
+
+from app.services.sso_settings import (
+    decrypt_client_secret,
+    email_domain_allowed,
+    encrypt_client_secret,
+)
+
+
+class ClientSecretStorageTests(unittest.TestCase):
+    def test_secret_round_trips_through_encryption(self) -> None:
+        stored = encrypt_client_secret("heym-local-secret")
+        self.assertEqual(decrypt_client_secret(stored), "heym-local-secret")
+
+    def test_stored_form_is_not_the_plaintext(self) -> None:
+        stored = encrypt_client_secret("heym-local-secret")
+        self.assertNotIn("heym-local-secret", stored)
+
+    def test_missing_secret_decrypts_to_empty(self) -> None:
+        self.assertEqual(decrypt_client_secret(None), "")
+
+
+class EmailDomainAllowlistTests(unittest.TestCase):
+    def test_empty_allowlist_permits_any_domain(self) -> None:
+        self.assertTrue(email_domain_allowed("ada@anywhere.example", ""))
+
+    def test_listed_domain_is_permitted(self) -> None:
+        self.assertTrue(email_domain_allowed("ada@heym.local", "heym.local, other.example"))
+
+    def test_comparison_ignores_case_and_whitespace(self) -> None:
+        self.assertTrue(email_domain_allowed("Ada@HEYM.Local", "  heym.local  "))
+
+    def test_unlisted_domain_is_rejected(self) -> None:
+        self.assertFalse(email_domain_allowed("mallory@evil.example", "heym.local"))
+
+    def test_suffix_lookalike_is_rejected(self) -> None:
+        """notheym.local must not pass an allowlist of heym.local."""
+        self.assertFalse(email_domain_allowed("mallory@notheym.local", "heym.local"))
+
+    def test_address_without_a_domain_is_rejected(self) -> None:
+        self.assertFalse(email_domain_allowed("nodomain", "heym.local"))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_settings_service.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.sso_settings'`
+
+- [ ] **Step 3: Write the service**
+
+Create `backend/app/services/sso_settings.py`:
+
+```python
+"""Instance-wide SSO configuration: the singleton row, its secret, and its allowlist."""
+
+from fastapi import Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import SSO_SETTINGS_ID, SsoSettings
+from app.services.encryption import decrypt_config, encrypt_config
+from app.services.instance_admin import is_instance_admin
+from app.services.public_url import resolve_public_origin
+
+
+def encrypt_client_secret(secret: str) -> str:
+    """Encrypt the OIDC client secret for storage.
+
+    The secret is replayed to the provider's token endpoint, so it cannot be hashed the
+    way `secret_tokens.py` treats secrets that Heym itself verifies.
+    """
+    return encrypt_config({"client_secret": secret})
+
+
+def decrypt_client_secret(stored: str | None) -> str:
+    """Return the plaintext client secret, or an empty string when none is stored."""
+    if not stored:
+        return ""
+    return str(decrypt_config(stored).get("client_secret", ""))
+
+
+def email_domain_allowed(email: str, allowed_domains: str) -> bool:
+    """Return True when the address is inside the configured domain allowlist.
+
+    An empty allowlist permits every domain. Matching is on the whole domain label, so
+    `notheym.local` does not satisfy an allowlist of `heym.local`.
+    """
+    allowed = {d.strip().lower() for d in allowed_domains.split(",") if d.strip()}
+    if not allowed:
+        return True
+    _, separator, domain = email.strip().lower().rpartition("@")
+    if not separator:
+        return False
+    return domain in allowed
+
+
+CALLBACK_PATH = "/api/auth/sso/callback"
+
+
+def callback_url(request: Request) -> str:
+    """The redirect URI the provider must allowlist. Derived, never typed by the admin."""
+    return resolve_public_origin(request).rstrip("/") + CALLBACK_PATH
+
+
+async def get_sso_settings(db: AsyncSession) -> SsoSettings:
+    """Return the singleton settings row, creating the default row on first access."""
+    result = await db.execute(select(SsoSettings).where(SsoSettings.id == SSO_SETTINGS_ID))
+    row = result.scalar_one_or_none()
+    if row is None:
+        row = SsoSettings(id=SSO_SETTINGS_ID)
+        db.add(row)
+        await db.flush()
+        await db.refresh(row)
+    return row
+
+
+def password_login_blocked(row: SsoSettings, email: str) -> bool:
+    """Return True when this address may not use a password on this instance.
+
+    Instance admins are always exempt. That is the break-glass path: whoever can edit the
+    environment file can already recover the instance, so the guarantee belongs in code
+    rather than in an operator's memory. It lives here, beside the settings it reads, so
+    that every password surface can reach it without importing from the API layer.
+    """
+    if not (row.enabled and row.issuer and row.client_id and row.password_login_disabled):
+        return False
+    return not is_instance_admin(SimpleNamespace(email=email))
+```
+
+Add `from types import SimpleNamespace` to that module's import block.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_settings_service.py -v
+```
+
+Expected: 9 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/sso_settings.py backend/tests/test_sso_settings_service.py
+git commit -m "feat(sso): settings service with encrypted client secret and domain allowlist"
+```
+
+---
+
+## Task 5: OIDC client — discovery, PKCE, authorization URL
+
+**Files:**
+- Create: `backend/app/services/oidc_client.py`
+- Test: `backend/tests/test_sso_oidc_client.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_sso_oidc_client.py`:
+
+```python
+"""OIDC mechanics: discovery, PKCE, authorization URL, token exchange, ID token checks."""
+
+import base64
+import hashlib
+import unittest
+from urllib.parse import parse_qs, urlparse
+
+from app.services.oidc_client import (
+    OidcError,
+    build_authorization_url,
+    make_pkce_pair,
+    parse_discovery_document,
+)
+
+_DISCOVERY = {
+    "issuer": "https://idp.example/realms/heym",
+    "authorization_endpoint": "https://idp.example/realms/heym/protocol/openid-connect/auth",
+    "token_endpoint": "https://idp.example/realms/heym/protocol/openid-connect/token",
+    "jwks_uri": "https://idp.example/realms/heym/protocol/openid-connect/certs",
+    "userinfo_endpoint": "https://idp.example/realms/heym/protocol/openid-connect/userinfo",
+    "id_token_signing_alg_values_supported": ["RS256", "ES256"],
+    "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+}
+
+
+class DiscoveryParsingTests(unittest.TestCase):
+    def test_parses_a_complete_document(self) -> None:
+        discovery = parse_discovery_document(_DISCOVERY)
+
+        self.assertEqual(discovery.issuer, "https://idp.example/realms/heym")
+        self.assertEqual(discovery.token_auth_method, "client_secret_post")
+        self.assertEqual(discovery.signing_algorithms, ["RS256", "ES256"])
+
+    def test_missing_required_endpoint_is_rejected(self) -> None:
+        broken = {k: v for k, v in _DISCOVERY.items() if k != "jwks_uri"}
+
+        with self.assertRaises(OidcError):
+            parse_discovery_document(broken)
+
+    def test_basic_auth_is_used_when_post_is_unsupported(self) -> None:
+        doc = dict(_DISCOVERY, token_endpoint_auth_methods_supported=["client_secret_basic"])
+
+        self.assertEqual(parse_discovery_document(doc).token_auth_method, "client_secret_basic")
+
+    def test_absent_auth_methods_default_to_post(self) -> None:
+        doc = {k: v for k, v in _DISCOVERY.items() if k != "token_endpoint_auth_methods_supported"}
+
+        self.assertEqual(parse_discovery_document(doc).token_auth_method, "client_secret_post")
+
+    def test_unsupported_signing_algorithms_are_filtered_out(self) -> None:
+        """`none` and symmetric algorithms must never survive into verification."""
+        doc = dict(
+            _DISCOVERY,
+            id_token_signing_alg_values_supported=["none", "HS256", "RS256"],
+        )
+
+        self.assertEqual(parse_discovery_document(doc).signing_algorithms, ["RS256"])
+
+    def test_no_usable_signing_algorithm_is_rejected(self) -> None:
+        doc = dict(_DISCOVERY, id_token_signing_alg_values_supported=["none", "HS256"])
+
+        with self.assertRaises(OidcError):
+            parse_discovery_document(doc)
+
+
+class PkceTests(unittest.TestCase):
+    def test_challenge_is_the_url_safe_sha256_of_the_verifier(self) -> None:
+        verifier, challenge = make_pkce_pair()
+
+        expected = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        self.assertEqual(challenge, expected)
+
+    def test_verifier_length_is_within_the_rfc_range(self) -> None:
+        verifier, _ = make_pkce_pair()
+
+        self.assertGreaterEqual(len(verifier), 43)
+        self.assertLessEqual(len(verifier), 128)
+
+    def test_pairs_are_not_reused(self) -> None:
+        self.assertNotEqual(make_pkce_pair()[0], make_pkce_pair()[0])
+
+
+class AuthorizationUrlTests(unittest.TestCase):
+    def test_url_carries_pkce_state_nonce_and_scopes(self) -> None:
+        discovery = parse_discovery_document(_DISCOVERY)
+
+        url = build_authorization_url(
+            discovery,
+            client_id="heym",
+            redirect_uri="http://localhost:4017/api/auth/sso/callback",
+            scopes="openid email profile",
+            state="state-value",
+            nonce="nonce-value",
+            code_challenge="challenge-value",
+        )
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        self.assertTrue(url.startswith(discovery.authorization_endpoint))
+        self.assertEqual(params["response_type"], ["code"])
+        self.assertEqual(params["client_id"], ["heym"])
+        self.assertEqual(params["scope"], ["openid email profile"])
+        self.assertEqual(params["state"], ["state-value"])
+        self.assertEqual(params["nonce"], ["nonce-value"])
+        self.assertEqual(params["code_challenge"], ["challenge-value"])
+        self.assertEqual(params["code_challenge_method"], ["S256"])
+
+    def test_the_verifier_never_appears_in_the_url(self) -> None:
+        """PKCE is pointless if the verifier travels through the provider."""
+        discovery = parse_discovery_document(_DISCOVERY)
+        verifier, challenge = make_pkce_pair()
+
+        url = build_authorization_url(
+            discovery,
+            client_id="heym",
+            redirect_uri="http://localhost:4017/api/auth/sso/callback",
+            scopes="openid email profile",
+            state="state-value",
+            nonce="nonce-value",
+            code_challenge=challenge,
+        )
+
+        self.assertNotIn(verifier, url)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_oidc_client.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.oidc_client'`
+
+- [ ] **Step 3: Write the module**
+
+Create `backend/app/services/oidc_client.py`:
+
+```python
+"""A minimal OpenID Connect relying-party client.
+
+Every endpoint is derived from the provider's discovery document, so no provider is named
+here. The module knows nothing about Heym's users or database.
+"""
+
+import base64
+import hashlib
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+# Asymmetric signatures only. A symmetric algorithm would let anyone holding the client
+# secret mint an ID token, and `none` would let anyone at all.
+_ALLOWED_SIGNING_ALGORITHMS = ("RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256")
+_DISCOVERY_TTL_SECONDS = 300
+_HTTP_TIMEOUT_SECONDS = 10.0
+_MAX_RESPONSE_BYTES = 512 * 1024
+
+_discovery_cache: dict[str, tuple[float, "OidcDiscovery"]] = {}
+
+
+class OidcError(Exception):
+    """A provider response could not be used."""
+
+
+@dataclass(frozen=True)
+class OidcDiscovery:
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+    userinfo_endpoint: str | None
+    signing_algorithms: list[str]
+    token_auth_method: str
+
+
+def parse_discovery_document(document: dict[str, Any]) -> OidcDiscovery:
+    """Validate a discovery document and reduce it to the fields the flow needs."""
+    required = ("issuer", "authorization_endpoint", "token_endpoint", "jwks_uri")
+    missing = [key for key in required if not document.get(key)]
+    if missing:
+        raise OidcError(f"Discovery document is missing: {', '.join(missing)}")
+
+    advertised = document.get("id_token_signing_alg_values_supported") or ["RS256"]
+    algorithms = [alg for alg in advertised if alg in _ALLOWED_SIGNING_ALGORITHMS]
+    if not algorithms:
+        raise OidcError("Provider offers no supported ID token signing algorithm")
+
+    methods = document.get("token_endpoint_auth_methods_supported") or ["client_secret_post"]
+    auth_method = "client_secret_post" if "client_secret_post" in methods else "client_secret_basic"
+
+    return OidcDiscovery(
+        issuer=str(document["issuer"]),
+        authorization_endpoint=str(document["authorization_endpoint"]),
+        token_endpoint=str(document["token_endpoint"]),
+        jwks_uri=str(document["jwks_uri"]),
+        userinfo_endpoint=(
+            str(document["userinfo_endpoint"]) if document.get("userinfo_endpoint") else None
+        ),
+        signing_algorithms=algorithms,
+        token_auth_method=auth_method,
+    )
+
+
+def discovery_url(issuer: str) -> str:
+    """Return the well-known discovery URL for an issuer."""
+    if not issuer.startswith(("http://", "https://")):
+        raise OidcError("Issuer must be an http or https URL")
+    return issuer.rstrip("/") + "/.well-known/openid-configuration"
+
+
+async def fetch_discovery(issuer: str, *, use_cache: bool = True) -> OidcDiscovery:
+    """Fetch and cache the provider's discovery document."""
+    cached = _discovery_cache.get(issuer)
+    if use_cache and cached and cached[0] > time.monotonic():
+        return cached[1]
+
+    url = discovery_url(issuer)
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False
+    ) as client:
+        response = await client.get(url)
+    if response.status_code != 200:
+        raise OidcError(f"Discovery request failed with HTTP {response.status_code}")
+    if len(response.content) > _MAX_RESPONSE_BYTES:
+        raise OidcError("Discovery document is implausibly large")
+
+    discovery = parse_discovery_document(response.json())
+    _discovery_cache[issuer] = (time.monotonic() + _DISCOVERY_TTL_SECONDS, discovery)
+    return discovery
+
+
+def make_pkce_pair() -> tuple[str, str]:
+    """Return a fresh (code_verifier, code_challenge) pair using S256."""
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def build_authorization_url(
+    discovery: OidcDiscovery,
+    *,
+    client_id: str,
+    redirect_uri: str,
+    scopes: str,
+    state: str,
+    nonce: str,
+    code_challenge: str,
+) -> str:
+    """Build the authorization-code request URL. The verifier is never included."""
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "scope": scopes,
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    separator = "&" if "?" in discovery.authorization_endpoint else "?"
+    return f"{discovery.authorization_endpoint}{separator}{urlencode(params)}"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_oidc_client.py -v
+```
+
+Expected: 12 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/oidc_client.py backend/tests/test_sso_oidc_client.py
+git commit -m "feat(sso): OIDC discovery, PKCE, and authorization URL"
+```
+
+---
+
+## Task 6: OIDC client — token exchange and ID token verification
+
+**Files:**
+- Modify: `backend/app/services/oidc_client.py`
+- Modify: `backend/tests/test_sso_oidc_client.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_sso_oidc_client.py`, merging the new imports into the file's
+existing top import block — Ruff's `E402` rejects imports that appear after code:
+
+```python
+import datetime
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.services.oidc_client import verify_id_token
+
+_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_OTHER_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _issue(key: object = _PRIVATE_KEY, **overrides: object) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    claims: dict[str, object] = {
+        "iss": "https://idp.example/realms/heym",
+        "aud": "heym",
+        "sub": "ada-subject",
+        "email": "ada@heym.local",
+        "email_verified": True,
+        "nonce": "nonce-value",
+        "iat": now,
+        "exp": now + datetime.timedelta(minutes=5),
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, key, algorithm="RS256")
+
+
+class IdTokenVerificationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.discovery = parse_discovery_document(_DISCOVERY)
+        self.key = _PRIVATE_KEY.public_key()
+
+    def _verify(self, token: str, nonce: str = "nonce-value") -> dict:
+        return verify_id_token(
+            token,
+            signing_key=self.key,
+            discovery=self.discovery,
+            client_id="heym",
+            expected_nonce=nonce,
+        )
+
+    def test_valid_token_returns_its_claims(self) -> None:
+        claims = self._verify(_issue())
+
+        self.assertEqual(claims["sub"], "ada-subject")
+        self.assertEqual(claims["email"], "ada@heym.local")
+
+    def test_wrong_audience_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(aud="someone-else"))
+
+    def test_wrong_issuer_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(iss="https://evil.example"))
+
+    def test_expired_token_is_rejected(self) -> None:
+        past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        with self.assertRaises(OidcError):
+            self._verify(_issue(exp=past, iat=past))
+
+    def test_token_signed_by_another_key_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(key=_OTHER_KEY))
+
+    def test_nonce_mismatch_is_rejected(self) -> None:
+        """Without this check a replayed token from another login would be accepted."""
+        with self.assertRaises(OidcError):
+            self._verify(_issue(nonce="someone-elses-nonce"))
+
+    def test_missing_nonce_is_rejected(self) -> None:
+        token = _issue()
+        payload = jwt.decode(token, options={"verify_signature": False})
+        payload.pop("nonce")
+        unsigned = jwt.encode(payload, _PRIVATE_KEY, algorithm="RS256")
+
+        with self.assertRaises(OidcError):
+            self._verify(unsigned)
+
+    def test_token_without_a_subject_is_rejected(self) -> None:
+        with self.assertRaises(OidcError):
+            self._verify(_issue(sub=""))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_oidc_client.py -k IdToken -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'verify_id_token'`
+
+- [ ] **Step 3: Implement token exchange and verification**
+
+Append to `backend/app/services/oidc_client.py`:
+
+```python
+import jwt
+from jwt import PyJWKClient
+
+
+async def exchange_code(
+    discovery: OidcDiscovery,
+    *,
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict[str, Any]:
+    """Trade an authorization code for tokens, using the provider's advertised auth method."""
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": code_verifier,
+        "client_id": client_id,
+    }
+    auth: tuple[str, str] | None = None
+    if discovery.token_auth_method == "client_secret_basic":
+        auth = (client_id, client_secret)
+    else:
+        form["client_secret"] = client_secret
+
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False
+    ) as client:
+        response = await client.post(discovery.token_endpoint, data=form, auth=auth)
+
+    if response.status_code != 200:
+        raise OidcError(f"Token exchange failed with HTTP {response.status_code}")
+    payload = response.json()
+    if not payload.get("id_token"):
+        raise OidcError("Token response contained no id_token")
+    return dict(payload)
+
+
+def get_signing_key(discovery: OidcDiscovery, id_token: str) -> Any:
+    """Resolve the provider's signing key for this token. PyJWKClient caches the key set."""
+    try:
+        return PyJWKClient(discovery.jwks_uri).get_signing_key_from_jwt(id_token).key
+    except Exception as exc:  # noqa: BLE001 - any JWKS failure is one failure to the caller
+        raise OidcError(f"Could not resolve the provider signing key: {exc}") from exc
+
+
+def verify_id_token(
+    id_token: str,
+    *,
+    signing_key: Any,
+    discovery: OidcDiscovery,
+    client_id: str,
+    expected_nonce: str,
+) -> dict[str, Any]:
+    """Verify signature, audience, issuer, expiry, and nonce, then return the claims."""
+    try:
+        claims = jwt.decode(
+            id_token,
+            signing_key,
+            algorithms=discovery.signing_algorithms,
+            audience=client_id,
+            issuer=discovery.issuer,
+            options={"require": ["exp", "iat", "iss", "aud", "sub"]},
+        )
+    except jwt.PyJWTError as exc:
+        raise OidcError(f"ID token rejected: {exc}") from exc
+
+    if not claims.get("sub"):
+        raise OidcError("ID token carries no subject")
+    # The nonce ties this token to the login this browser started; without it a token
+    # captured from another session would be replayable here.
+    if claims.get("nonce") != expected_nonce:
+        raise OidcError("ID token nonce does not match this login attempt")
+    return dict(claims)
+
+
+async def fetch_userinfo(discovery: OidcDiscovery, access_token: str) -> dict[str, Any]:
+    """Fetch userinfo claims. Used only when the ID token carries no email."""
+    if not discovery.userinfo_endpoint:
+        return {}
+    async with httpx.AsyncClient(
+        timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False
+    ) as client:
+        response = await client.get(
+            discovery.userinfo_endpoint,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    if response.status_code != 200:
+        return {}
+    return dict(response.json())
+```
+
+Move the two new `import jwt` / `from jwt import PyJWKClient` lines up to the module's import block so Ruff's import ordering passes.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_oidc_client.py -v && uv run ruff check app/services/oidc_client.py
+```
+
+Expected: 20 passed, ruff clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/oidc_client.py backend/tests/test_sso_oidc_client.py
+git commit -m "feat(sso): token exchange and ID token verification"
+```
+
+---
+
+## Task 7: Admin configuration API
+
+**Files:**
+- Create: `backend/app/api/sso_admin.py`
+- Modify: `backend/app/models/schemas.py`
+- Modify: `backend/app/main.py:311`
+- Modify: `backend/tests/test_sso_admin_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_sso_admin_api.py`, merging the new imports into the file's
+existing top import block — Ruff's `E402` rejects imports that appear after code:
+
+```python
+from app.api.sso_admin import apply_settings_update
+from app.models.schemas import SsoSettingsResponse, SsoSettingsUpdate
+from app.services.sso_settings import decrypt_client_secret, encrypt_client_secret
+
+
+class _Row(SimpleNamespace):
+    pass
+
+
+def _row(**overrides: object) -> _Row:
+    base = dict(
+        enabled=False,
+        issuer="",
+        client_id="",
+        encrypted_client_secret=None,
+        scopes="openid email profile",
+        button_label="Sign in with SSO",
+        auto_provision_users=True,
+        allowed_email_domains="",
+        password_login_disabled=False,
+        last_test_ok=False,
+        last_test_at=None,
+        updated_by_id=None,
+    )
+    base.update(overrides)
+    return _Row(**base)
+
+
+class SettingsUpdateTests(unittest.TestCase):
+    def test_a_supplied_secret_is_stored_encrypted(self) -> None:
+        row = _row()
+
+        apply_settings_update(row, SsoSettingsUpdate(client_secret="top-secret"))
+
+        self.assertNotIn("top-secret", row.encrypted_client_secret)
+        self.assertEqual(decrypt_client_secret(row.encrypted_client_secret), "top-secret")
+
+    def test_an_empty_secret_preserves_the_stored_one(self) -> None:
+        """The masked editor field posts back empty; it must not erase the real secret."""
+        row = _row(encrypted_client_secret=encrypt_client_secret("original"))
+
+        apply_settings_update(row, SsoSettingsUpdate(client_secret=""))
+
+        self.assertEqual(decrypt_client_secret(row.encrypted_client_secret), "original")
+
+    def test_changing_the_issuer_invalidates_the_recorded_test(self) -> None:
+        """A passing test result must not license the new issuer."""
+        row = _row(issuer="https://old.example", last_test_ok=True)
+
+        apply_settings_update(row, SsoSettingsUpdate(issuer="https://new.example"))
+
+        self.assertFalse(row.last_test_ok)
+
+    def test_password_login_cannot_be_disabled_before_a_passing_test(self) -> None:
+        row = _row(enabled=True, last_test_ok=False)
+
+        with self.assertRaises(HTTPException) as ctx:
+            apply_settings_update(row, SsoSettingsUpdate(password_login_disabled=True))
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_password_login_cannot_be_disabled_while_sso_is_off(self) -> None:
+        row = _row(enabled=False, last_test_ok=True)
+
+        with self.assertRaises(HTTPException):
+            apply_settings_update(row, SsoSettingsUpdate(password_login_disabled=True))
+
+    def test_password_login_may_be_disabled_once_sso_is_enabled_and_tested(self) -> None:
+        row = _row(enabled=True, last_test_ok=True)
+
+        apply_settings_update(row, SsoSettingsUpdate(password_login_disabled=True))
+
+        self.assertTrue(row.password_login_disabled)
+
+
+class SettingsResponseTests(unittest.TestCase):
+    def test_response_reports_the_secret_without_revealing_it(self) -> None:
+        row = _row(issuer="https://idp.example", encrypted_client_secret=encrypt_client_secret("s"))
+
+        payload = SsoSettingsResponse.from_row(row, redirect_uri="http://localhost:4017/cb")
+
+        self.assertTrue(payload.client_secret_set)
+        self.assertNotIn("client_secret", payload.model_dump())
+        self.assertEqual(payload.redirect_uri, "http://localhost:4017/cb")
+
+    def test_absent_secret_reports_false(self) -> None:
+        payload = SsoSettingsResponse.from_row(_row(), redirect_uri="http://localhost:4017/cb")
+
+        self.assertFalse(payload.client_secret_set)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_admin_api.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.api.sso_admin'`
+
+- [ ] **Step 3: Add the schemas**
+
+Append to `backend/app/models/schemas.py`:
+
+```python
+class SsoSettingsUpdate(BaseModel):
+    enabled: bool | None = None
+    issuer: str | None = None
+    client_id: str | None = None
+    # Empty string means "leave the stored secret alone", which is what the masked
+    # editor field posts back when the admin does not retype it.
+    client_secret: str | None = None
+    scopes: str | None = None
+    button_label: str | None = None
+    auto_provision_users: bool | None = None
+    allowed_email_domains: str | None = None
+    password_login_disabled: bool | None = None
+
+
+class SsoSettingsResponse(BaseModel):
+    enabled: bool
+    issuer: str
+    client_id: str
+    client_secret_set: bool
+    scopes: str
+    button_label: str
+    auto_provision_users: bool
+    allowed_email_domains: str
+    password_login_disabled: bool
+    last_test_ok: bool
+    last_test_at: datetime | None
+    redirect_uri: str
+
+    @classmethod
+    def from_row(cls, row: Any, *, redirect_uri: str) -> "SsoSettingsResponse":
+        """Build the admin payload. The client secret is reported, never returned."""
+        return cls(
+            enabled=row.enabled,
+            issuer=row.issuer,
+            client_id=row.client_id,
+            client_secret_set=bool(row.encrypted_client_secret),
+            scopes=row.scopes,
+            button_label=row.button_label,
+            auto_provision_users=row.auto_provision_users,
+            allowed_email_domains=row.allowed_email_domains,
+            password_login_disabled=row.password_login_disabled,
+            last_test_ok=row.last_test_ok,
+            last_test_at=row.last_test_at,
+            redirect_uri=redirect_uri,
+        )
+
+
+class SsoTestResponse(BaseModel):
+    ok: bool
+    issuer: str | None = None
+    authorization_endpoint: str | None = None
+    token_endpoint: str | None = None
+    jwks_uri: str | None = None
+    userinfo_endpoint: str | None = None
+    error: str | None = None
+
+
+class SsoStatusResponse(BaseModel):
+    enabled: bool
+    button_label: str
+    password_login_enabled: bool
+```
+
+If `Any` is not already imported in `schemas.py`, add `from typing import Any` to its import block.
+
+- [ ] **Step 4: Write the router**
+
+Create `backend/app/api/sso_admin.py`:
+
+```python
+"""Admin-only OIDC configuration."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_instance_admin
+from app.db.models import SsoSettings, User
+from app.db.session import get_db
+from app.models.schemas import SsoSettingsResponse, SsoSettingsUpdate, SsoTestResponse
+from app.services.audit_log import audit
+from app.services.oidc_client import OidcError, fetch_discovery
+from app.services.sso_settings import callback_url, encrypt_client_secret, get_sso_settings
+
+router = APIRouter()
+
+
+def apply_settings_update(row: SsoSettings, update: SsoSettingsUpdate) -> None:
+    """Apply a partial update to the settings row, enforcing the lockout preconditions."""
+    connection_fields = ("issuer", "client_id", "scopes")
+    for field in connection_fields:
+        value = getattr(update, field)
+        if value is not None and value.strip() != getattr(row, field):
+            setattr(row, field, value.strip())
+            # The recorded test result belongs to the old connection details.
+            row.last_test_ok = False
+
+    if update.client_secret:
+        row.encrypted_client_secret = encrypt_client_secret(update.client_secret)
+        row.last_test_ok = False
+
+    if update.enabled is not None:
+        row.enabled = update.enabled
+    if update.button_label is not None:
+        row.button_label = update.button_label.strip() or "Sign in with SSO"
+    if update.auto_provision_users is not None:
+        row.auto_provision_users = update.auto_provision_users
+    if update.allowed_email_domains is not None:
+        row.allowed_email_domains = update.allowed_email_domains.strip()
+
+    if update.password_login_disabled is not None:
+        if update.password_login_disabled and not (row.enabled and row.last_test_ok):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Password login can only be disabled once SSO is enabled and a "
+                    "connection test has passed."
+                ),
+            )
+        row.password_login_disabled = update.password_login_disabled
+
+
+@router.get("", response_model=SsoSettingsResponse)
+async def get_sso_config(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SsoSettingsResponse:
+    require_instance_admin(current_user)
+    row = await get_sso_settings(db)
+    return SsoSettingsResponse.from_row(row, redirect_uri=callback_url(request))
+
+
+@router.put("", response_model=SsoSettingsResponse)
+async def update_sso_config(
+    update: SsoSettingsUpdate,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SsoSettingsResponse:
+    require_instance_admin(current_user)
+    row = await get_sso_settings(db)
+    apply_settings_update(row, update)
+    row.updated_by_id = current_user.id
+    await db.flush()
+    await db.refresh(row)
+
+    audit(
+        action="sso.settings.update",
+        actor=current_user,
+        target_type="sso_settings",
+        enabled=row.enabled,
+        password_login_disabled=row.password_login_disabled,
+    )
+    return SsoSettingsResponse.from_row(row, redirect_uri=callback_url(request))
+
+
+@router.post("/test", response_model=SsoTestResponse)
+async def test_sso_connection(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> SsoTestResponse:
+    require_instance_admin(current_user)
+    row = await get_sso_settings(db)
+    if not row.issuer:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Set an issuer URL first"
+        )
+
+    try:
+        discovery = await fetch_discovery(row.issuer, use_cache=False)
+    except Exception as exc:  # noqa: BLE001 - any network failure surfaces to the admin as text
+        row.last_test_ok = False
+        row.last_test_at = datetime.now(timezone.utc)
+        await db.flush()
+        audit(action="sso.settings.test", actor=current_user, outcome="failure", reason=str(exc))
+        return SsoTestResponse(ok=False, error=str(exc))
+
+    row.last_test_ok = True
+    row.last_test_at = datetime.now(timezone.utc)
+    await db.flush()
+    audit(action="sso.settings.test", actor=current_user)
+    return SsoTestResponse(
+        ok=True,
+        issuer=discovery.issuer,
+        authorization_endpoint=discovery.authorization_endpoint,
+        token_endpoint=discovery.token_endpoint,
+        jwks_uri=discovery.jwks_uri,
+        userinfo_endpoint=discovery.userinfo_endpoint,
+    )
+```
+
+- [ ] **Step 5: Register the router**
+
+In `backend/app/main.py`, add `sso_admin` to the `from app.api import (...)` block, then after
+line 311 (`app.include_router(auth.router, ...)`) add:
+
+```python
+app.include_router(sso_admin.router, prefix="/api/admin/sso", tags=["SSO Admin"])
+```
+
+Task 8 adds the `sso_auth` line beside it. Registering only what exists keeps every task's
+tree importable on its own.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_admin_api.py -v
+```
+
+Expected: 13 passed
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/api/sso_admin.py backend/app/models/schemas.py backend/app/main.py \
+        backend/tests/test_sso_admin_api.py
+git commit -m "feat(sso): admin configuration API with connection test"
+```
+
+---
+
+## Task 8: Login initiation
+
+**Files:**
+- Create: `backend/app/api/sso_auth.py`
+- Modify: `backend/app/main.py`
+- Test: `backend/tests/test_sso_auth_flow.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_sso_auth_flow.py`:
+
+```python
+"""SSO login initiation, callback state handling, and account resolution."""
+
+import unittest
+
+from app.api.sso_auth import safe_next_path
+
+
+class NextPathTests(unittest.TestCase):
+    def test_a_relative_path_is_kept(self) -> None:
+        self.assertEqual(safe_next_path("/workflows/42"), "/workflows/42")
+
+    def test_an_absolute_url_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path("https://evil.example/phish"), "/")
+
+    def test_a_protocol_relative_url_falls_back_to_root(self) -> None:
+        """//evil.example is a URL, not a path; browsers follow it off-site."""
+        self.assertEqual(safe_next_path("//evil.example"), "/")
+
+    def test_a_backslash_variant_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path("/\\evil.example"), "/")
+
+    def test_a_path_without_a_leading_slash_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path("workflows"), "/")
+
+    def test_none_falls_back_to_root(self) -> None:
+        self.assertEqual(safe_next_path(None), "/")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_auth_flow.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.api.sso_auth'`
+
+- [ ] **Step 3: Write the module header, status endpoint, and login endpoint**
+
+Create `backend/app/api/sso_auth.py`:
+
+```python
+"""Public SSO login: status, initiation, and callback."""
+
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_client_ip
+from app.config import settings
+from app.db.session import get_db
+from app.models.schemas import SsoStatusResponse
+from app.services.auth_rate_limiter import login_limiter
+from app.services.oidc_client import (
+    OidcError,
+    build_authorization_url,
+    fetch_discovery,
+    make_pkce_pair,
+)
+from app.services.sso_settings import callback_url, decrypt_client_secret, get_sso_settings
+
+router = APIRouter()
+
+_TX_COOKIE = "sso_tx"
+_TX_COOKIE_PATH = "/api/auth/sso/"
+_TX_TTL_MINUTES = 10
+_TX_TYPE = "sso_tx"
+
+
+def safe_next_path(candidate: str | None) -> str:
+    """Reduce a post-login target to a same-origin path.
+
+    An unchecked value turns the callback into an open redirect, so anything that is not a
+    single-slash relative path is discarded rather than repaired.
+    """
+    if not candidate or not candidate.startswith("/"):
+        return "/"
+    if candidate.startswith("//") or candidate.startswith("/\\"):
+        return "/"
+    return candidate
+
+
+def _encode_transaction(state: str, nonce: str, code_verifier: str, next_path: str) -> str:
+    """Sign the in-flight login state for the browser cookie.
+
+    The PKCE verifier lives here and never in the `state` parameter: `state` round-trips
+    through the provider, and a signed JWT is not an encrypted one.
+    """
+    payload = {
+        "type": _TX_TYPE,
+        "state": state,
+        "nonce": nonce,
+        "code_verifier": code_verifier,
+        "next": next_path,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_TX_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
+
+
+def _decode_transaction(token: str | None) -> dict | None:
+    if not token:
+        return None
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    except jwt.PyJWTError:
+        return None
+    return payload if payload.get("type") == _TX_TYPE else None
+
+
+@router.get("/status", response_model=SsoStatusResponse)
+async def sso_status(db: AsyncSession = Depends(get_db)) -> SsoStatusResponse:
+    """What the login screen needs. The issuer and client id are not disclosed here."""
+    row = await get_sso_settings(db)
+    configured = bool(row.enabled and row.issuer and row.client_id)
+    return SsoStatusResponse(
+        enabled=configured,
+        button_label=row.button_label,
+        password_login_enabled=not (configured and row.password_login_disabled),
+    )
+
+
+@router.get("/login")
+async def sso_login(
+    request: Request,
+    next: str | None = None,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    allowed, retry_after = login_limiter.is_allowed(get_client_ip(request))
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many login attempts. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    row = await get_sso_settings(db)
+    if not (row.enabled and row.issuer and row.client_id):
+        return RedirectResponse(url="/login?sso_error=sso_disabled", status_code=302)
+    if not decrypt_client_secret(row.encrypted_client_secret):
+        return RedirectResponse(url="/login?sso_error=sso_disabled", status_code=302)
+
+    try:
+        discovery = await fetch_discovery(row.issuer)
+    except Exception:  # noqa: BLE001 - the browser gets one error code, never provider text
+        return RedirectResponse(url="/login?sso_error=token_exchange_failed", status_code=302)
+
+    state = secrets.token_urlsafe(32)
+    nonce = secrets.token_urlsafe(32)
+    code_verifier, code_challenge = make_pkce_pair()
+
+    auth_url = build_authorization_url(
+        discovery,
+        client_id=row.client_id,
+        redirect_uri=callback_url(request),
+        scopes=row.scopes,
+        state=state,
+        nonce=nonce,
+        code_challenge=code_challenge,
+    )
+
+    response = RedirectResponse(url=auth_url, status_code=302)
+    response.set_cookie(
+        key=_TX_COOKIE,
+        value=_encode_transaction(state, nonce, code_verifier, safe_next_path(next)),
+        httponly=True,
+        samesite="lax",
+        secure=request.url.scheme == "https",
+        max_age=_TX_TTL_MINUTES * 60,
+        path=_TX_COOKIE_PATH,
+    )
+    return response
+```
+
+- [ ] **Step 4: Register the router**
+
+In `backend/app/main.py`, add `sso_auth` to the `from app.api import (...)` block and this
+line directly above the `sso_admin` registration added in Task 7:
+
+```python
+app.include_router(sso_auth.router, prefix="/api/auth/sso", tags=["SSO"])
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_auth_flow.py -v
+```
+
+Expected: 6 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/sso_auth.py backend/app/main.py backend/tests/test_sso_auth_flow.py
+git commit -m "feat(sso): login initiation with PKCE and a transaction cookie"
+```
+
+---
+
+## Task 9: Callback and account resolution
+
+**Files:**
+- Modify: `backend/app/api/sso_auth.py`
+- Modify: `backend/tests/test_sso_auth_flow.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_sso_auth_flow.py`, merging the new imports into the file's
+existing top import block — Ruff's `E402` rejects imports that appear after code:
+
+```python
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from app.api.sso_auth import SsoLoginRejected, resolve_sso_user
+
+
+class _ScalarResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+def _settings_row(**overrides: object) -> SimpleNamespace:
+    base = dict(auto_provision_users=True, allowed_email_domains="")
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _db(*results: object) -> AsyncMock:
+    db = AsyncMock()
+    db.execute.side_effect = [_ScalarResult(r) for r in results]
+    return db
+
+
+_CLAIMS = {
+    "sub": "ada-subject",
+    "email": "ada@heym.local",
+    "email_verified": True,
+    "name": "Ada",
+}
+_ISSUER = "https://idp.example/realms/heym"
+
+
+class AccountResolutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_subject_match_wins_and_skips_the_email_lookup(self) -> None:
+        existing = SimpleNamespace(
+            id=uuid.uuid4(), email="renamed@heym.local", sso_issuer=_ISSUER, sso_subject="ada-subject"
+        )
+        db = _db(existing)
+
+        user = await resolve_sso_user(db, _settings_row(), _ISSUER, _CLAIMS)
+
+        self.assertIs(user, existing)
+        self.assertEqual(db.execute.await_count, 1)
+
+    async def test_verified_email_claims_an_existing_account(self) -> None:
+        existing = SimpleNamespace(
+            id=uuid.uuid4(), email="ada@heym.local", sso_issuer=None, sso_subject=None
+        )
+        db = _db(None, existing)
+
+        user = await resolve_sso_user(db, _settings_row(), _ISSUER, _CLAIMS)
+
+        self.assertIs(user, existing)
+        self.assertEqual(user.sso_issuer, _ISSUER)
+        self.assertEqual(user.sso_subject, "ada-subject")
+
+    async def test_unverified_email_is_rejected(self) -> None:
+        db = _db(None)
+
+        with self.assertRaises(SsoLoginRejected) as ctx:
+            await resolve_sso_user(
+                db, _settings_row(), _ISSUER, dict(_CLAIMS, email_verified=False)
+            )
+
+        self.assertEqual(ctx.exception.code, "email_not_verified")
+
+    async def test_absent_email_verified_claim_is_rejected(self) -> None:
+        db = _db(None)
+        claims = {k: v for k, v in _CLAIMS.items() if k != "email_verified"}
+
+        with self.assertRaises(SsoLoginRejected) as ctx:
+            await resolve_sso_user(db, _settings_row(), _ISSUER, claims)
+
+        self.assertEqual(ctx.exception.code, "email_not_verified")
+
+    async def test_missing_email_is_rejected(self) -> None:
+        db = _db(None)
+
+        with self.assertRaises(SsoLoginRejected) as ctx:
+            await resolve_sso_user(db, _settings_row(), _ISSUER, dict(_CLAIMS, email=""))
+
+        self.assertEqual(ctx.exception.code, "email_missing")
+
+    async def test_disallowed_domain_is_rejected(self) -> None:
+        db = _db(None)
+        row = _settings_row(allowed_email_domains="corp.example")
+
+        with self.assertRaises(SsoLoginRejected) as ctx:
+            await resolve_sso_user(db, row, _ISSUER, _CLAIMS)
+
+        self.assertEqual(ctx.exception.code, "domain_not_allowed")
+
+    async def test_unknown_email_is_provisioned_when_enabled(self) -> None:
+        db = _db(None, None)
+
+        user = await resolve_sso_user(db, _settings_row(), _ISSUER, _CLAIMS)
+
+        self.assertEqual(user.email, "ada@heym.local")
+        self.assertEqual(user.name, "Ada")
+        self.assertIsNone(user.hashed_password)
+        self.assertEqual(user.sso_subject, "ada-subject")
+        db.add.assert_called_once()
+
+    async def test_unknown_email_is_rejected_when_provisioning_is_off(self) -> None:
+        db = _db(None, None)
+
+        with self.assertRaises(SsoLoginRejected) as ctx:
+            await resolve_sso_user(
+                db, _settings_row(auto_provision_users=False), _ISSUER, _CLAIMS
+            )
+
+        self.assertEqual(ctx.exception.code, "provisioning_disabled")
+        db.add.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_auth_flow.py -k AccountResolution -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'SsoLoginRejected'`
+
+- [ ] **Step 3: Implement resolution and the callback**
+
+Append to `backend/app/api/sso_auth.py`:
+
+```python
+class SsoLoginRejected(Exception):
+    """A login was refused for a reason the login screen may name."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+async def resolve_sso_user(
+    db: AsyncSession, row: SsoSettings, issuer: str, claims: dict
+) -> User:
+    """Find, claim, or provision the Heym account for a verified set of ID token claims."""
+    subject = str(claims.get("sub") or "")
+    result = await db.execute(
+        select(User).where(User.sso_issuer == issuer, User.sso_subject == subject)
+    )
+    matched = result.scalar_one_or_none()
+    if matched is not None:
+        return matched
+
+    email = str(claims.get("email") or "").strip().lower()
+    if not email:
+        raise SsoLoginRejected("email_missing")
+    # An address the provider will not vouch for must not claim an account, and must not
+    # create one either: that is a direct account-takeover path.
+    if claims.get("email_verified") is not True:
+        raise SsoLoginRejected("email_not_verified")
+    if not email_domain_allowed(email, row.allowed_email_domains):
+        raise SsoLoginRejected("domain_not_allowed")
+
+    result = await db.execute(select(User).where(User.email == email))
+    existing = result.scalar_one_or_none()
+    if existing is not None:
+        existing.sso_issuer = issuer
+        existing.sso_subject = subject
+        return existing
+
+    if not row.auto_provision_users:
+        raise SsoLoginRejected("provisioning_disabled")
+
+    user = User(
+        email=email,
+        hashed_password=None,
+        name=str(claims.get("name") or claims.get("preferred_username") or email),
+        sso_issuer=issuer,
+        sso_subject=subject,
+    )
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+
+@router.get("/callback")
+async def sso_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    db: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    def failure(reason: str) -> RedirectResponse:
+        # The provider's own error text is never echoed: it is an XSS surface and leaks
+        # configuration detail to anyone who can reach the login page.
+        response = RedirectResponse(url=f"/login?{urlencode({'sso_error': reason})}", status_code=302)
+        response.delete_cookie(_TX_COOKIE, path=_TX_COOKIE_PATH)
+        return response
+
+    transaction = _decode_transaction(request.cookies.get(_TX_COOKIE))
+    if transaction is None or not state or transaction.get("state") != state:
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason="state_mismatch")
+        return failure("state_mismatch")
+    if error or not code:
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason="provider_error")
+        return failure("token_exchange_failed")
+
+    row = await get_sso_settings(db)
+    if not (row.enabled and row.issuer and row.client_id):
+        return failure("sso_disabled")
+
+    try:
+        discovery = await fetch_discovery(row.issuer)
+        tokens = await exchange_code(
+            discovery,
+            client_id=row.client_id,
+            client_secret=decrypt_client_secret(row.encrypted_client_secret),
+            code=code,
+            redirect_uri=callback_url(request),
+            code_verifier=str(transaction["code_verifier"]),
+        )
+        signing_key = get_signing_key(discovery, tokens["id_token"])
+        claims = verify_id_token(
+            tokens["id_token"],
+            signing_key=signing_key,
+            discovery=discovery,
+            client_id=row.client_id,
+            expected_nonce=str(transaction["nonce"]),
+        )
+    except OidcError as exc:
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason=str(exc))
+        return failure("invalid_token")
+    except Exception as exc:  # noqa: BLE001 - network failures reach the browser as one code
+        audit(action="auth.sso_login", outcome=OUTCOME_FAILURE, reason=str(exc))
+        return failure("token_exchange_failed")
+
+    if not claims.get("email") and tokens.get("access_token"):
+        claims = {**(await fetch_userinfo(discovery, tokens["access_token"])), **claims}
+
+    try:
+        user = await resolve_sso_user(db, row, discovery.issuer, claims)
+    except SsoLoginRejected as rejection:
+        audit(
+            action="auth.sso_login",
+            outcome=OUTCOME_DENIED,
+            actor_email=str(claims.get("email") or ""),
+            reason=rejection.code,
+        )
+        return failure(rejection.code)
+
+    access_token = create_access_token(user.id)
+    refresh_token = create_refresh_token(user.id)
+    await store_refresh_token(db, refresh_token, user.id)
+
+    response = RedirectResponse(url=safe_next_path(transaction.get("next")), status_code=302)
+    _set_auth_cookies(response, access_token, refresh_token)
+    response.delete_cookie(_TX_COOKIE, path=_TX_COOKIE_PATH)
+
+    audit(action="auth.sso_login", actor=user)
+    return response
+```
+
+Extend the module's import block with everything the callback uses:
+
+```python
+from sqlalchemy import select
+
+from app.api.auth import _set_auth_cookies
+from app.db.models import SsoSettings, User
+from app.services.audit_log import OUTCOME_DENIED, OUTCOME_FAILURE, audit
+from app.services.auth import create_access_token, create_refresh_token, store_refresh_token
+from app.services.oidc_client import (
+    exchange_code,
+    fetch_userinfo,
+    get_signing_key,
+    verify_id_token,
+)
+from app.services.sso_settings import email_domain_allowed
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_sso_auth_flow.py -v && uv run ruff check app/api/sso_auth.py
+```
+
+Expected: 14 passed, ruff clean
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/sso_auth.py backend/tests/test_sso_auth_flow.py
+git commit -m "feat(sso): callback with account resolution and provisioning"
+```
+
+---
+
+## Task 10: Close both password surfaces
+
+`password_login_disabled` must gate `/api/auth/login` **and** the MCP OAuth consent form. Closing one would make the setting a lie.
+
+**Files:**
+- Modify: `backend/app/api/auth.py:156-195`
+- Modify: `backend/app/api/oauth.py:540-545`
+- Modify: `backend/tests/test_advisory_sso.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_advisory_sso.py`:
+
+Merge the new imports into the file's existing top import block — Ruff's `E402` rejects
+imports that appear after code.
+
+```python
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.services.sso_settings import password_login_blocked
+
+_ADMINS = "app.services.instance_admin.settings.admin_emails"
+
+
+def _row(**overrides: object) -> SimpleNamespace:
+    base = dict(enabled=True, issuer="https://idp.example", client_id="heym",
+                password_login_disabled=True)
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class PasswordLoginGateTests(unittest.TestCase):
+    def test_blocked_when_disabled_and_sso_is_live(self) -> None:
+        with patch(_ADMINS, "grace@heym.local"):
+            self.assertTrue(password_login_blocked(_row(), "ada@heym.local"))
+
+    def test_break_glass_admin_is_never_blocked(self) -> None:
+        """Whoever can edit the env file can already recover the instance; say so in code."""
+        with patch(_ADMINS, "grace@heym.local"):
+            self.assertFalse(password_login_blocked(_row(), "GRACE@heym.local"))
+
+    def test_not_blocked_when_the_toggle_is_off(self) -> None:
+        with patch(_ADMINS, ""):
+            self.assertFalse(password_login_blocked(_row(password_login_disabled=False), "ada@x"))
+
+    def test_not_blocked_when_sso_is_disabled(self) -> None:
+        """A stale toggle on a disabled provider must not lock everyone out."""
+        with patch(_ADMINS, ""):
+            self.assertFalse(password_login_blocked(_row(enabled=False), "ada@heym.local"))
+
+    def test_not_blocked_when_the_issuer_is_blank(self) -> None:
+        with patch(_ADMINS, ""):
+            self.assertFalse(password_login_blocked(_row(issuer=""), "ada@heym.local"))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_advisory_sso.py -v
+```
+
+Expected: FAIL — the tests exercise a gate that no endpoint consults yet. If
+`password_login_blocked` was not added in Task 4, this fails with
+`ImportError: cannot import name 'password_login_blocked'`; add it there first.
+
+- [ ] **Step 3: Apply the gate in `/api/auth/login`**
+
+In `backend/app/api/auth.py`, add `from app.services.sso_settings import get_sso_settings,
+password_login_blocked` to the import block, then insert this inside `login`, directly after
+the rate-limit block:
+
+```python
+    sso_row = await get_sso_settings(db)
+    if password_login_blocked(sso_row, user_data.email):
+        audit(
+            action="auth.login",
+            outcome=OUTCOME_DENIED,
+            actor_email=user_data.email,
+            reason="password_login_disabled",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Password sign-in is disabled on this instance. Use SSO.",
+        )
+```
+
+- [ ] **Step 4: Apply the gate on the MCP consent form**
+
+In `backend/app/api/oauth.py`, replace the authentication check around line 543:
+
+```python
+    user_result = await db.execute(select(User).where(User.email == email))
+    user = user_result.scalar_one_or_none()
+
+    sso_row = await get_sso_settings(db)
+    if password_login_blocked(sso_row, email) or user is None or not verify_password(
+        password, user.hashed_password
+    ):
+```
+
+Add to that file's import block:
+
+```python
+from app.services.sso_settings import get_sso_settings, password_login_blocked
+```
+
+Both routers import the gate from the service rather than from each other, so no import
+cycle is possible.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd backend && HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes \
+  uv run pytest tests/test_advisory_sso.py -v
+```
+
+Expected: 8 passed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/api/auth.py backend/app/api/oauth.py backend/tests/test_advisory_sso.py
+git commit -m "feat(sso): password login gate covers both credential surfaces"
+```
+
+---
+
+## Task 11: Frontend types and API client
+
+**Files:**
+- Create: `frontend/src/types/sso.ts`
+- Create: `frontend/src/services/sso.ts`
+- Modify: `frontend/src/types/auth.ts:1-11`
+
+- [ ] **Step 1: Add the user flag**
+
+In `frontend/src/types/auth.ts`, add to `interface User` after `name`:
+
+```typescript
+  is_admin: boolean;
+```
+
+- [ ] **Step 2: Add the SSO types**
+
+Create `frontend/src/types/sso.ts`:
+
+```typescript
+export interface SsoStatus {
+  enabled: boolean;
+  button_label: string;
+  password_login_enabled: boolean;
+}
+
+export interface SsoSettings {
+  enabled: boolean;
+  issuer: string;
+  client_id: string;
+  client_secret_set: boolean;
+  scopes: string;
+  button_label: string;
+  auto_provision_users: boolean;
+  allowed_email_domains: string;
+  password_login_disabled: boolean;
+  last_test_ok: boolean;
+  last_test_at: string | null;
+  redirect_uri: string;
+}
+
+export interface SsoSettingsUpdate {
+  enabled?: boolean;
+  issuer?: string;
+  client_id?: string;
+  client_secret?: string;
+  scopes?: string;
+  button_label?: string;
+  auto_provision_users?: boolean;
+  allowed_email_domains?: string;
+  password_login_disabled?: boolean;
+}
+
+export interface SsoTestResult {
+  ok: boolean;
+  issuer: string | null;
+  authorization_endpoint: string | null;
+  token_endpoint: string | null;
+  jwks_uri: string | null;
+  userinfo_endpoint: string | null;
+  error: string | null;
+}
+```
+
+- [ ] **Step 3: Add the API client**
+
+Create `frontend/src/services/sso.ts`:
+
+```typescript
+import api from "@/services/api";
+
+import type {
+  SsoSettings,
+  SsoSettingsUpdate,
+  SsoStatus,
+  SsoTestResult,
+} from "@/types/sso";
+
+export async function getSsoStatus(): Promise<SsoStatus> {
+  const { data } = await api.get<SsoStatus>("/auth/sso/status");
+  return data;
+}
+
+export async function getAdminSsoConfig(): Promise<SsoSettings> {
+  const { data } = await api.get<SsoSettings>("/admin/sso");
+  return data;
+}
+
+export async function saveAdminSsoConfig(update: SsoSettingsUpdate): Promise<SsoSettings> {
+  const { data } = await api.put<SsoSettings>("/admin/sso", update);
+  return data;
+}
+
+export async function testSsoConnection(): Promise<SsoTestResult> {
+  const { data } = await api.post<SsoTestResult>("/admin/sso/test");
+  return data;
+}
+```
+
+- [ ] **Step 4: Verify types compile**
+
+```bash
+cd frontend && bun run typecheck
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/sso.ts frontend/src/services/sso.ts frontend/src/types/auth.ts
+git commit -m "feat(sso): frontend types and API client"
+```
+
+---
+
+## Task 12: Admin settings tab
+
+**Files:**
+- Create: `frontend/src/components/Layout/settings/SsoSettingsTab.vue`
+- Modify: `frontend/src/components/Layout/UserSettingsDialog.vue`
+
+- [ ] **Step 1: Create the tab component**
+
+Create `frontend/src/components/Layout/settings/SsoSettingsTab.vue`:
+
+```vue
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { Check, Copy, X } from "lucide-vue-next";
+
+import Button from "@/components/ui/Button.vue";
+import Input from "@/components/ui/Input.vue";
+import Label from "@/components/ui/Label.vue";
+import { getAdminSsoConfig, saveAdminSsoConfig, testSsoConnection } from "@/services/sso";
+import type { SsoSettings, SsoTestResult } from "@/types/sso";
+
+const config = ref<SsoSettings | null>(null);
+const clientSecret = ref("");
+const loading = ref(false);
+const saving = ref(false);
+const testing = ref(false);
+const testResult = ref<SsoTestResult | null>(null);
+const error = ref<string | null>(null);
+const copied = ref(false);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+  try {
+    config.value = await getAdminSsoConfig();
+  } catch {
+    error.value = "Failed to load SSO settings.";
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleSave(): Promise<void> {
+  if (!config.value) return;
+  saving.value = true;
+  error.value = null;
+  try {
+    config.value = await saveAdminSsoConfig({
+      enabled: config.value.enabled,
+      issuer: config.value.issuer,
+      client_id: config.value.client_id,
+      client_secret: clientSecret.value,
+      scopes: config.value.scopes,
+      button_label: config.value.button_label,
+      auto_provision_users: config.value.auto_provision_users,
+      allowed_email_domains: config.value.allowed_email_domains,
+      password_login_disabled: config.value.password_login_disabled,
+    });
+    clientSecret.value = "";
+    testResult.value = null;
+  } catch {
+    error.value = "Failed to save. Check that password login can be disabled yet.";
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function handleTest(): Promise<void> {
+  testing.value = true;
+  error.value = null;
+  try {
+    testResult.value = await testSsoConnection();
+    if (config.value) config.value.last_test_ok = testResult.value.ok;
+  } catch {
+    error.value = "Connection test could not run. Save the issuer first.";
+  } finally {
+    testing.value = false;
+  }
+}
+
+async function copyRedirectUri(): Promise<void> {
+  if (!config.value) return;
+  await navigator.clipboard.writeText(config.value.redirect_uri);
+  copied.value = true;
+  window.setTimeout(() => (copied.value = false), 1500);
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="space-y-5">
+    <p
+      v-if="error"
+      class="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+    >
+      {{ error }}
+    </p>
+
+    <p
+      v-if="loading"
+      class="text-sm text-muted-foreground"
+    >
+      Loading...
+    </p>
+
+    <template v-if="config">
+      <div class="flex items-center gap-2">
+        <input
+          id="sso-enabled"
+          v-model="config.enabled"
+          type="checkbox"
+          class="h-4 w-4 rounded border-input bg-background"
+        >
+        <Label
+          for="sso-enabled"
+          class="text-sm font-normal"
+        >
+          Enable single sign-on
+        </Label>
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-issuer">Issuer URL</Label>
+        <p class="text-xs text-muted-foreground">
+          The provider's base URL. Every other endpoint is read from its discovery document.
+        </p>
+        <Input
+          id="sso-issuer"
+          v-model="config.issuer"
+          placeholder="https://idp.example.com/realms/your-realm"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-client-id">Client ID</Label>
+        <Input
+          id="sso-client-id"
+          v-model="config.client_id"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-client-secret">Client secret</Label>
+        <p class="text-xs text-muted-foreground">
+          Leave blank to keep the stored secret.
+        </p>
+        <Input
+          id="sso-client-secret"
+          v-model="clientSecret"
+          type="password"
+          :placeholder="config.client_secret_set ? '••••••••' : 'Not configured'"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-redirect-uri">Redirect URI</Label>
+        <p class="text-xs text-muted-foreground">
+          Add this exact value to the provider's allowed redirect URIs.
+        </p>
+        <div class="flex gap-2">
+          <Input
+            id="sso-redirect-uri"
+            :model-value="config.redirect_uri"
+            readonly
+          />
+          <Button
+            variant="outline"
+            type="button"
+            @click="copyRedirectUri"
+          >
+            <Check
+              v-if="copied"
+              class="w-4 h-4"
+            />
+            <Copy
+              v-else
+              class="w-4 h-4"
+            />
+          </Button>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-scopes">Scopes</Label>
+        <Input
+          id="sso-scopes"
+          v-model="config.scopes"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-button-label">Sign-in button label</Label>
+        <Input
+          id="sso-button-label"
+          v-model="config.button_label"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input
+          id="sso-auto-provision"
+          v-model="config.auto_provision_users"
+          type="checkbox"
+          class="h-4 w-4 rounded border-input bg-background"
+        >
+        <Label
+          for="sso-auto-provision"
+          class="text-sm font-normal"
+        >
+          Create an account on first sign-in
+        </Label>
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-domains">Allowed email domains</Label>
+        <p class="text-xs text-muted-foreground">
+          Comma-separated. Leave blank to allow any domain the provider authenticates.
+        </p>
+        <Input
+          id="sso-domains"
+          v-model="config.allowed_email_domains"
+          placeholder="example.com, example.org"
+        />
+      </div>
+
+      <div class="flex items-center gap-3 pt-2">
+        <Button
+          variant="outline"
+          type="button"
+          :loading="testing"
+          @click="handleTest"
+        >
+          Test connection
+        </Button>
+        <span
+          v-if="testResult"
+          class="text-sm flex items-center gap-1.5"
+          :class="testResult.ok ? 'text-primary' : 'text-destructive'"
+        >
+          <Check
+            v-if="testResult.ok"
+            class="w-4 h-4"
+          />
+          <X
+            v-else
+            class="w-4 h-4"
+          />
+          {{ testResult.ok ? testResult.token_endpoint : testResult.error }}
+        </span>
+      </div>
+
+      <div class="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-2">
+        <div class="flex items-center gap-2">
+          <input
+            id="sso-disable-password"
+            v-model="config.password_login_disabled"
+            type="checkbox"
+            class="h-4 w-4 rounded border-input bg-background"
+            :disabled="!config.enabled || !config.last_test_ok"
+          >
+          <Label
+            for="sso-disable-password"
+            class="text-sm font-normal"
+          >
+            Disable password sign-in
+          </Label>
+        </div>
+        <p class="text-xs text-muted-foreground">
+          <span v-if="!config.enabled || !config.last_test_ok">
+            Available once SSO is enabled and a connection test has passed.
+          </span>
+          <span v-else>
+            Accounts listed in HEYM_ADMIN_EMAILS keep password access, so the instance stays
+            recoverable if the provider becomes unreachable.
+          </span>
+        </p>
+      </div>
+
+      <div class="flex justify-end pt-2">
+        <Button
+          variant="gradient"
+          type="button"
+          :loading="saving"
+          @click="handleSave"
+        >
+          Save
+        </Button>
+      </div>
+    </template>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Wire it into the dialog**
+
+In `frontend/src/components/Layout/UserSettingsDialog.vue`:
+
+Extend the tab union type (line 33):
+
+```typescript
+type SettingsTab = "profile" | "security" | "voice" | "ai-defaults" | "observability" | "plugins" | "sso";
+```
+
+Add to the `<script setup>` imports:
+
+```typescript
+import SsoSettingsTab from "@/components/Layout/settings/SsoSettingsTab.vue";
+```
+
+Add after the Plugins tab button, inside the same tab bar `<div>`:
+
+```vue
+          <button
+            v-if="authStore.user?.is_admin"
+            type="button"
+            class="px-3 py-2 text-sm font-medium transition-colors border-b-2 -mb-px whitespace-nowrap shrink-0"
+            :class="activeTab === 'sso' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'"
+            @click="activeTab = 'sso'"
+          >
+            SSO
+          </button>
+```
+
+Add the panel alongside the other tab bodies:
+
+```vue
+      <SsoSettingsTab v-if="activeTab === 'sso' && authStore.user?.is_admin" />
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd frontend && bun run lint && bun run typecheck
+```
+
+Expected: both clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/Layout/settings/SsoSettingsTab.vue \
+        frontend/src/components/Layout/UserSettingsDialog.vue
+git commit -m "feat(sso): admin settings tab"
+```
+
+---
+
+## Task 13: Login screen
+
+**Files:**
+- Modify: `frontend/src/views/LoginView.vue`
+
+- [ ] **Step 1: Extend the script block**
+
+Replace the `<script setup>` body of `frontend/src/views/LoginView.vue` with:
+
+```typescript
+import { computed, onMounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { ArrowRight, KeyRound, Sparkles, Zap } from "lucide-vue-next";
+
+import Button from "@/components/ui/Button.vue";
+import Card from "@/components/ui/Card.vue";
+import Input from "@/components/ui/Input.vue";
+import Label from "@/components/ui/Label.vue";
+import WorkflowHeroBackground from "@/components/Layout/WorkflowHeroBackground.vue";
+import { getSsoStatus } from "@/services/sso";
+import { useAuthStore } from "@/stores/auth";
+import type { SsoStatus } from "@/types/sso";
+
+const router = useRouter();
+const route = useRoute();
+const authStore = useAuthStore();
+
+const email = ref("");
+const password = ref("");
+const error = ref("");
+const loading = ref(false);
+const sso = ref<SsoStatus>({
+  enabled: false,
+  button_label: "Sign in with SSO",
+  password_login_enabled: true,
+});
+
+const SSO_ERRORS: Record<string, string> = {
+  state_mismatch: "That sign-in attempt expired. Please try again.",
+  token_exchange_failed: "Could not reach the identity provider. Try again shortly.",
+  invalid_token: "The identity provider's response could not be verified.",
+  email_missing: "The identity provider did not return an email address.",
+  email_not_verified: "Your email address is not verified with the identity provider.",
+  domain_not_allowed: "Your email domain is not allowed on this instance.",
+  provisioning_disabled: "No Heym account exists for you. Ask an administrator to create one.",
+  sso_disabled: "Single sign-on is not configured on this instance.",
+};
+
+const ssoError = computed<string>(() => {
+  const code = route.query.sso_error;
+  return typeof code === "string" ? (SSO_ERRORS[code] ?? SSO_ERRORS.invalid_token) : "";
+});
+
+async function handleSubmit(): Promise<void> {
+  error.value = "";
+  loading.value = true;
+
+  try {
+    await authStore.login({ email: email.value, password: password.value });
+    router.push("/");
+  } catch {
+    error.value = "Invalid email or password";
+  } finally {
+    loading.value = false;
+  }
+}
+
+function startSso(): void {
+  // A full navigation, not an XHR: the browser must follow the redirect chain into the
+  // provider's own login UI.
+  window.location.href = "/api/auth/sso/login";
+}
+
+onMounted(async () => {
+  try {
+    sso.value = await getSsoStatus();
+  } catch {
+    // A status failure must never hide the password form.
+    sso.value = { enabled: false, button_label: "Sign in with SSO", password_login_enabled: true };
+  }
+});
+```
+
+- [ ] **Step 2: Update the template**
+
+In the same file, wrap the existing `<form ...>` element with `v-if="sso.password_login_enabled"`:
+
+```vue
+        <form
+          v-if="sso.password_login_enabled"
+          class="space-y-5"
+          @submit.prevent="handleSubmit"
+        >
+```
+
+Insert directly above that form:
+
+```vue
+        <div
+          v-if="ssoError"
+          class="mb-5 p-4 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+        >
+          {{ ssoError }}
+        </div>
+```
+
+Insert directly after the closing `</form>` tag:
+
+```vue
+        <div
+          v-if="sso.enabled && sso.password_login_enabled"
+          class="divider relative my-8"
+        >
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-border" />
+          </div>
+          <div class="relative flex justify-center text-xs uppercase">
+            <span class="bg-card px-3 text-muted-foreground">or</span>
+          </div>
+        </div>
+
+        <Button
+          v-if="sso.enabled"
+          type="button"
+          variant="outline"
+          class="w-full h-12 min-h-[44px] text-base"
+          @click="startSso"
+        >
+          <KeyRound class="w-4 h-4 mr-1" />
+          {{ sso.button_label }}
+        </Button>
+```
+
+Add `v-if="sso.password_login_enabled"` to the existing "New to Heym?" divider `<div class="divider relative my-8">` and to the `<RouterLink to="/register">` element, so a password-free instance does not offer registration.
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd frontend && bun run lint && bun run typecheck
+```
+
+Expected: both clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/views/LoginView.vue
+git commit -m "feat(sso): login screen SSO button and error surface"
+```
+
+---
+
+## Task 14: Documentation and release tour
+
+**Files:**
+- Create: `frontend/src/docs/content/reference/sso.md`
+- Modify: `frontend/src/docs/manifest.ts`
+- Modify: `frontend/src/docs/content/reference/features.md`
+- Modify: `frontend/src/docs/content/reference/user-settings.md`
+- Modify: `frontend/src/features/release-tour/releaseRegistry.ts`
+- Create: `frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue`
+- Modify: `frontend/src/features/release-tour/tourVisuals.ts`
+
+- [ ] **Step 1: Write the docs**
+
+Invoke the `heym-documentation` skill and follow it to produce `reference/sso.md`, covering: what OIDC SSO is in Heym, the `HEYM_ADMIN_EMAILS` prerequisite, each field in the settings tab, the redirect URI the provider must allowlist, the account mapping rule `(issuer, sub)` then verified email, auto-provisioning and the domain allowlist, disabling password sign-in and the break-glass exemption, and the meaning of each `sso_error` code. Register the page in `manifest.ts`, and add SSO to the feature list in `reference/features.md` and to the settings tab list in `reference/user-settings.md`.
+
+- [ ] **Step 2: Add the release tour section**
+
+In `frontend/src/features/release-tour/releaseRegistry.ts`, add a section to the current unreleased entry:
+
+```typescript
+      {
+        id: "oidc-sso",
+        title: "Sign in with your identity provider",
+        blocks: [
+          "Connect Heym to any OpenID Connect provider from Settings. Paste an issuer URL, and Heym reads the rest from the provider's discovery document.",
+          "New people get an account on first sign-in, optionally limited to your email domains. Once SSO is tested and working, password sign-in can be switched off.",
+        ],
+        tour: {
+          description:
+            "Configure single sign-on against any OIDC provider from the settings panel.",
+          useCases: [
+            "Let your team sign in with the accounts they already have",
+            "Restrict new accounts to your own email domains",
+            "Turn off password sign-in once SSO is verified",
+          ],
+          tourVisual: "sso-login",
+        },
+      },
+```
+
+Add `"oidc-sso"` to that release's `sectionOrder`.
+
+- [ ] **Step 3: Build the visual**
+
+This is mock UI, not live UI: semantic Tailwind tokens only, no API calls, no host-page
+state. Create `frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed } from "vue";
+import { Check, KeyRound, ShieldCheck } from "lucide-vue-next";
+
+import { useCycleStep } from "@/features/release-tour/useCycleStep";
+
+// 0: password + SSO side by side · 1: SSO button focused · 2: provider hand-off · 3: signed in
+const step = useCycleStep(4, 1300);
+
+const showPasswordForm = computed(() => step.value === 0);
+const ssoFocused = computed(() => step.value === 1);
+const atProvider = computed(() => step.value === 2);
+const signedIn = computed(() => step.value === 3);
+</script>
+
+<template>
+  <div class="flex h-full w-full flex-col gap-2 p-3">
+    <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-2 py-1">
+        <ShieldCheck class="h-3.5 w-3.5 text-primary" />
+        <span class="text-[11px] font-semibold text-foreground">Single sign-on</span>
+      </div>
+      <span class="ml-auto text-[10px] font-medium text-muted-foreground transition-colors duration-300">
+        {{ atProvider ? "Redirecting to your provider" : signedIn ? "Signed in" : "OpenID Connect" }}
+      </span>
+    </div>
+
+    <div class="flex flex-1 flex-col justify-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-sunken p-3">
+      <Transition
+        enter-active-class="transition-all duration-300"
+        leave-active-class="transition-all duration-200"
+        enter-from-class="opacity-0 -translate-y-1"
+        leave-to-class="opacity-0 -translate-y-1"
+        mode="out-in"
+      >
+        <div
+          v-if="signedIn"
+          key="done"
+          class="flex flex-col items-center gap-1.5 py-3"
+        >
+          <Check class="h-5 w-5 text-emerald-500" />
+          <span class="text-[11px] font-medium text-foreground">ada@example.com</span>
+          <span class="text-[10px] text-muted-foreground">Account created on first sign-in</span>
+        </div>
+
+        <div
+          v-else
+          key="form"
+          class="flex flex-col gap-2"
+        >
+          <div
+            v-if="showPasswordForm"
+            class="flex flex-col gap-1.5"
+          >
+            <div class="h-6 rounded border border-border bg-background" />
+            <div class="h-6 rounded border border-border bg-background" />
+          </div>
+
+          <div
+            v-if="showPasswordForm"
+            class="text-center text-[9px] uppercase tracking-wide text-muted-foreground"
+          >
+            or
+          </div>
+
+          <div
+            class="flex items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 transition-all duration-300"
+            :class="ssoFocused || atProvider
+              ? 'border-primary bg-primary/12 text-foreground'
+              : 'border-border bg-background text-muted-foreground'"
+          >
+            <KeyRound class="h-3.5 w-3.5" />
+            <span class="text-[11px] font-medium">Sign in with SSO</span>
+          </div>
+
+          <div
+            class="h-1 overflow-hidden rounded-full bg-border transition-opacity duration-300"
+            :class="atProvider ? 'opacity-100' : 'opacity-0'"
+          >
+            <div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
+          </div>
+        </div>
+      </Transition>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Register the visual**
+
+In `frontend/src/features/release-tour/tourVisuals.ts`, import the component and add it to the
+lookup map under the key `"sso-login"`, matching the `tourVisual` value used in Step 2. An
+unregistered key silently falls back to the neutral visual, which is exactly what
+`releaseTourMapper.test.ts` guards against.
+
+- [ ] **Step 5: Verify the registry test still passes**
+
+```bash
+cd frontend && bun run test -- releaseTourMapper && bun run lint && bun run typecheck
+```
+
+Expected: all clean. An unregistered `tourVisual` key fails `releaseTourMapper.test.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/docs frontend/src/features/release-tour
+git commit -m "docs(sso): reference page and release tour entry"
+```
+
+---
+
+## Task 15: Full verification and manual run against a local provider
+
+**Files:** none in the repository. The identity provider lives in the session scratchpad.
+
+- [ ] **Step 1: Run the full check**
+
+```bash
+cd /Users/mbakgun/Projects/heym/heymrun && \
+  HEYM_OTEL_ENABLED=false SECRET_KEY=test-secret-key-for-tests-only-32-bytes ./check.sh
+```
+
+Expected: ruff format applied, lint clean, backend suite green. Commit any formatting-only diffs.
+
+Do not run `check.sh` and `run_tests.sh` concurrently — each spawns a large parallel pytest run.
+
+- [ ] **Step 2: Start a local provider**
+
+Write `docker-compose.yml` to the scratchpad directory (**not** the repository):
+
+```yaml
+services:
+  idp:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./realm-heym.json:/opt/keycloak/data/import/realm-heym.json:ro
+```
+
+The realm import must define: realm `heym`; a confidential client `heym` with standard flow enabled, `clientAuthenticatorType: client-secret`, secret `heym-local-secret-change-me`, and redirect URI `http://localhost:4017/api/auth/sso/callback`; and two users `ada@heym.local` and `grace@heym.local`, both with `emailVerified: true` and password `Passw0rd!`.
+
+```bash
+cd <scratchpad> && docker compose up -d && \
+  curl -s http://localhost:8080/realms/heym/.well-known/openid-configuration | head -c 200
+```
+
+Expected: a JSON document containing `authorization_endpoint`.
+
+- [ ] **Step 3: Start Heym with an admin allowlist**
+
+Add to `backend/.env`:
+
+```
+HEYM_ADMIN_EMAILS=grace@heym.local
+```
+
+Then `./run.sh`.
+
+- [ ] **Step 4: Configure and verify**
+
+1. Sign in with an existing password account, open Settings, confirm the **SSO** tab appears only for a `HEYM_ADMIN_EMAILS` account.
+2. Enter issuer `http://localhost:8080/realms/heym`, client id `heym`, secret `heym-local-secret-change-me`. Save, then **Test connection** — it must report the token endpoint.
+3. Enable SSO, save, sign out.
+4. On the login screen the SSO button appears. Click it, authenticate as `ada@heym.local` / `Passw0rd!`, and confirm you land in Heym.
+5. Confirm the account was created exactly once:
+
+```bash
+docker exec -i $(docker ps -qf name=postgres) \
+  psql -U heym -d heym -c \
+  "SELECT email, sso_issuer, sso_subject, hashed_password IS NULL AS no_password FROM users WHERE email='ada@heym.local';"
+```
+
+Expected: exactly one row, `sso_issuer` and `sso_subject` populated, `no_password` true.
+
+6. Sign out and sign in through SSO again. Re-run the query: still exactly one row.
+7. Enable **Disable password sign-in**, save, sign out. Confirm `ada@heym.local` cannot use the password form and that `grace@heym.local` still can.
+8. Set the issuer to a wrong URL and confirm the login button produces a readable error rather than a stack trace.
+
+- [ ] **Step 5: Tear down and commit**
+
+```bash
+cd <scratchpad> && docker compose down -v
+```
+
+```bash
+cd /Users/mbakgun/Projects/heym/heymrun && git status --short
+```
+
+Expected: clean, or only formatting diffs from `check.sh` — commit those. Do not push; pushing requires explicit approval.

--- a/docs/superpowers/specs/2026-08-26-oidc-sso-design.md
+++ b/docs/superpowers/specs/2026-08-26-oidc-sso-design.md
@@ -1,0 +1,341 @@
+# OIDC Single Sign-On — Design
+
+Date: 2026-08-26
+Status: Approved, ready for implementation planning
+
+## Goal
+
+Let a Heym instance authenticate users against any external OpenID Connect provider,
+configured at runtime from the admin settings UI. No identity provider name, URL, or
+vendor-specific behavior may appear in Heym's code: the admin supplies an issuer URL and
+everything else is derived from OIDC discovery.
+
+Keycloak is used only as the local provider for manual verification. It is not a
+dependency, not a code path, and nothing about it is committed to this repository.
+
+## Non-goals
+
+- SAML. OIDC is the default for new products; SAML is a separate future decision.
+- Multiple simultaneous providers. One instance connects to one corporate IdP.
+- Group or role mapping from IdP claims. Heym has no role model to map onto yet.
+- Portal end-user login (`portal_users`). That is a different table and a different
+  audience; it stays on its existing password flow.
+- Self-service password reset for SSO-provisioned accounts.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Who configures SSO | New `HEYM_ADMIN_EMAILS` env allowlist | Mirrors the existing `HEYM_PLUGIN_ADMIN_EMAILS` pattern exactly. No migration, no new role model, and the break-glass path is already outside the database. |
+| Provider count | Single singleton row | A self-hosted instance connects to one IdP. Switching providers means editing one row. |
+| Unknown user on first SSO login | Auto-provision, admin toggle (default on) + optional email domain allowlist | What a team connecting Okta/Entra expects. The toggle and allowlist keep a shared IdP from becoming an open door. |
+| Password login | Both enabled by default; admin may disable password login | Requested explicitly. Two guards prevent lockout (below). |
+| OIDC client | Hand-rolled on `httpx` + `pyjwt[crypto]` | Zero new dependencies — all three libraries are already in `pyproject.toml`. Matches the existing `*_oauth.py` routers. Authlib's ~150 saved lines do not justify a new runtime dependency and a second OAuth style. |
+| Client secret at rest | Fernet-encrypted via existing `encrypt_config` | The secret must be replayed to the IdP's token endpoint, so it cannot be hashed. `secret_tokens.py` governs secrets *we* verify; this is a credential we *present*. |
+
+## Data model
+
+### New table `sso_settings`
+
+Singleton, addressed by a fixed sentinel primary key
+(`SSO_SETTINGS_ID = UUID("00000000-0000-0000-0000-000000000001")`) so read-modify-write is
+an upsert with no race.
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `id` | UUID PK | sentinel | |
+| `enabled` | bool | `false` | |
+| `issuer` | String(512) | `""` | The only URL an admin types. Discovery derives the rest. |
+| `client_id` | String(255) | `""` | |
+| `encrypted_client_secret` | Text | `null` | Fernet, via `encrypt_config({"client_secret": ...})` |
+| `scopes` | String(255) | `"openid email profile"` | |
+| `button_label` | String(64) | `"Sign in with SSO"` | Keeps the provider's name in data, never in code |
+| `auto_provision_users` | bool | `true` | |
+| `allowed_email_domains` | String(512) | `""` | Comma-separated; empty means any domain |
+| `password_login_disabled` | bool | `false` | |
+| `last_test_ok` | bool | `false` | Precondition for `password_login_disabled` |
+| `last_test_at` | timestamptz | `null` | |
+| `updated_by_id` | UUID FK users.id ON DELETE SET NULL | `null` | Audit trail |
+| `created_at` / `updated_at` | timestamptz | now() | |
+
+### `users` changes
+
+- `sso_issuer` String(512) nullable
+- `sso_subject` String(255) nullable
+- Unique index on `(sso_issuer, sso_subject)`
+- `hashed_password` becomes **nullable**
+
+Account resolution order on callback:
+
+1. `(sso_issuer, sso_subject)` match — authoritative, survives email changes at the IdP.
+2. Otherwise, a verified `email` match — the row is claimed and `sub` is written to it.
+3. Otherwise, provisioning rules apply.
+
+An email counts as verified only when the ID token carries `email_verified: true`. If the
+claim is `false` or absent, the login is rejected with `email_not_verified`: claiming an
+existing Heym account, or creating a new one, on the strength of an address the provider will
+not vouch for is an account-takeover path. A provider that does not emit `email_verified` is
+misconfigured for this purpose, and telling the admin so is better than guessing.
+
+Migration: `115_add_sso_settings`, on top of head `114_add_workflow_http_method`.
+Downgrade drops the table and the two user columns; it cannot restore a plaintext secret
+because none was ever stored.
+
+### Password verification guard
+
+`hashed_password` becomes nullable, so `verify_password` must tolerate it. Passing an empty
+or `None` hash to `bcrypt.checkpw` raises `ValueError: invalid salt`, turning a failed login
+into a 500. One guard at the bottom of the stack covers all three call sites
+(`auth.py` login, `auth.py` change-password, `oauth.py` MCP consent form):
+
+```python
+def verify_password(plain_password: str, hashed_password: str | None) -> bool:
+    if not hashed_password:
+        return False
+    ...
+```
+
+## Backend architecture
+
+One responsibility per module, each independently testable.
+
+| File | Responsibility |
+|---|---|
+| `app/services/oidc_client.py` | Pure OIDC mechanics: discovery fetch and cache, authorization URL construction, token exchange, ID token verification, userinfo fetch. Knows nothing about Heym. |
+| `app/services/sso_settings.py` | Load and upsert the singleton, decrypt the client secret, evaluate the email domain allowlist. |
+| `app/api/sso_auth.py` | Public routes: `/api/auth/sso/status`, `/login`, `/callback`. |
+| `app/api/sso_admin.py` | Admin routes: `/api/admin/sso` GET/PUT, `/api/admin/sso/test`. |
+| `app/api/deps.py` | `require_instance_admin(current_user)` — the twin of `plugins.py::require_plugin_admin`. |
+| `app/config.py` | `admin_emails: str = Field(default="", validation_alias="HEYM_ADMIN_EMAILS")` |
+
+### Public endpoints
+
+**`GET /api/auth/sso/status`** — unauthenticated. Returns
+`{enabled, button_label, password_login_enabled}` and nothing else. The issuer and client id
+are not disclosed to anonymous callers.
+
+**`GET /api/auth/sso/login`** — rate-limited with the existing `login_limiter`. Generates
+`state`, `nonce`, and a PKCE `code_verifier`, then 302s to the IdP's `authorization_endpoint`
+with `response_type=code`, `code_challenge_method=S256`, the configured scopes, and a
+`redirect_uri` derived from `resolve_public_origin(request)`.
+
+**`GET /api/auth/sso/callback`** — exchanges the code, verifies the ID token, resolves or
+provisions the user, issues Heym's own tokens via the existing `create_access_token` /
+`create_refresh_token` / `store_refresh_token` / `_set_auth_cookies` path, writes an
+`audit(action="auth.sso_login", actor=user)` line, and 302s to the stored `next` path.
+
+### Transaction state: cookie, not the `state` parameter
+
+The PKCE `code_verifier` must not travel inside the `state` JWT. `state` round-trips through
+the identity provider, and a signed JWT is not an encrypted one: the verifier would be
+readable in the authorization URL, in IdP logs, and in any proxy in between, which defeats
+the purpose of PKCE.
+
+Instead a short-lived transaction cookie holds it:
+
+- `sso_tx` = JWT signed with `settings.secret_key`, payload `{state, nonce, code_verifier, next, exp: +10m}`
+- `HttpOnly`, `SameSite=lax`, `Secure` per the existing `_COOKIE_SECURE` logic, `path=/api/auth/sso/`
+- The `state` URL parameter carries only a random identifier; the callback compares it to the
+  cookie's copy and rejects a mismatch.
+
+The `next` value is validated before it is stored, not after it comes back: it must be a
+relative path beginning with a single `/` and not `//`. Anything else is discarded in favour
+of `/`. An unchecked `next` turns the callback into an open redirect that a phishing page can
+point anywhere.
+
+`SameSite=lax` is correct here: the return from the IdP is a top-level GET navigation, so the
+cookie is sent. No database table is needed for in-flight logins.
+
+### ID token verification
+
+`PyJWKClient(jwks_uri)` supplies the signing key (it caches keys itself). Then
+`jwt.decode(token, key, audience=client_id, issuer=issuer, algorithms=...)` where the
+algorithm list is the intersection of the provider's advertised
+`id_token_signing_alg_values_supported` and an allowlist of asymmetric algorithms. `none` and
+symmetric algorithms are rejected. After signature validation, `nonce` is compared to the
+cookie's copy.
+
+If the ID token carries no `email`, the `userinfo_endpoint` is queried as a fallback. Keycloak
+returns `email` in the ID token under the `email` scope; not every provider does.
+
+`sub` is read from the ID token only, never from userinfo.
+
+The token endpoint's client authentication method is chosen from the provider's advertised
+`token_endpoint_auth_methods_supported`, preferring `client_secret_post` and falling back to
+`client_secret_basic`. Nothing is hardcoded to one provider's habit.
+
+### Admin endpoints
+
+**`GET /api/admin/sso`** returns the configuration with the secret replaced by
+`client_secret_set: bool`, plus a computed read-only `redirect_uri`
+(`resolve_public_origin(request) + "/api/auth/sso/callback"`). The admin copies that value
+into the IdP's allowlist rather than retyping it, which removes the most common setup error.
+
+**`PUT /api/admin/sso`** saves the configuration. An empty `client_secret` in the payload
+**preserves the stored value**. Without this, the masked, empty editor field would overwrite
+the real secret on the next save.
+
+**`POST /api/admin/sso/test`** fetches discovery, asserts that `authorization_endpoint`,
+`token_endpoint`, and `jwks_uri` are present, downloads JWKS, records the outcome in
+`last_test_ok` / `last_test_at`, and returns the discovered endpoints.
+
+### Disabling password login
+
+When `password_login_disabled` is true, both password surfaces reject credentials:
+
+- `POST /api/auth/login`
+- the MCP OAuth consent form in `app/api/oauth.py` (currently around line 543)
+
+Closing only the first would make the setting a lie. `portal.py` is out of scope — it
+authenticates `portal_users`, a separate table and audience.
+
+Two guards prevent lockout:
+
+1. **Break-glass.** Accounts listed in `HEYM_ADMIN_EMAILS` may always sign in with a password.
+   Whoever can edit the environment file can already recover the instance; this makes that
+   guarantee explicit in code rather than incidental.
+2. **Precondition.** The toggle can only be enabled when SSO is enabled *and* `last_test_ok`
+   is true, so a wrong issuer cannot lock the door behind itself.
+
+### Outbound request safety
+
+The issuer is admin-supplied, which makes discovery an outbound-fetch surface. `ssrf_guard`
+is deliberately **not** applied: it rejects private and loopback addresses, which is exactly
+where a self-hosted IdP lives, and the admin is already a trusted boundary. The narrower
+controls are:
+
+- scheme restricted to `http`/`https`
+- `follow_redirects=False`
+- 10 second timeout
+- bounded response size
+- discovery cached in-process with a 5 minute TTL, keyed by issuer
+
+## Frontend
+
+### Admin visibility
+
+`UserResponse` (`GET /api/auth/me`) gains `is_admin: bool`, computed from
+`HEYM_ADMIN_EMAILS`. The plugins tab currently infers its availability by catching a 404;
+the SSO tab should not repeat that. The frontend hides the tab honestly instead of
+discovering the answer through a rejected request.
+
+### Files
+
+| File | Change |
+|---|---|
+| `src/services/sso.ts` | New. `getSsoStatus`, `getAdminSsoConfig`, `saveAdminSsoConfig`, `testSsoConnection` |
+| `src/components/Layout/settings/SsoSettingsTab.vue` | New. The whole admin form. |
+| `src/components/Layout/UserSettingsDialog.vue` | Tab button plus `<SsoSettingsTab v-if="activeTab === 'sso'">` — roughly ten lines |
+| `src/views/LoginView.vue` | SSO button and conditional password form |
+| `src/types/auth.ts`, `src/stores/auth.ts` | `is_admin` field |
+
+`UserSettingsDialog.vue` is already 860 lines, past the 300-line guidance. Inlining the form
+would push it beyond 1000. Extracting the tab body keeps the dialog's growth to the tab
+button, and the new component owns its own state, loading, and handlers.
+
+### SsoSettingsTab form
+
+Enabled toggle · Issuer URL · Client ID · Client Secret (placeholder `••••••` when
+`client_secret_set`; leaving it blank preserves the stored value) · Scopes · Button label ·
+Auto-provision toggle · Allowed email domains · Redirect URI (read-only, with a copy button) ·
+`Test connection` button reporting the discovered endpoints · and, visually separated and
+styled as a warning, **Disable password login**, which stays disabled with an explanatory
+tooltip until SSO is enabled and a connection test has passed.
+
+### LoginView
+
+On mount, `GET /api/auth/sso/status`.
+
+- `enabled` renders a button labelled `button_label`. Its click handler performs a full
+  navigation: `window.location.href = "/api/auth/sso/login"`. An XHR cannot follow the
+  cross-origin redirect into the provider's login UI.
+- `password_login_enabled === false` hides the password form and the register link, leaving
+  only the SSO button.
+- With both enabled: password form, divider, SSO button.
+
+### Error surface
+
+A failed callback redirects to `/login?sso_error=<code>` with a code drawn from a fixed set:
+`state_mismatch`, `token_exchange_failed`, `invalid_token`, `email_missing`,
+`domain_not_allowed`, `provisioning_disabled`, `sso_disabled`, `email_not_verified`. The frontend maps codes to
+readable text. The provider's raw error string is never rendered — it is both an XSS surface
+and an information leak.
+
+## Testing
+
+Backend tests are required by `AGENTS.md`.
+
+**`backend/tests/test_sso_oidc_client.py`**
+- discovery document parsing, including a document missing required endpoints
+- authorization URL construction, asserting the `S256` challenge matches the verifier
+- token exchange against a mocked `httpx` transport
+- ID token verification: valid; wrong `aud`; wrong `iss`; expired; bad signature;
+  `nonce` mismatch; `alg: none` rejected
+
+**`backend/tests/test_sso_auth_flow.py`**
+- state mismatch produces the error redirect, not an exception
+- happy path creates the user and sets auth cookies
+- an existing email is claimed and `sub` is written to that row
+- `(issuer, sub)` match takes precedence over an email match
+- a disallowed email domain is rejected
+- auto-provisioning disabled plus an unknown email is rejected
+- `email_verified: false` and a missing `email_verified` claim are both rejected, and neither
+  claims an existing account
+- a `next` value of `//evil.example` or an absolute URL falls back to `/`
+
+**`backend/tests/test_sso_admin_api.py`**
+- a non-admin receives 403
+- the client secret is never present in any response body
+- an empty `client_secret` on PUT preserves the stored value
+- the test endpoint records `last_test_ok`
+
+**`backend/tests/test_advisory_sso.py`**
+- the stored client secret is not plaintext in the database
+- `password_login_disabled` blocks both `/api/auth/login` and the `oauth.py` consent form
+- a break-glass admin can still sign in with a password
+- `verify_password(x, None) is False` rather than raising
+
+**Frontend tests:** none. The standing instruction for this repository is to verify frontend
+work with lint, typecheck, and manual checks rather than UI tests. `AGENTS.md` asks for
+Playwright coverage on new UI; the repository owner's instruction takes precedence and was
+reconfirmed for this feature.
+
+## Documentation and release tour
+
+This feature crosses the medium/large threshold in `AGENTS.md`, so both are required in the
+same change:
+
+- Docs via the `heym-documentation` skill: a new `frontend/src/docs/content/reference/sso.md`,
+  plus updates to `reference/user-settings.md` and `reference/features.md`.
+- A release tour section in `releaseRegistry.ts` with an animated mock registered in
+  `tourVisuals.ts`, and the section id listed in that release's `sectionOrder`.
+
+## Local identity provider
+
+Keycloak runs from the session scratchpad, **not** from this repository — it is example setup
+for manual verification, unrelated to the product. A `docker-compose.yml` (Keycloak 26 in dev
+mode on port 8080, which is free on this machine) plus a realm import providing a `heym` realm,
+a confidential client, and two test users.
+
+Values the admin form receives during verification:
+
+```
+issuer        http://localhost:8080/realms/heym
+client_id     heym
+client_secret heym-local-secret-change-me
+scopes        openid email profile
+redirect_uri  http://localhost:4017/api/auth/sso/callback   (read-only, shown by the form)
+```
+
+The redirect URI resolves to the frontend origin because `vite.config.ts` proxies `/api` to
+the backend, and `resolve_public_origin` returns `FRONTEND_URL`, which defaults to
+`http://localhost:4017`. The browser only ever sees one origin; no second port is involved.
+
+## Verification checklist
+
+1. `./check.sh` from the repository root, with the backend suite passing.
+2. Manual: configure the form, run `Test connection`, sign in as `ada@heym.local`, confirm a
+   user row was created with `sso_issuer` and `sso_subject` set.
+3. Manual: sign out, sign in again, confirm no second user row is created.
+4. Manual: enable `Disable password login`, confirm `/api/auth/login` rejects a normal user
+   and still accepts a `HEYM_ADMIN_EMAILS` account.

--- a/frontend/src/components/Layout/UserSettingsDialog.vue
+++ b/frontend/src/components/Layout/UserSettingsDialog.vue
@@ -864,15 +864,6 @@ HEYM_PLUGIN_ADMIN_EMAILS=you@example.com</pre>
 
       <div v-else-if="activeTab === 'sso' && authStore.user?.is_admin">
         <SsoSettingsTab />
-        <div class="flex justify-end gap-3 pt-2">
-          <Button
-            variant="outline"
-            type="button"
-            @click="emit('close')"
-          >
-            Close
-          </Button>
-        </div>
       </div>
     </div>
   </Dialog>

--- a/frontend/src/components/Layout/UserSettingsDialog.vue
+++ b/frontend/src/components/Layout/UserSettingsDialog.vue
@@ -23,6 +23,7 @@ import {
   setPluginEnabled,
   uninstallPlugin,
 } from "@/services/plugins";
+import SsoSettingsTab from "@/components/Layout/settings/SsoSettingsTab.vue";
 import { useAuthStore } from "@/stores/auth";
 
 import AiDefaultsTab from "@/components/Layout/aiDefaults/AiDefaultsTab.vue";
@@ -30,7 +31,14 @@ import { clearPluginIconCache } from "@/components/Panels/PluginIcon.vue";
 
 import type { PluginSummary } from "@/types/workflow";
 
-type SettingsTab = "profile" | "security" | "voice" | "ai-defaults" | "observability" | "plugins";
+type SettingsTab =
+  | "profile"
+  | "security"
+  | "voice"
+  | "ai-defaults"
+  | "observability"
+  | "plugins"
+  | "sso";
 
 const props = defineProps<{
   open: boolean;
@@ -431,6 +439,15 @@ async function handleChangePassword(): Promise<void> {
             @click="activeTab = 'plugins'"
           >
             Plugins
+          </button>
+          <button
+            v-if="authStore.user?.is_admin"
+            type="button"
+            class="px-3 py-2 text-sm font-medium transition-colors border-b-2 -mb-px whitespace-nowrap shrink-0"
+            :class="activeTab === 'sso' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'"
+            @click="activeTab = 'sso'"
+          >
+            SSO
           </button>
         </div>
       </div>
@@ -834,6 +851,19 @@ HEYM_PLUGIN_ADMIN_EMAILS=you@example.com</pre>
           </ul>
         </template>
 
+        <div class="flex justify-end gap-3 pt-2">
+          <Button
+            variant="outline"
+            type="button"
+            @click="emit('close')"
+          >
+            Close
+          </Button>
+        </div>
+      </div>
+
+      <div v-else-if="activeTab === 'sso' && authStore.user?.is_admin">
+        <SsoSettingsTab />
         <div class="flex justify-end gap-3 pt-2">
           <Button
             variant="outline"

--- a/frontend/src/components/Layout/settings/SettingsToggle.vue
+++ b/frontend/src/components/Layout/settings/SettingsToggle.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+const props = defineProps<{
+  id: string;
+  modelValue: boolean;
+  label: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{ "update:modelValue": [value: boolean] }>();
+
+function toggle(): void {
+  if (props.disabled) return;
+  emit("update:modelValue", !props.modelValue);
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-3">
+    <button
+      :id="props.id"
+      type="button"
+      role="switch"
+      :aria-checked="props.modelValue"
+      :disabled="props.disabled"
+      class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+      :class="props.modelValue ? 'bg-primary border-primary' : 'bg-muted border-border'"
+      @click="toggle"
+    >
+      <span
+        class="inline-block h-3.5 w-3.5 rounded-full bg-background shadow-sm transition-transform duration-200"
+        :class="props.modelValue ? 'translate-x-[18px]' : 'translate-x-[3px]'"
+      />
+    </button>
+    <span
+      class="text-sm font-normal select-none"
+      :class="props.disabled ? 'text-muted-foreground' : 'text-foreground cursor-pointer'"
+      @click="toggle"
+    >
+      {{ props.label }}
+    </span>
+  </div>
+</template>

--- a/frontend/src/components/Layout/settings/SsoSettingsTab.vue
+++ b/frontend/src/components/Layout/settings/SsoSettingsTab.vue
@@ -5,6 +5,7 @@ import { Check, Copy, X } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
+import SettingsToggle from "@/components/Layout/settings/SettingsToggle.vue";
 import { getAdminSsoConfig, saveAdminSsoConfig, testSsoConnection } from "@/services/sso";
 import type { SsoSettings, SsoTestResult } from "@/types/sso";
 
@@ -96,20 +97,11 @@ onMounted(load);
     </p>
 
     <template v-if="config">
-      <div class="flex items-center gap-2">
-        <input
-          id="sso-enabled"
-          v-model="config.enabled"
-          type="checkbox"
-          class="h-4 w-4 rounded border-input bg-background"
-        >
-        <Label
-          for="sso-enabled"
-          class="text-sm font-normal"
-        >
-          Enable single sign-on
-        </Label>
-      </div>
+      <SettingsToggle
+        id="sso-enabled"
+        v-model="config.enabled"
+        label="Enable single sign-on"
+      />
 
       <div class="space-y-2">
         <Label for="sso-issuer">Issuer URL</Label>
@@ -188,20 +180,11 @@ onMounted(load);
         />
       </div>
 
-      <div class="flex items-center gap-2">
-        <input
-          id="sso-auto-provision"
-          v-model="config.auto_provision_users"
-          type="checkbox"
-          class="h-4 w-4 rounded border-input bg-background"
-        >
-        <Label
-          for="sso-auto-provision"
-          class="text-sm font-normal"
-        >
-          Create an account on first sign-in
-        </Label>
-      </div>
+      <SettingsToggle
+        id="sso-auto-provision"
+        v-model="config.auto_provision_users"
+        label="Create an account on first sign-in"
+      />
 
       <div class="space-y-2">
         <Label for="sso-domains">Allowed email domains</Label>
@@ -242,21 +225,12 @@ onMounted(load);
       </div>
 
       <div class="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-2">
-        <div class="flex items-center gap-2">
-          <input
-            id="sso-disable-password"
-            v-model="config.password_login_disabled"
-            type="checkbox"
-            class="h-4 w-4 rounded border-input bg-background"
-            :disabled="!config.enabled || !config.last_test_ok"
-          >
-          <Label
-            for="sso-disable-password"
-            class="text-sm font-normal"
-          >
-            Disable password sign-in
-          </Label>
-        </div>
+        <SettingsToggle
+          id="sso-disable-password"
+          v-model="config.password_login_disabled"
+          label="Disable password sign-in"
+          :disabled="!config.enabled || !config.last_test_ok"
+        />
         <p class="text-xs text-muted-foreground">
           <span v-if="!config.enabled || !config.last_test_ok">
             Available once SSO is enabled and a connection test has passed.

--- a/frontend/src/components/Layout/settings/SsoSettingsTab.vue
+++ b/frontend/src/components/Layout/settings/SsoSettingsTab.vue
@@ -59,10 +59,10 @@ async function handleTest(): Promise<void> {
   testing.value = true;
   error.value = null;
   try {
-    testResult.value = await testSsoConnection();
+    testResult.value = await testSsoConnection(config.value?.issuer);
     if (config.value) config.value.last_test_ok = testResult.value.ok;
   } catch {
-    error.value = "Connection test could not run. Save the issuer first.";
+    error.value = "Connection test could not run.";
   } finally {
     testing.value = false;
   }
@@ -198,7 +198,7 @@ onMounted(load);
         />
       </div>
 
-      <div class="flex items-center gap-3 pt-2">
+      <div class="space-y-2 pt-2">
         <Button
           variant="outline"
           type="button"
@@ -207,21 +207,23 @@ onMounted(load);
         >
           Test connection
         </Button>
-        <span
+        <div
           v-if="testResult"
-          class="text-sm flex items-center gap-1.5"
+          class="flex items-start gap-1.5 text-sm min-w-0"
           :class="testResult.ok ? 'text-primary' : 'text-destructive'"
         >
           <Check
             v-if="testResult.ok"
-            class="w-4 h-4"
+            class="w-4 h-4 mt-0.5 shrink-0"
           />
           <X
             v-else
-            class="w-4 h-4"
+            class="w-4 h-4 mt-0.5 shrink-0"
           />
-          {{ testResult.ok ? testResult.token_endpoint : testResult.error }}
-        </span>
+          <span class="min-w-0 break-all">
+            {{ testResult.ok ? testResult.token_endpoint : testResult.error }}
+          </span>
+        </div>
       </div>
 
       <div class="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-2">
@@ -229,11 +231,15 @@ onMounted(load);
           id="sso-disable-password"
           v-model="config.password_login_disabled"
           label="Disable password sign-in"
-          :disabled="!config.enabled || !config.last_test_ok"
+          :disabled="!config.enabled || !config.last_test_ok || !config.break_glass_ready"
         />
         <p class="text-xs text-muted-foreground">
           <span v-if="!config.enabled || !config.last_test_ok">
             Available once SSO is enabled and a connection test has passed.
+          </span>
+          <span v-else-if="!config.break_glass_ready">
+            Unavailable: no account in HEYM_ADMIN_EMAILS has a password, so nobody could get
+            back in if the provider became unreachable. Give one of them a password first.
           </span>
           <span v-else>
             Accounts listed in HEYM_ADMIN_EMAILS keep password access, so the instance stays

--- a/frontend/src/components/Layout/settings/SsoSettingsTab.vue
+++ b/frontend/src/components/Layout/settings/SsoSettingsTab.vue
@@ -1,0 +1,283 @@
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { Check, Copy, X } from "lucide-vue-next";
+
+import Button from "@/components/ui/Button.vue";
+import Input from "@/components/ui/Input.vue";
+import Label from "@/components/ui/Label.vue";
+import { getAdminSsoConfig, saveAdminSsoConfig, testSsoConnection } from "@/services/sso";
+import type { SsoSettings, SsoTestResult } from "@/types/sso";
+
+const config = ref<SsoSettings | null>(null);
+const clientSecret = ref("");
+const loading = ref(false);
+const saving = ref(false);
+const testing = ref(false);
+const testResult = ref<SsoTestResult | null>(null);
+const error = ref<string | null>(null);
+const copied = ref(false);
+
+async function load(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+  try {
+    config.value = await getAdminSsoConfig();
+  } catch {
+    error.value = "Failed to load SSO settings.";
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function handleSave(): Promise<void> {
+  if (!config.value) return;
+  saving.value = true;
+  error.value = null;
+  try {
+    config.value = await saveAdminSsoConfig({
+      enabled: config.value.enabled,
+      issuer: config.value.issuer,
+      client_id: config.value.client_id,
+      client_secret: clientSecret.value,
+      scopes: config.value.scopes,
+      button_label: config.value.button_label,
+      auto_provision_users: config.value.auto_provision_users,
+      allowed_email_domains: config.value.allowed_email_domains,
+      password_login_disabled: config.value.password_login_disabled,
+    });
+    clientSecret.value = "";
+    testResult.value = null;
+  } catch {
+    error.value = "Failed to save. Check that password login can be disabled yet.";
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function handleTest(): Promise<void> {
+  testing.value = true;
+  error.value = null;
+  try {
+    testResult.value = await testSsoConnection();
+    if (config.value) config.value.last_test_ok = testResult.value.ok;
+  } catch {
+    error.value = "Connection test could not run. Save the issuer first.";
+  } finally {
+    testing.value = false;
+  }
+}
+
+async function copyRedirectUri(): Promise<void> {
+  if (!config.value) return;
+  await navigator.clipboard.writeText(config.value.redirect_uri);
+  copied.value = true;
+  window.setTimeout(() => {
+    copied.value = false;
+  }, 1500);
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="space-y-5">
+    <p
+      v-if="error"
+      class="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+    >
+      {{ error }}
+    </p>
+
+    <p
+      v-if="loading"
+      class="text-sm text-muted-foreground"
+    >
+      Loading...
+    </p>
+
+    <template v-if="config">
+      <div class="flex items-center gap-2">
+        <input
+          id="sso-enabled"
+          v-model="config.enabled"
+          type="checkbox"
+          class="h-4 w-4 rounded border-input bg-background"
+        >
+        <Label
+          for="sso-enabled"
+          class="text-sm font-normal"
+        >
+          Enable single sign-on
+        </Label>
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-issuer">Issuer URL</Label>
+        <p class="text-xs text-muted-foreground">
+          The provider's base URL. Every other endpoint is read from its discovery document.
+        </p>
+        <Input
+          id="sso-issuer"
+          v-model="config.issuer"
+          placeholder="https://idp.example.com/realms/your-realm"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-client-id">Client ID</Label>
+        <Input
+          id="sso-client-id"
+          v-model="config.client_id"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-client-secret">Client secret</Label>
+        <p class="text-xs text-muted-foreground">
+          Leave blank to keep the stored secret.
+        </p>
+        <Input
+          id="sso-client-secret"
+          v-model="clientSecret"
+          type="password"
+          :placeholder="config.client_secret_set ? '••••••••' : 'Not configured'"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-redirect-uri">Redirect URI</Label>
+        <p class="text-xs text-muted-foreground">
+          Add this exact value to the provider's allowed redirect URIs.
+        </p>
+        <div class="flex gap-2">
+          <Input
+            id="sso-redirect-uri"
+            :model-value="config.redirect_uri"
+            readonly
+          />
+          <Button
+            variant="outline"
+            type="button"
+            @click="copyRedirectUri"
+          >
+            <Check
+              v-if="copied"
+              class="w-4 h-4"
+            />
+            <Copy
+              v-else
+              class="w-4 h-4"
+            />
+          </Button>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-scopes">Scopes</Label>
+        <Input
+          id="sso-scopes"
+          v-model="config.scopes"
+        />
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-button-label">Sign-in button label</Label>
+        <Input
+          id="sso-button-label"
+          v-model="config.button_label"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <input
+          id="sso-auto-provision"
+          v-model="config.auto_provision_users"
+          type="checkbox"
+          class="h-4 w-4 rounded border-input bg-background"
+        >
+        <Label
+          for="sso-auto-provision"
+          class="text-sm font-normal"
+        >
+          Create an account on first sign-in
+        </Label>
+      </div>
+
+      <div class="space-y-2">
+        <Label for="sso-domains">Allowed email domains</Label>
+        <p class="text-xs text-muted-foreground">
+          Comma-separated. Leave blank to allow any domain the provider authenticates.
+        </p>
+        <Input
+          id="sso-domains"
+          v-model="config.allowed_email_domains"
+          placeholder="example.com, example.org"
+        />
+      </div>
+
+      <div class="flex items-center gap-3 pt-2">
+        <Button
+          variant="outline"
+          type="button"
+          :loading="testing"
+          @click="handleTest"
+        >
+          Test connection
+        </Button>
+        <span
+          v-if="testResult"
+          class="text-sm flex items-center gap-1.5"
+          :class="testResult.ok ? 'text-primary' : 'text-destructive'"
+        >
+          <Check
+            v-if="testResult.ok"
+            class="w-4 h-4"
+          />
+          <X
+            v-else
+            class="w-4 h-4"
+          />
+          {{ testResult.ok ? testResult.token_endpoint : testResult.error }}
+        </span>
+      </div>
+
+      <div class="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-2">
+        <div class="flex items-center gap-2">
+          <input
+            id="sso-disable-password"
+            v-model="config.password_login_disabled"
+            type="checkbox"
+            class="h-4 w-4 rounded border-input bg-background"
+            :disabled="!config.enabled || !config.last_test_ok"
+          >
+          <Label
+            for="sso-disable-password"
+            class="text-sm font-normal"
+          >
+            Disable password sign-in
+          </Label>
+        </div>
+        <p class="text-xs text-muted-foreground">
+          <span v-if="!config.enabled || !config.last_test_ok">
+            Available once SSO is enabled and a connection test has passed.
+          </span>
+          <span v-else>
+            Accounts listed in HEYM_ADMIN_EMAILS keep password access, so the instance stays
+            recoverable if the provider becomes unreachable.
+          </span>
+        </p>
+      </div>
+
+      <div class="flex justify-end pt-2">
+        <Button
+          variant="gradient"
+          type="button"
+          :loading="saving"
+          @click="handleSave"
+        >
+          Save
+        </Button>
+      </div>
+    </template>
+  </div>
+</template>

--- a/frontend/src/docs/content/reference/audit.md
+++ b/frontend/src/docs/content/reference/audit.md
@@ -53,7 +53,7 @@ Every state change is logged. Reads are logged only where reading is itself the 
 
 | Action | Notes |
 |--------|-------|
-| `auth.register` | `outcome=denied` when registration is disabled, `failure` when the email is taken. |
+| `auth.register` | `outcome=denied` when registration is disabled or when password sign-in is off (`reason=password_login_disabled`), `failure` when the email is taken. |
 | `auth.login` | `outcome=failure` records the attempted address and whether the email was unknown or the password wrong. |
 | `auth.logout` | The actor is resolved from the refresh cookie, so a logout without one is logged with no identity. |
 | `auth.token_refresh` | `outcome=denied` with `reason=refresh_token_replayed_or_revoked` — a token-theft signal worth alerting on. |

--- a/frontend/src/docs/content/reference/audit.md
+++ b/frontend/src/docs/content/reference/audit.md
@@ -58,6 +58,9 @@ Every state change is logged. Reads are logged only where reading is itself the 
 | `auth.logout` | The actor is resolved from the refresh cookie, so a logout without one is logged with no identity. |
 | `auth.token_refresh` | `outcome=denied` with `reason=refresh_token_replayed_or_revoked` — a token-theft signal worth alerting on. |
 | `auth.password_change` | `outcome=failure` when the current password was wrong. |
+| `auth.sso_login` | Single sign-on. `outcome=failure` carries the reason the provider response was rejected; `denied` carries `email_not_verified`, `domain_not_allowed`, or `provisioning_disabled`. |
+| `sso_settings.update` | An administrator changed the [SSO](./sso.md) configuration. Records `enabled` and `password_login_disabled`, never the client secret. |
+| `sso_settings.test` | An administrator ran the SSO connection test. |
 
 ### Workflows
 

--- a/frontend/src/docs/content/reference/features.md
+++ b/frontend/src/docs/content/reference/features.md
@@ -637,6 +637,12 @@ Heym enforces a password policy (length, uppercase, lowercase, digit), stores ac
 
 See also [Execution Tokens](./execution-tokens.md), [Guardrails](./guardrails.md), [Portal](./portal.md), and [Credentials](./credentials.md).
 
+### [Single Sign-On](./sso.md)
+
+Heym authenticates people against any external OpenID Connect provider - Keycloak, Okta, Entra ID, Auth0, Google - configured at runtime from **Settings → SSO** by an instance administrator listed in `HEYM_ADMIN_EMAILS`. Only an issuer URL and client credentials are entered; every endpoint comes from the provider's discovery document, so no provider is hardcoded. Sign-in uses Authorization Code with PKCE, and the ID token is verified against the provider's published keys. Accounts map by `(issuer, subject)` first and verified email second, with optional auto-provisioning limited to an email domain allowlist. Password sign-in stays available alongside SSO and can be switched off once a connection test passes, with `HEYM_ADMIN_EMAILS` accounts exempt so a misconfigured provider cannot lock the instance.
+
+See also [Settings](./user-settings.md), [Security](./security.md), and [Audit Logging](./audit.md).
+
 ### [Third-Party Integrations](./integrations.md)
 
 Heym connects to external services through credentials stored in the [Credentials](../tabs/credentials-tab.md) tab (encrypted at rest). Supported types include OpenAI, Google, GitHub for the [GitHub node](../nodes/github-node.md) and MCP integrations, Jira for the [Jira node](../nodes/jira-node.md), Notion for the [Notion node](../nodes/notion-node.md), Custom LLM, Cohere, RAG: Qdrant + OpenAI, RAG: Psql + OpenAI, [Grist](../nodes/grist-node.md), SMTP for [Send Email](../nodes/send-email-node.md), [RabbitMQ](../nodes/rabbitmq-node.md), [Redis](../nodes/redis-node.md), [Telegram](../nodes/telegram-node.md), [Slack](../nodes/slack-node.md), Bearer, Header, and FlareSolverr for [Crawler](../nodes/crawler-node.md). Each type documents required fields; credentials can be shared with users or [teams](./teams.md) and referenced by name in nodes or as `$credentials.Name` in expressions.

--- a/frontend/src/docs/content/reference/sso.md
+++ b/frontend/src/docs/content/reference/sso.md
@@ -100,7 +100,7 @@ If you hit that message, sign in through SSO and register a password account on 
 
 In order of preference:
 
-1. **Sign in with a break-glass admin password.** This is what the third condition guarantees exists.
+1. **Sign in with a break-glass admin password.** The login screen hides the password form when password sign-in is off, so click **Administrator sign-in** underneath the SSO button to reveal it. The form is not a bypass: every address outside `HEYM_ADMIN_EMAILS` is still refused, and told why.
 2. **Add yourself to `HEYM_ADMIN_EMAILS`** in the environment file and restart the backend. An account that already has a password can then sign in.
 3. **Re-open password sign-in directly in the database**, if no admin has a password at all:
 

--- a/frontend/src/docs/content/reference/sso.md
+++ b/frontend/src/docs/content/reference/sso.md
@@ -51,7 +51,9 @@ Open **Settings → SSO**. The tab only appears for accounts in `HEYM_ADMIN_EMAI
 
 ### Test the connection first
 
-**Test connection** fetches the discovery document and the provider's signing keys, then reports the token endpoint it found. Run it before enabling SSO. Changing the issuer, client ID, scopes, or secret clears the recorded result, because a passing test belongs to the settings it was run against.
+**Test connection** fetches the discovery document and the provider's signing keys, then reports the token endpoint it found. You can run it on an issuer you have typed but not saved yet, so a wrong URL costs a click rather than a save.
+
+A test only *records* a passing result when the issuer tested is the one already stored. A draft test tells you whether the URL resolves; it does not license a configuration that is not saved. Changing the issuer, client ID, scopes, or secret clears the recorded result for the same reason.
 
 ## How Sign-In Works
 
@@ -78,11 +80,35 @@ Accounts created this way have no password. They sign in through the provider on
 
 ## Disabling Password Sign-In
 
-The **Disable password sign-in** switch stays unavailable until SSO is enabled **and** a connection test has passed, so a wrong issuer cannot lock the door behind itself.
+The **Disable password sign-in** switch stays unavailable until three things are true:
 
-When it is on, password authentication is refused on both surfaces that accept one: the normal login form and the MCP OAuth consent page.
+1. SSO is enabled.
+2. A connection test has passed, so a wrong issuer cannot lock the door behind itself.
+3. At least one account in `HEYM_ADMIN_EMAILS` actually has a password.
 
-Accounts listed in `HEYM_ADMIN_EMAILS` are always exempt. Whoever can edit the environment file can already recover the instance, so this guarantee lives in code rather than in an operator's memory. Keep at least one such account with a working password.
+When it is on, password authentication is refused on all three surfaces that mint or accept one: the login form, **registration**, and the MCP OAuth consent page. Registration counts because it issues a password; leaving it open would make the setting bypassable by anyone who can reach `/register`.
+
+Accounts listed in `HEYM_ADMIN_EMAILS` are exempt from all three. Whoever can edit the environment file can already recover the instance, so this guarantee lives in code rather than in an operator's memory.
+
+### Why the third condition exists
+
+An administrator whose Heym account was created *through* SSO has no password at all. The exemption would let them past the gate, but there is nothing for them to sign in with — so the instance would have no way back if the provider went down. Heym refuses to enter that state and says so.
+
+If you hit that message, sign in through SSO and register a password account on one of your admin addresses (registration is still open to admin addresses for exactly this reason), or add an address that already has a password to `HEYM_ADMIN_EMAILS`.
+
+### Recovering when the provider is down
+
+In order of preference:
+
+1. **Sign in with a break-glass admin password.** This is what the third condition guarantees exists.
+2. **Add yourself to `HEYM_ADMIN_EMAILS`** in the environment file and restart the backend. An account that already has a password can then sign in.
+3. **Re-open password sign-in directly in the database**, if no admin has a password at all:
+
+   ```sql
+   UPDATE sso_settings SET password_login_disabled = false;
+   ```
+
+   No restart is needed; the setting is read per request.
 
 Portal end-users are unaffected. They authenticate against a separate directory — see [Portal](./portal.md).
 

--- a/frontend/src/docs/content/reference/sso.md
+++ b/frontend/src/docs/content/reference/sso.md
@@ -1,0 +1,117 @@
+# Single Sign-On
+
+Heym can authenticate people against any external **OpenID Connect** provider. An administrator enters an issuer URL under **Settings → SSO**, and Heym reads every other endpoint from that provider's discovery document.
+
+No provider is hardcoded. Keycloak, Okta, Entra ID, Auth0, Google and any other OIDC provider connect through the same fields, because the only thing Heym is told is the issuer.
+
+Password sign-in and SSO work side by side. Password sign-in can be switched off once SSO is verified.
+
+## Before You Start
+
+SSO settings are instance-wide, so only instance administrators may change them. Administrators are named by an environment variable, not stored in the database:
+
+```
+HEYM_ADMIN_EMAILS=admin@example.com,ops@example.com
+```
+
+An empty value grants nobody. Restart the backend after changing it. Accounts on this list also see the **SSO** tab in Settings, and keep password access even when password sign-in is disabled — see [Disabling Password Sign-In](#disabling-password-sign-in).
+
+## Registering Heym With Your Provider
+
+In your identity provider, create a **confidential client** (also called an app registration) with:
+
+| Setting | Value |
+|---------|-------|
+| Protocol | OpenID Connect |
+| Grant type | Authorization Code with PKCE |
+| Client authentication | On — Heym uses a client secret |
+| Redirect URI | The exact value shown in Heym's SSO tab |
+| Scopes | `openid email profile` |
+
+Heym computes the redirect URI from `FRONTEND_URL` and shows it read-only in the settings form with a copy button. It always ends in `/api/auth/sso/callback`. Copy it rather than typing it — a mismatched redirect URI is the most common setup failure, and providers reject it without explanation.
+
+Your provider must return a verified email address. See [Account Mapping](#account-mapping).
+
+## Configuring Heym
+
+Open **Settings → SSO**. The tab only appears for accounts in `HEYM_ADMIN_EMAILS`.
+
+| Field | What it does |
+|-------|--------------|
+| **Enable single sign-on** | Shows the sign-in button on the login screen. |
+| **Issuer URL** | The provider's base URL, for example `https://idp.example.com/realms/your-realm`. Heym appends `/.well-known/openid-configuration` and reads the rest from there. |
+| **Client ID** | The client identifier from your provider. |
+| **Client secret** | Stored encrypted. Leave the field blank to keep the stored value — Heym never returns a secret it holds. |
+| **Redirect URI** | Read-only. Copy this into your provider's allowlist. |
+| **Scopes** | `openid email profile` by default. |
+| **Sign-in button label** | The text on the login screen button, for example "Sign in with Okta". |
+| **Create an account on first sign-in** | Whether unknown people get a Heym account automatically. |
+| **Allowed email domains** | Comma-separated. Blank allows any domain the provider authenticates. |
+| **Disable password sign-in** | Turns off password authentication instance-wide. |
+
+### Test the connection first
+
+**Test connection** fetches the discovery document and the provider's signing keys, then reports the token endpoint it found. Run it before enabling SSO. Changing the issuer, client ID, scopes, or secret clears the recorded result, because a passing test belongs to the settings it was run against.
+
+## How Sign-In Works
+
+1. Someone clicks the sign-in button on the login screen.
+2. Heym redirects them to the provider with a `state`, a `nonce`, and a PKCE challenge.
+3. They authenticate with the provider.
+4. The provider redirects back to Heym's callback with an authorization code.
+5. Heym exchanges the code for tokens and verifies the ID token against the provider's published keys, checking the signature, audience, issuer, expiry, and nonce.
+6. Heym resolves the account and issues its own session, exactly as a password sign-in does.
+
+Everything downstream of step 6 is unchanged: the same session cookies, the same token lifetimes, the same permissions.
+
+## Account Mapping
+
+Heym resolves an account in this order:
+
+1. **`(issuer, subject)`** — the identity the provider asserted on a previous sign-in. This is authoritative and survives an email change at the provider.
+2. **Verified email** — an existing Heym account with that address is claimed, and the provider's subject is recorded on it from then on.
+3. **A new account** — created if **Create an account on first sign-in** is on and the domain is allowed.
+
+An email counts as verified only when the ID token carries `email_verified: true`. If that claim is `false` or missing, the sign-in is refused. Claiming an existing account — or creating a new one — on the strength of an address the provider will not vouch for is an account-takeover path, so Heym does not do it. A provider that never emits `email_verified` needs to be configured to do so.
+
+Accounts created this way have no password. They sign in through the provider only.
+
+## Disabling Password Sign-In
+
+The **Disable password sign-in** switch stays unavailable until SSO is enabled **and** a connection test has passed, so a wrong issuer cannot lock the door behind itself.
+
+When it is on, password authentication is refused on both surfaces that accept one: the normal login form and the MCP OAuth consent page.
+
+Accounts listed in `HEYM_ADMIN_EMAILS` are always exempt. Whoever can edit the environment file can already recover the instance, so this guarantee lives in code rather than in an operator's memory. Keep at least one such account with a working password.
+
+Portal end-users are unaffected. They authenticate against a separate directory — see [Portal](./portal.md).
+
+## Sign-In Errors
+
+A failed sign-in returns to the login screen with a readable message. Heym never displays the provider's raw error text.
+
+| Message | Cause |
+|---------|-------|
+| That sign-in attempt expired | The attempt took longer than ten minutes, or the browser dropped the transaction cookie. Try again. |
+| Could not reach the identity provider | Discovery or the token exchange failed. Check the issuer URL and that the provider is reachable from the backend. |
+| The provider's response could not be verified | The ID token failed signature, audience, issuer, expiry, or nonce validation. Usually a client ID mismatch. |
+| The provider did not return an email address | The `email` scope is missing, or the provider does not release the claim. |
+| Your email address is not verified | The provider sent `email_verified: false`, or omitted the claim. |
+| Your email domain is not allowed | The address is outside **Allowed email domains**. |
+| No Heym account exists for you | **Create an account on first sign-in** is off and no account matches. An administrator must create one. |
+| Single sign-on is not configured | SSO is disabled, or the issuer, client ID, or secret is missing. |
+
+## Security Notes
+
+- **The client secret is encrypted at rest** and is never returned by any endpoint. The settings form reports only whether one is stored.
+- **The PKCE verifier never leaves Heym.** It is held in a short-lived `HttpOnly` cookie rather than in the `state` parameter, which round-trips through the provider in plain view.
+- **Only asymmetric signatures are accepted.** `none` and symmetric algorithms are rejected regardless of what the provider advertises.
+- **The post-login destination is validated** as a same-origin path, so the callback cannot be used as an open redirect.
+- **Every sign-in is audited.** Successes, failures, and refusals appear as `auth.sso_login` lines, and configuration changes as `sso_settings.update` — see [Audit Logging](./audit.md).
+
+## What Is Not Supported
+
+- **SAML.** OIDC is the only protocol.
+- **Multiple simultaneous providers.** One instance connects to one provider.
+- **Group or role mapping** from provider claims.
+- **Single logout.** Signing out of Heym does not sign you out of the provider.

--- a/frontend/src/docs/content/reference/sso.md
+++ b/frontend/src/docs/content/reference/sso.md
@@ -100,7 +100,7 @@ If you hit that message, sign in through SSO and register a password account on 
 
 In order of preference:
 
-1. **Sign in with a break-glass admin password.** The login screen hides the password form when password sign-in is off, so click **Administrator sign-in** underneath the SSO button to reveal it. The form is not a bypass: every address outside `HEYM_ADMIN_EMAILS` is still refused, and told why.
+1. **Sign in with a break-glass admin password.** The login screen hides the password form when password sign-in is off, so click **Sign in with a password instead** underneath the SSO button to reveal it. The form is not a bypass: every address outside `HEYM_ADMIN_EMAILS` is still refused, and told why.
 2. **Add yourself to `HEYM_ADMIN_EMAILS`** in the environment file and restart the backend. An account that already has a password can then sign in.
 3. **Re-open password sign-in directly in the database**, if no admin has a password at all:
 

--- a/frontend/src/docs/content/reference/user-settings.md
+++ b/frontend/src/docs/content/reference/user-settings.md
@@ -4,7 +4,7 @@ The Settings dialog lets you manage your profile, set persistent AI instructions
 
 ## Opening the Dialog
 
-Click the **gear (Settings) badge** in the top-right of the header. The dialog opens with these tabs: **Profile**, **Security**, **Voice**, **AI Defaults**, and **Observability**.
+Click the **gear (Settings) badge** in the top-right of the header. The dialog opens with these tabs: **Profile**, **Security**, **Voice**, **AI Defaults**, and **Observability**. Instance administrators also see an **SSO** tab.
 
 ## Profile Tab
 
@@ -92,6 +92,10 @@ For each **OpenCode** credential the tab shows the OpenCode Go subscription wind
 
 The Observability tab shows the read-only status of [OpenTelemetry Tracing](./opentelemetry.md) for this instance: whether tracing is enabled, the OTLP endpoint, service name, sampler ratio, and which spans are emitted. Tracing is configured through `HEYM_OTEL_*` environment variables on the backend, so this tab does not edit anything. When tracing is disabled, the tab lists the environment variables needed to turn it on. Secrets such as OTLP auth headers are never shown here. See [Environment Variables](https://github.com/heymrun/heym/blob/main/ENVIRONMENT-VARIABLES.md) for the full configuration reference.
 
+## SSO Tab
+
+Visible only to instance administrators — the accounts listed in `HEYM_ADMIN_EMAILS`. This tab connects Heym to an external OpenID Connect provider so people sign in with the accounts they already have. Enter an issuer URL and client credentials, copy the read-only redirect URI into your provider, and run **Test connection** before enabling it. Password sign-in can be switched off from here once the test passes. See [Single Sign-On](./sso.md) for the full setup.
+
 ## What Is Not in This Dialog
 
 | Feature | Where to Find It |
@@ -108,4 +112,5 @@ The Observability tab shows the read-only status of [OpenTelemetry Tracing](./op
 - [MCP Tab](../tabs/mcp-tab.md) – MCP server API key and workflow tool exposure
 - [Credentials Tab](../tabs/credentials-tab.md) – API keys for AI nodes and integrations
 - [Security](./security.md) – Session management, rate limiting, credential encryption
+- [Single Sign-On](./sso.md) – Connect an external OpenID Connect provider
 - [OpenTelemetry Tracing](./opentelemetry.md) – Distributed tracing for workflow and node executions

--- a/frontend/src/docs/manifest.ts
+++ b/frontend/src/docs/manifest.ts
@@ -136,6 +136,7 @@ export const DOCS_MANIFEST: Record<string, DocCategory> = {
       { slug: "file-generation", title: "File Generation" },
       { slug: "drive", title: "Drive" },
       { slug: "security", title: "Security" },
+      { slug: "sso", title: "Single Sign-On" },
       { slug: "plugin-authoring", title: "Plugin Authoring" },
       { slug: "integrations", title: "Third-Party Integrations" },
       { slug: "guardrails", title: "Guardrails" },

--- a/frontend/src/features/release-tour/components/ReleaseFeatureTour.vue
+++ b/frontend/src/features/release-tour/components/ReleaseFeatureTour.vue
@@ -101,6 +101,20 @@ function openDocs(): void {
   void router.push(getDocPath(target.categoryId, target.slug));
 }
 
+/** Clicking anywhere else dismisses the panel. It has no backdrop to catch the click. */
+function handlePointerDown(event: MouseEvent): void {
+  if (!isVisible.value) return;
+
+  const node = event.target;
+  const element = node instanceof Element ? node : (node as Node | null)?.parentElement;
+  if (!element) return;
+  if (panelRef.value?.contains(element)) return;
+  // The launcher toggles the panel itself; closing here too would fight that.
+  if (element.closest("#release-tour-launcher-slot")) return;
+
+  complete();
+}
+
 function handleKeydown(event: KeyboardEvent): void {
   if (!isVisible.value) return;
 
@@ -132,6 +146,7 @@ watch(isVisible, (visible, wasVisible) => {
 
 onMounted(() => {
   document.addEventListener("keydown", handleKeydown);
+  document.addEventListener("mousedown", handlePointerDown);
   unsubscribeDismissOverlays = onDismissOverlays(() => {
     if (isVisible.value) complete();
   });
@@ -139,6 +154,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   document.removeEventListener("keydown", handleKeydown);
+  document.removeEventListener("mousedown", handlePointerDown);
   unsubscribeDismissOverlays?.();
   unsubscribeDismissOverlays = null;
 });

--- a/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
+++ b/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Check, KeyRound, ShieldCheck } from "lucide-vue-next";
+
+import { useCycleStep } from "@/features/release-tour/useCycleStep";
+
+// 0: password + SSO side by side · 1: SSO button focused · 2: provider hand-off · 3: signed in
+const step = useCycleStep(4, 1300);
+
+const showPasswordForm = computed(() => step.value === 0);
+const ssoFocused = computed(() => step.value === 1);
+const atProvider = computed(() => step.value === 2);
+const signedIn = computed(() => step.value === 3);
+</script>
+
+<template>
+  <div class="flex h-full w-full flex-col gap-2 p-3">
+    <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-2 py-1">
+        <ShieldCheck class="h-3.5 w-3.5 text-primary" />
+        <span class="text-[11px] font-semibold text-foreground">Single sign-on</span>
+      </div>
+      <span class="ml-auto text-[10px] font-medium text-muted-foreground transition-colors duration-300">
+        {{ atProvider ? "Redirecting to your provider" : signedIn ? "Signed in" : "OpenID Connect" }}
+      </span>
+    </div>
+
+    <div class="flex flex-1 flex-col justify-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-sunken p-3">
+      <Transition
+        enter-active-class="transition-all duration-300"
+        leave-active-class="transition-all duration-200"
+        enter-from-class="opacity-0 -translate-y-1"
+        leave-to-class="opacity-0 -translate-y-1"
+        mode="out-in"
+      >
+        <div
+          v-if="signedIn"
+          key="done"
+          class="flex flex-col items-center gap-1.5 py-3"
+        >
+          <Check class="h-5 w-5 text-emerald-500" />
+          <span class="text-[11px] font-medium text-foreground">ada@example.com</span>
+          <span class="text-[10px] text-muted-foreground">Account created on first sign-in</span>
+        </div>
+
+        <div
+          v-else
+          key="form"
+          class="flex flex-col gap-2"
+        >
+          <div
+            v-if="showPasswordForm"
+            class="flex flex-col gap-1.5"
+          >
+            <div class="h-6 rounded border border-border bg-background" />
+            <div class="h-6 rounded border border-border bg-background" />
+          </div>
+
+          <div
+            v-if="showPasswordForm"
+            class="text-center text-[9px] uppercase tracking-wide text-muted-foreground"
+          >
+            or
+          </div>
+
+          <div
+            class="flex items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 transition-all duration-300"
+            :class="ssoFocused || atProvider
+              ? 'border-primary bg-primary/12 text-foreground'
+              : 'border-border bg-background text-muted-foreground'"
+          >
+            <KeyRound class="h-3.5 w-3.5" />
+            <span class="text-[11px] font-medium">Sign in with SSO</span>
+          </div>
+
+          <div
+            class="h-1 overflow-hidden rounded-full bg-border transition-opacity duration-300"
+            :class="atProvider ? 'opacity-100' : 'opacity-0'"
+          >
+            <div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
+          </div>
+        </div>
+      </Transition>
+    </div>
+  </div>
+</template>

--- a/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
+++ b/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
@@ -76,29 +76,29 @@ const statusLabel = computed(() => {
       >
         <div
           v-if="atProvider || signedIn"
-          class="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-surface-sunken px-2"
+          class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-sunken px-2"
         >
           <template v-if="atProvider">
             <div class="flex items-center gap-1.5">
-              <span class="rounded border border-border bg-background px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+              <span class="rounded border border-border bg-background px-2 py-1 text-[11px] font-medium leading-none text-muted-foreground">
                 Heym
               </span>
-              <ArrowRight class="h-2.5 w-2.5 text-primary" />
-              <span class="rounded border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium leading-none text-foreground">
+              <ArrowRight class="h-3 w-3 text-primary" />
+              <span class="rounded border border-primary/40 bg-primary/10 px-2 py-1 text-[11px] font-medium leading-none text-foreground">
                 Your provider
               </span>
             </div>
-            <div class="h-1 w-20 overflow-hidden rounded-full bg-border">
+            <div class="h-1 w-24 overflow-hidden rounded-full bg-border">
               <div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
             </div>
           </template>
 
           <template v-else>
-            <div class="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/15">
-              <Check class="h-3.5 w-3.5 text-emerald-500" />
+            <div class="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500/15">
+              <Check class="h-4 w-4 text-emerald-500" />
             </div>
-            <span class="text-[10px] font-medium leading-none text-foreground">ada@heym.run</span>
-            <span class="text-[9px] leading-none text-muted-foreground">Account created on first sign-in</span>
+            <span class="text-[12px] font-medium leading-none text-foreground">ada@heym.run</span>
+            <span class="text-[10.5px] leading-none text-muted-foreground">Account created on first sign-in</span>
           </template>
         </div>
       </Transition>

--- a/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
+++ b/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { Check, KeyRound, ShieldCheck } from "lucide-vue-next";
+import { ArrowRight, Check, KeyRound, Lock, Mail, ShieldCheck } from "lucide-vue-next";
 
 import { useCycleStep } from "@/features/release-tour/useCycleStep";
 
-// 0: password + SSO side by side · 1: SSO button focused · 2: provider hand-off · 3: signed in
-const step = useCycleStep(4, 1300);
+// 0: password and SSO side by side · 1: SSO chosen · 2: provider hand-off · 3: signed in
+const step = useCycleStep(4, 1400);
 
-const showPasswordForm = computed(() => step.value === 0);
-const ssoFocused = computed(() => step.value === 1);
+const ssoChosen = computed(() => step.value >= 1);
 const atProvider = computed(() => step.value === 2);
 const signedIn = computed(() => step.value === 3);
+
+const statusLabel = computed(() => {
+  if (signedIn.value) return "Signed in";
+  if (atProvider.value) return "Redirecting";
+  return "OpenID Connect";
+});
 </script>
 
 <template>
@@ -21,64 +26,76 @@ const signedIn = computed(() => step.value === 3);
         <span class="text-[11px] font-semibold text-foreground">Single sign-on</span>
       </div>
       <span class="ml-auto text-[10px] font-medium text-muted-foreground transition-colors duration-300">
-        {{ atProvider ? "Redirecting to your provider" : signedIn ? "Signed in" : "OpenID Connect" }}
+        {{ statusLabel }}
       </span>
     </div>
 
-    <div class="flex flex-1 flex-col justify-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-sunken p-3">
+    <div class="relative flex flex-1 flex-col justify-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-sunken p-3">
+      <!-- The password form stays in place and dims, so choosing SSO never empties the card. -->
+      <div
+        class="flex flex-col gap-1.5 transition-opacity duration-500"
+        :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
+      >
+        <div class="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5">
+          <Mail class="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span class="truncate text-[10.5px] text-muted-foreground">ada@heym.run</span>
+        </div>
+        <div class="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5">
+          <Lock class="h-3 w-3 shrink-0 text-muted-foreground" />
+          <span class="tracking-[0.2em] text-[10.5px] text-muted-foreground">••••••••</span>
+        </div>
+      </div>
+
+      <div
+        class="text-center text-[9px] uppercase tracking-wide text-muted-foreground transition-opacity duration-500"
+        :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
+      >
+        or
+      </div>
+
+      <div
+        class="flex items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 transition-all duration-300"
+        :class="ssoChosen
+          ? 'border-primary bg-primary/12 text-foreground shadow-[0_0_0_3px_hsl(var(--primary)/0.12)]'
+          : 'border-border bg-background text-muted-foreground'"
+      >
+        <KeyRound class="h-3.5 w-3.5" />
+        <span class="text-[11px] font-medium">Sign in with SSO</span>
+      </div>
+
+      <!-- Hand-off and result cover the card so its height never changes. -->
       <Transition
         enter-active-class="transition-all duration-300"
         leave-active-class="transition-all duration-200"
-        enter-from-class="opacity-0 -translate-y-1"
-        leave-to-class="opacity-0 -translate-y-1"
-        mode="out-in"
+        enter-from-class="opacity-0"
+        leave-to-class="opacity-0"
       >
         <div
-          v-if="signedIn"
-          key="done"
-          class="flex flex-col items-center gap-1.5 py-3"
+          v-if="atProvider || signedIn"
+          class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-sunken/95 px-3"
         >
-          <Check class="h-5 w-5 text-emerald-500" />
-          <span class="text-[11px] font-medium text-foreground">ada@example.com</span>
-          <span class="text-[10px] text-muted-foreground">Account created on first sign-in</span>
-        </div>
+          <template v-if="atProvider">
+            <div class="flex items-center gap-2">
+              <div class="rounded-md border border-border bg-background px-2 py-1 text-[10px] font-medium text-muted-foreground">
+                Heym
+              </div>
+              <ArrowRight class="h-3 w-3 text-primary" />
+              <div class="rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-[10px] font-medium text-foreground">
+                Your provider
+              </div>
+            </div>
+            <div class="h-1 w-24 overflow-hidden rounded-full bg-border">
+              <div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
+            </div>
+          </template>
 
-        <div
-          v-else
-          key="form"
-          class="flex flex-col gap-2"
-        >
-          <div
-            v-if="showPasswordForm"
-            class="flex flex-col gap-1.5"
-          >
-            <div class="h-6 rounded border border-border bg-background" />
-            <div class="h-6 rounded border border-border bg-background" />
-          </div>
-
-          <div
-            v-if="showPasswordForm"
-            class="text-center text-[9px] uppercase tracking-wide text-muted-foreground"
-          >
-            or
-          </div>
-
-          <div
-            class="flex items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 transition-all duration-300"
-            :class="ssoFocused || atProvider
-              ? 'border-primary bg-primary/12 text-foreground'
-              : 'border-border bg-background text-muted-foreground'"
-          >
-            <KeyRound class="h-3.5 w-3.5" />
-            <span class="text-[11px] font-medium">Sign in with SSO</span>
-          </div>
-
-          <div
-            class="h-1 overflow-hidden rounded-full bg-border transition-opacity duration-300"
-            :class="atProvider ? 'opacity-100' : 'opacity-0'"
-          >
-            <div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
-          </div>
+          <template v-else>
+            <div class="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500/15">
+              <Check class="h-4 w-4 text-emerald-500" />
+            </div>
+            <span class="text-[11px] font-medium text-foreground">ada@heym.run</span>
+            <span class="text-[10px] text-muted-foreground">Account created on first sign-in</span>
+          </template>
         </div>
       </Transition>
     </div>

--- a/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
+++ b/frontend/src/features/release-tour/components/visuals/SsoLoginTourVisual.vue
@@ -19,82 +19,86 @@ const statusLabel = computed(() => {
 </script>
 
 <template>
-  <div class="flex h-full w-full flex-col gap-2 p-3">
-    <div class="flex items-center gap-2">
-      <div class="flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/10 px-2 py-1">
-        <ShieldCheck class="h-3.5 w-3.5 text-primary" />
-        <span class="text-[11px] font-semibold text-foreground">Single sign-on</span>
+  <!-- The tour slot is a fixed 168px, so every row below is sized to fit inside it. -->
+  <div class="flex h-full w-full flex-col gap-1.5 p-2.5">
+    <div class="flex h-[20px] shrink-0 items-center gap-1.5">
+      <div class="flex items-center gap-1 rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5">
+        <ShieldCheck class="h-3 w-3 text-primary" />
+        <span class="text-[10px] font-semibold leading-none text-foreground">Single sign-on</span>
       </div>
-      <span class="ml-auto text-[10px] font-medium text-muted-foreground transition-colors duration-300">
+      <span class="ml-auto text-[9px] font-medium leading-none text-muted-foreground transition-colors duration-300">
         {{ statusLabel }}
       </span>
     </div>
 
-    <div class="relative flex flex-1 flex-col justify-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-sunken p-3">
-      <!-- The password form stays in place and dims, so choosing SSO never empties the card. -->
-      <div
-        class="flex flex-col gap-1.5 transition-opacity duration-500"
-        :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
-      >
-        <div class="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5">
-          <Mail class="h-3 w-3 shrink-0 text-muted-foreground" />
-          <span class="truncate text-[10.5px] text-muted-foreground">ada@heym.run</span>
+    <div class="relative min-h-0 flex-1 overflow-hidden rounded-md border border-border bg-surface-sunken p-2">
+      <div class="flex h-full flex-col justify-center gap-1.5">
+        <!-- The password form stays put and dims, so choosing SSO never empties the card. -->
+        <div
+          class="flex h-[22px] items-center gap-1.5 rounded border border-border bg-background px-1.5 transition-opacity duration-500"
+          :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
+        >
+          <Mail class="h-2.5 w-2.5 shrink-0 text-muted-foreground" />
+          <span class="truncate text-[10px] leading-none text-muted-foreground">ada@heym.run</span>
         </div>
-        <div class="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5">
-          <Lock class="h-3 w-3 shrink-0 text-muted-foreground" />
-          <span class="tracking-[0.2em] text-[10.5px] text-muted-foreground">••••••••</span>
+        <div
+          class="flex h-[22px] items-center gap-1.5 rounded border border-border bg-background px-1.5 transition-opacity duration-500"
+          :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
+        >
+          <Lock class="h-2.5 w-2.5 shrink-0 text-muted-foreground" />
+          <span class="text-[10px] leading-none tracking-[0.18em] text-muted-foreground">••••••</span>
+        </div>
+
+        <div
+          class="text-center text-[8px] uppercase leading-none tracking-wide text-muted-foreground transition-opacity duration-500"
+          :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
+        >
+          or
+        </div>
+
+        <div
+          class="flex h-[26px] items-center justify-center gap-1.5 rounded border transition-all duration-300"
+          :class="ssoChosen
+            ? 'border-primary bg-primary/12 text-foreground'
+            : 'border-border bg-background text-muted-foreground'"
+        >
+          <KeyRound class="h-3 w-3" />
+          <span class="text-[10px] font-medium leading-none">Sign in with SSO</span>
         </div>
       </div>
 
-      <div
-        class="text-center text-[9px] uppercase tracking-wide text-muted-foreground transition-opacity duration-500"
-        :class="ssoChosen ? 'opacity-30' : 'opacity-100'"
-      >
-        or
-      </div>
-
-      <div
-        class="flex items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 transition-all duration-300"
-        :class="ssoChosen
-          ? 'border-primary bg-primary/12 text-foreground shadow-[0_0_0_3px_hsl(var(--primary)/0.12)]'
-          : 'border-border bg-background text-muted-foreground'"
-      >
-        <KeyRound class="h-3.5 w-3.5" />
-        <span class="text-[11px] font-medium">Sign in with SSO</span>
-      </div>
-
-      <!-- Hand-off and result cover the card so its height never changes. -->
+      <!-- Hand-off and result cover the box, so its height never changes. -->
       <Transition
-        enter-active-class="transition-all duration-300"
-        leave-active-class="transition-all duration-200"
+        enter-active-class="transition-opacity duration-300"
+        leave-active-class="transition-opacity duration-200"
         enter-from-class="opacity-0"
         leave-to-class="opacity-0"
       >
         <div
           v-if="atProvider || signedIn"
-          class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-surface-sunken/95 px-3"
+          class="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-surface-sunken px-2"
         >
           <template v-if="atProvider">
-            <div class="flex items-center gap-2">
-              <div class="rounded-md border border-border bg-background px-2 py-1 text-[10px] font-medium text-muted-foreground">
+            <div class="flex items-center gap-1.5">
+              <span class="rounded border border-border bg-background px-1.5 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
                 Heym
-              </div>
-              <ArrowRight class="h-3 w-3 text-primary" />
-              <div class="rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-[10px] font-medium text-foreground">
+              </span>
+              <ArrowRight class="h-2.5 w-2.5 text-primary" />
+              <span class="rounded border border-primary/40 bg-primary/10 px-1.5 py-0.5 text-[9px] font-medium leading-none text-foreground">
                 Your provider
-              </div>
+              </span>
             </div>
-            <div class="h-1 w-24 overflow-hidden rounded-full bg-border">
+            <div class="h-1 w-20 overflow-hidden rounded-full bg-border">
               <div class="h-full w-1/2 animate-pulse rounded-full bg-primary" />
             </div>
           </template>
 
           <template v-else>
-            <div class="flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500/15">
-              <Check class="h-4 w-4 text-emerald-500" />
+            <div class="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/15">
+              <Check class="h-3.5 w-3.5 text-emerald-500" />
             </div>
-            <span class="text-[11px] font-medium text-foreground">ada@heym.run</span>
-            <span class="text-[10px] text-muted-foreground">Account created on first sign-in</span>
+            <span class="text-[10px] font-medium leading-none text-foreground">ada@heym.run</span>
+            <span class="text-[9px] leading-none text-muted-foreground">Account created on first sign-in</span>
           </template>
         </div>
       </Transition>

--- a/frontend/src/features/release-tour/releaseRegistry.ts
+++ b/frontend/src/features/release-tour/releaseRegistry.ts
@@ -13,6 +13,49 @@ import type { ReleaseEntry } from "@/features/release-tour/releaseTour.types";
  */
 export const RELEASE_REGISTRY: ReleaseEntry[] = [
   {
+    releaseId: "2026.09",
+    publishedAt: new Date("2026-08-26T00:00:00Z"),
+    headline: "Sign in with your own identity provider",
+    releaseTour: {
+      label: "New in Heym",
+      introTitle: "New in this release",
+      introDescription:
+        "A quick look at what changed since your last update. Takes about a minute.",
+      // Still in progress. Flipped on in the release commit.
+      tourEnabled: false,
+      sectionOrder: ["oidc-sso"],
+    },
+    sections: [
+      {
+        id: "oidc-sso",
+        title: "Sign in with your identity provider",
+        blocks: [
+          {
+            type: "prose",
+            markdown:
+              "Heym can now authenticate people against any **OpenID Connect** provider. An instance administrator pastes an issuer URL under **Settings → SSO**, and Heym reads the authorization, token, and key endpoints from the provider's own discovery document. No provider is hardcoded, so Keycloak, Okta, Entra ID, Auth0 and Google all connect the same way.",
+          },
+          {
+            type: "prose",
+            markdown:
+              "People who have never signed in get an account on first sign-in, optionally limited to your own email domains. Password sign-in stays available beside SSO, and can be switched off once a connection test has passed - accounts listed in `HEYM_ADMIN_EMAILS` keep password access so a misconfigured provider can never lock you out.",
+          },
+        ],
+        tour: {
+          description:
+            "Configure single sign-on against any OIDC provider from the settings panel. Paste an issuer URL, copy the redirect URI into your provider, and test the connection before you turn it on.",
+          useCases: [
+            "Let your team sign in with the accounts they already have",
+            "Restrict new accounts to your own email domains",
+            "Turn off password sign-in once SSO is verified",
+          ],
+          tourVisual: "sso-login",
+          docTarget: { categoryId: "reference", slug: "sso", title: "Single Sign-On" },
+        },
+      },
+    ],
+  },
+  {
     releaseId: "2026.08",
     publishedAt: new Date("2026-08-18T00:00:00Z"),
     headline:

--- a/frontend/src/features/release-tour/releaseRegistry.ts
+++ b/frontend/src/features/release-tour/releaseRegistry.ts
@@ -21,8 +21,7 @@ export const RELEASE_REGISTRY: ReleaseEntry[] = [
       introTitle: "New in this release",
       introDescription:
         "A quick look at what changed since your last update. Takes about a minute.",
-      // Still in progress. Flipped on in the release commit.
-      tourEnabled: false,
+      tourEnabled: true,
       sectionOrder: ["oidc-sso"],
     },
     sections: [

--- a/frontend/src/features/release-tour/tourVisuals.ts
+++ b/frontend/src/features/release-tour/tourVisuals.ts
@@ -5,6 +5,7 @@ import FallbackTourVisual from "@/features/release-tour/components/visuals/Fallb
 import FolderIconsTourVisual from "@/features/release-tour/components/visuals/FolderIconsTourVisual.vue";
 import HtmlOutputMapperTourVisual from "@/features/release-tour/components/visuals/HtmlOutputMapperTourVisual.vue";
 import PlaywrightAiStepsTourVisual from "@/features/release-tour/components/visuals/PlaywrightAiStepsTourVisual.vue";
+import SsoLoginTourVisual from "@/features/release-tour/components/visuals/SsoLoginTourVisual.vue";
 import WorkflowListingTourVisual from "@/features/release-tour/components/visuals/WorkflowListingTourVisual.vue";
 
 /** Maps a section's `tourVisual` key to the mock UI that demonstrates it. */
@@ -13,6 +14,7 @@ export const TOUR_VISUALS: Record<string, Component> = {
   "folder-icons": FolderIconsTourVisual,
   "html-output-mapper": HtmlOutputMapperTourVisual,
   "playwright-ai-steps": PlaywrightAiStepsTourVisual,
+  "sso-login": SsoLoginTourVisual,
   "workflow-listing": WorkflowListingTourVisual,
 };
 

--- a/frontend/src/services/sso.ts
+++ b/frontend/src/services/sso.ts
@@ -1,0 +1,23 @@
+import api from "@/services/api";
+
+import type { SsoSettings, SsoSettingsUpdate, SsoStatus, SsoTestResult } from "@/types/sso";
+
+export async function getSsoStatus(): Promise<SsoStatus> {
+  const { data } = await api.get<SsoStatus>("/auth/sso/status");
+  return data;
+}
+
+export async function getAdminSsoConfig(): Promise<SsoSettings> {
+  const { data } = await api.get<SsoSettings>("/admin/sso");
+  return data;
+}
+
+export async function saveAdminSsoConfig(update: SsoSettingsUpdate): Promise<SsoSettings> {
+  const { data } = await api.put<SsoSettings>("/admin/sso", update);
+  return data;
+}
+
+export async function testSsoConnection(): Promise<SsoTestResult> {
+  const { data } = await api.post<SsoTestResult>("/admin/sso/test");
+  return data;
+}

--- a/frontend/src/services/sso.ts
+++ b/frontend/src/services/sso.ts
@@ -17,7 +17,7 @@ export async function saveAdminSsoConfig(update: SsoSettingsUpdate): Promise<Sso
   return data;
 }
 
-export async function testSsoConnection(): Promise<SsoTestResult> {
-  const { data } = await api.post<SsoTestResult>("/admin/sso/test");
+export async function testSsoConnection(issuer?: string): Promise<SsoTestResult> {
+  const { data } = await api.post<SsoTestResult>("/admin/sso/test", { issuer: issuer ?? null });
   return data;
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -2,6 +2,7 @@ export interface User {
   id: string;
   email: string;
   name: string;
+  is_admin: boolean;
   user_rules: string | null;
   tts_credential_id: string | null;
   tts_voice_id: string | null;

--- a/frontend/src/types/sso.ts
+++ b/frontend/src/types/sso.ts
@@ -17,6 +17,7 @@ export interface SsoSettings {
   last_test_ok: boolean;
   last_test_at: string | null;
   redirect_uri: string;
+  break_glass_ready: boolean;
 }
 
 export interface SsoSettingsUpdate {

--- a/frontend/src/types/sso.ts
+++ b/frontend/src/types/sso.ts
@@ -1,0 +1,42 @@
+export interface SsoStatus {
+  enabled: boolean;
+  button_label: string;
+  password_login_enabled: boolean;
+}
+
+export interface SsoSettings {
+  enabled: boolean;
+  issuer: string;
+  client_id: string;
+  client_secret_set: boolean;
+  scopes: string;
+  button_label: string;
+  auto_provision_users: boolean;
+  allowed_email_domains: string;
+  password_login_disabled: boolean;
+  last_test_ok: boolean;
+  last_test_at: string | null;
+  redirect_uri: string;
+}
+
+export interface SsoSettingsUpdate {
+  enabled?: boolean;
+  issuer?: string;
+  client_id?: string;
+  client_secret?: string;
+  scopes?: string;
+  button_label?: string;
+  auto_provision_users?: boolean;
+  allowed_email_domains?: string;
+  password_login_disabled?: boolean;
+}
+
+export interface SsoTestResult {
+  ok: boolean;
+  issuer: string | null;
+  authorization_endpoint: string | null;
+  token_endpoint: string | null;
+  jwks_uri: string | null;
+  userinfo_endpoint: string | null;
+  error: string | null;
+}

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -100,22 +100,22 @@ onMounted(async () => {
     <WorkflowHeroBackground />
 
     <div class="relative z-10 w-full max-w-full sm:max-w-lg pt-14 sm:pt-16">
-      <div class="auth-badge absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20 text-primary text-sm font-medium whitespace-nowrap">
-        <Sparkles class="w-4 h-4" />
-        AI Workflow Automation
+      <div class="auth-badge absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-2 px-5 py-2.5 rounded-full bg-card border border-primary/25 text-primary text-sm font-medium whitespace-nowrap before:absolute before:inset-0 before:rounded-full before:bg-primary/10 before:content-['']">
+        <Sparkles class="relative w-4 h-4" />
+        <span class="relative">AI Workflow Automation</span>
       </div>
 
       <Card class="auth-card relative w-full p-7 md:p-9 lg:p-11 animate-scale-in-bounce gradient-border-hover">
-        <div class="flex flex-col items-center mb-8">
+        <div class="flex flex-col items-center mb-10">
           <img
             src="/fav.svg"
             alt="Heym"
-            class="w-16 h-16 mb-6"
+            class="w-20 h-20 mb-7"
           >
-          <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-center">
+          <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-center">
             Welcome back
           </h1>
-          <p class="text-muted-foreground text-sm mt-2 text-center max-w-[300px]">
+          <p class="text-muted-foreground text-base mt-3 text-center max-w-[340px]">
             {{
               passwordFormVisible
                 ? "Sign in to continue building powerful AI workflows"
@@ -208,12 +208,12 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div :class="passwordFormVisible ? '' : 'space-y-4 py-2'">
+        <div :class="passwordFormVisible ? '' : 'space-y-5 py-3'">
           <Button
             v-if="sso.enabled"
             type="button"
             variant="outline"
-            class="w-full h-12 min-h-[44px] text-base"
+            class="w-full h-14 min-h-[44px] text-base"
             @click="startSso"
           >
             <KeyRound class="w-4 h-4 mr-1" />
@@ -223,7 +223,7 @@ onMounted(async () => {
           <button
             v-if="!sso.password_login_enabled && !showAdminSignIn"
             type="button"
-            class="w-full text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+            class="w-full text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
             @click="showAdminSignIn = true"
           >
             Sign in with a password instead

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,22 +1,46 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import { useRouter } from "vue-router";
-import { ArrowRight, Sparkles, Zap } from "lucide-vue-next";
+import { computed, onMounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { ArrowRight, KeyRound, Sparkles, Zap } from "lucide-vue-next";
 
 import Button from "@/components/ui/Button.vue";
 import Card from "@/components/ui/Card.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
 import WorkflowHeroBackground from "@/components/Layout/WorkflowHeroBackground.vue";
+import { getSsoStatus } from "@/services/sso";
 import { useAuthStore } from "@/stores/auth";
+import type { SsoStatus } from "@/types/sso";
 
 const router = useRouter();
+const route = useRoute();
 const authStore = useAuthStore();
 
 const email = ref("");
 const password = ref("");
 const error = ref("");
 const loading = ref(false);
+const sso = ref<SsoStatus>({
+  enabled: false,
+  button_label: "Sign in with SSO",
+  password_login_enabled: true,
+});
+
+const SSO_ERRORS: Record<string, string> = {
+  state_mismatch: "That sign-in attempt expired. Please try again.",
+  token_exchange_failed: "Could not reach the identity provider. Try again shortly.",
+  invalid_token: "The identity provider's response could not be verified.",
+  email_missing: "The identity provider did not return an email address.",
+  email_not_verified: "Your email address is not verified with the identity provider.",
+  domain_not_allowed: "Your email domain is not allowed on this instance.",
+  provisioning_disabled: "No Heym account exists for you. Ask an administrator to create one.",
+  sso_disabled: "Single sign-on is not configured on this instance.",
+};
+
+const ssoError = computed<string>(() => {
+  const code = route.query.sso_error;
+  return typeof code === "string" ? (SSO_ERRORS[code] ?? SSO_ERRORS.invalid_token) : "";
+});
 
 async function handleSubmit(): Promise<void> {
   error.value = "";
@@ -31,6 +55,21 @@ async function handleSubmit(): Promise<void> {
     loading.value = false;
   }
 }
+
+function startSso(): void {
+  // A full navigation, not an XHR: the browser must follow the redirect chain into the
+  // provider's own login UI.
+  window.location.href = "/api/auth/sso/login";
+}
+
+onMounted(async () => {
+  try {
+    sso.value = await getSsoStatus();
+  } catch {
+    // A status failure must never hide the password form.
+    sso.value = { enabled: false, button_label: "Sign in with SSO", password_login_enabled: true };
+  }
+});
 </script>
 
 <template>
@@ -67,7 +106,15 @@ async function handleSubmit(): Promise<void> {
           </p>
         </div>
 
+        <div
+          v-if="ssoError"
+          class="mb-5 p-4 rounded-xl bg-destructive/10 border border-destructive/20 text-destructive text-sm"
+        >
+          {{ ssoError }}
+        </div>
+
         <form
+          v-if="sso.password_login_enabled"
           class="space-y-5"
           @submit.prevent="handleSubmit"
         >
@@ -131,7 +178,33 @@ async function handleSubmit(): Promise<void> {
           </Button>
         </form>
 
-        <div class="divider relative my-8">
+        <div
+          v-if="sso.enabled && sso.password_login_enabled"
+          class="divider relative my-8"
+        >
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-border" />
+          </div>
+          <div class="relative flex justify-center text-xs uppercase">
+            <span class="bg-card px-3 text-muted-foreground">or</span>
+          </div>
+        </div>
+
+        <Button
+          v-if="sso.enabled"
+          type="button"
+          variant="outline"
+          class="w-full h-12 min-h-[44px] text-base"
+          @click="startSso"
+        >
+          <KeyRound class="w-4 h-4 mr-1" />
+          {{ sso.button_label }}
+        </Button>
+
+        <div
+          v-if="sso.password_login_enabled"
+          class="divider relative my-8"
+        >
           <div class="absolute inset-0 flex items-center">
             <div class="w-full border-t border-border" />
           </div>
@@ -141,6 +214,7 @@ async function handleSubmit(): Promise<void> {
         </div>
 
         <router-link
+          v-if="sso.password_login_enabled"
           to="/register"
           class="register-link flex items-center justify-center gap-3 w-full h-12 min-h-[44px] rounded-xl border border-border bg-muted/30 text-sm font-medium text-foreground hover:bg-muted/50 hover:border-primary/30 transition-all duration-300"
         >

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import axios from "axios";
 import { ArrowRight, KeyRound, Sparkles, Zap } from "lucide-vue-next";
 
 import Button from "@/components/ui/Button.vue";
@@ -25,6 +26,14 @@ const sso = ref<SsoStatus>({
   button_label: "Sign in with SSO",
   password_login_enabled: true,
 });
+// When password sign-in is disabled instance-wide the form is hidden, but accounts in
+// HEYM_ADMIN_EMAILS are still allowed through. Without a way to reveal the form, that
+// break-glass exemption would be unreachable and a provider outage would strand everyone.
+const showAdminSignIn = ref(false);
+
+const passwordFormVisible = computed(
+  () => sso.value.password_login_enabled || showAdminSignIn.value,
+);
 
 const SSO_ERRORS: Record<string, string> = {
   state_mismatch: "That sign-in attempt expired. Please try again.",
@@ -49,8 +58,13 @@ async function handleSubmit(): Promise<void> {
   try {
     await authStore.login({ email: email.value, password: password.value });
     router.push("/");
-  } catch {
-    error.value = "Invalid email or password";
+  } catch (err) {
+    const detail = axios.isAxiosError(err) ? err.response?.data?.detail : null;
+    error.value =
+      typeof detail === "string" && err instanceof Error && axios.isAxiosError(err)
+      && err.response?.status === 403
+        ? detail
+        : "Invalid email or password";
   } finally {
     loading.value = false;
   }
@@ -85,13 +99,13 @@ onMounted(async () => {
     <!-- Workflow graph background (above blur, below card) -->
     <WorkflowHeroBackground />
 
-    <div class="relative z-10 w-full max-w-full sm:max-w-md pt-14 sm:pt-16">
+    <div class="relative z-10 w-full max-w-full sm:max-w-lg pt-14 sm:pt-16">
       <div class="auth-badge absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20 text-primary text-sm font-medium whitespace-nowrap">
         <Sparkles class="w-4 h-4" />
         AI Workflow Automation
       </div>
 
-      <Card class="auth-card relative w-full p-6 md:p-8 lg:p-10 animate-scale-in-bounce gradient-border-hover">
+      <Card class="auth-card relative w-full p-7 md:p-9 lg:p-11 animate-scale-in-bounce gradient-border-hover">
         <div class="flex flex-col items-center mb-8">
           <img
             src="/fav.svg"
@@ -114,7 +128,7 @@ onMounted(async () => {
         </div>
 
         <form
-          v-if="sso.password_login_enabled"
+          v-if="passwordFormVisible"
           class="space-y-5"
           @submit.prevent="handleSubmit"
         >
@@ -179,7 +193,7 @@ onMounted(async () => {
         </form>
 
         <div
-          v-if="sso.enabled && sso.password_login_enabled"
+          v-if="sso.enabled && passwordFormVisible"
           class="divider relative my-8"
         >
           <div class="absolute inset-0 flex items-center">
@@ -190,9 +204,9 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div :class="sso.password_login_enabled ? '' : 'py-6 space-y-4'">
+        <div :class="passwordFormVisible ? '' : 'py-4 space-y-5'">
           <p
-            v-if="!sso.password_login_enabled"
+            v-if="!passwordFormVisible"
             class="text-sm text-muted-foreground text-center"
           >
             This workspace signs in through your identity provider.
@@ -209,11 +223,21 @@ onMounted(async () => {
             {{ sso.button_label }}
           </Button>
 
+          <button
+            v-if="!sso.password_login_enabled && !showAdminSignIn"
+            type="button"
+            class="w-full text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+            @click="showAdminSignIn = true"
+          >
+            Administrator sign-in
+          </button>
+
           <p
-            v-if="!sso.password_login_enabled"
+            v-if="!sso.password_login_enabled && showAdminSignIn"
             class="text-xs text-muted-foreground text-center"
           >
-            Trouble signing in? Ask an instance administrator.
+            Password sign-in is off for this workspace. Only accounts listed in
+            <code>HEYM_ADMIN_EMAILS</code> can use this form.
           </p>
         </div>
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -115,8 +115,12 @@ onMounted(async () => {
           <h1 class="text-2xl md:text-3xl font-bold tracking-tight text-center">
             Welcome back
           </h1>
-          <p class="text-muted-foreground text-sm mt-2 text-center max-w-[280px]">
-            Sign in to continue building powerful AI workflows
+          <p class="text-muted-foreground text-sm mt-2 text-center max-w-[300px]">
+            {{
+              passwordFormVisible
+                ? "Sign in to continue building powerful AI workflows"
+                : "This workspace signs in through your identity provider"
+            }}
           </p>
         </div>
 
@@ -204,14 +208,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div :class="passwordFormVisible ? '' : 'py-4 space-y-5'">
-          <p
-            v-if="!passwordFormVisible"
-            class="text-sm text-muted-foreground text-center"
-          >
-            This workspace signs in through your identity provider.
-          </p>
-
+        <div :class="passwordFormVisible ? '' : 'space-y-4 py-2'">
           <Button
             v-if="sso.enabled"
             type="button"
@@ -229,15 +226,14 @@ onMounted(async () => {
             class="w-full text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
             @click="showAdminSignIn = true"
           >
-            Administrator sign-in
+            Sign in with a password instead
           </button>
 
           <p
             v-if="!sso.password_login_enabled && showAdminSignIn"
             class="text-xs text-muted-foreground text-center"
           >
-            Password sign-in is off for this workspace. Only accounts listed in
-            <code>HEYM_ADMIN_EMAILS</code> can use this form.
+            Password sign-in is off here. Only instance administrators can use this form.
           </p>
         </div>
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -190,16 +190,32 @@ onMounted(async () => {
           </div>
         </div>
 
-        <Button
-          v-if="sso.enabled"
-          type="button"
-          variant="outline"
-          class="w-full h-12 min-h-[44px] text-base"
-          @click="startSso"
-        >
-          <KeyRound class="w-4 h-4 mr-1" />
-          {{ sso.button_label }}
-        </Button>
+        <div :class="sso.password_login_enabled ? '' : 'py-6 space-y-4'">
+          <p
+            v-if="!sso.password_login_enabled"
+            class="text-sm text-muted-foreground text-center"
+          >
+            This workspace signs in through your identity provider.
+          </p>
+
+          <Button
+            v-if="sso.enabled"
+            type="button"
+            variant="outline"
+            class="w-full h-12 min-h-[44px] text-base"
+            @click="startSso"
+          >
+            <KeyRound class="w-4 h-4 mr-1" />
+            {{ sso.button_label }}
+          </Button>
+
+          <p
+            v-if="!sso.password_login_enabled"
+            class="text-xs text-muted-foreground text-center"
+          >
+            Trouble signing in? Ask an instance administrator.
+          </p>
+        </div>
 
         <div
           v-if="sso.password_login_enabled"

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -99,14 +99,14 @@ onMounted(async () => {
     <!-- Workflow graph background (above blur, below card) -->
     <WorkflowHeroBackground />
 
-    <div class="relative z-10 w-full max-w-full sm:max-w-lg pt-14 sm:pt-16">
+    <div class="relative z-10 w-full max-w-full sm:max-w-md pt-14 sm:pt-16">
       <div class="auth-badge absolute top-0 left-1/2 -translate-x-1/2 flex items-center gap-2 px-5 py-2.5 rounded-full bg-card border border-primary/25 text-primary text-sm font-medium whitespace-nowrap before:absolute before:inset-0 before:rounded-full before:bg-primary/10 before:content-['']">
         <Sparkles class="relative w-4 h-4" />
         <span class="relative">AI Workflow Automation</span>
       </div>
 
-      <Card class="auth-card relative w-full p-7 md:p-9 lg:p-11 animate-scale-in-bounce gradient-border-hover">
-        <div class="flex flex-col items-center mb-10">
+      <Card class="auth-card relative w-full px-6 py-10 md:px-8 md:py-12 lg:px-9 lg:py-14 animate-scale-in-bounce gradient-border-hover">
+        <div class="flex flex-col items-center mb-12">
           <img
             src="/fav.svg"
             alt="Heym"
@@ -208,7 +208,7 @@ onMounted(async () => {
           </div>
         </div>
 
-        <div :class="passwordFormVisible ? '' : 'space-y-5 py-3'">
+        <div :class="passwordFormVisible ? '' : 'space-y-12 py-4'">
           <Button
             v-if="sso.enabled"
             type="button"

--- a/frontend/src/visualcheck.ts
+++ b/frontend/src/visualcheck.ts
@@ -1,0 +1,14 @@
+import { createApp, h } from "vue";
+import { createPinia } from "pinia";
+import { createRouter, createWebHistory } from "vue-router";
+
+import LoginView from "@/views/LoginView.vue";
+
+import "./styles/globals.css";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [{ path: "/:rest(.*)", component: { render: () => null } }],
+});
+
+createApp({ render: () => h(LoginView) }).use(createPinia()).use(router).mount("#app");

--- a/frontend/visualcheck.html
+++ b/frontend/visualcheck.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<html class="dark"><head><meta charset="utf-8" /><title>vc</title></head>
+<body class="bg-background"><div id="app"></div>
+<script type="module" src="/src/visualcheck.ts"></script></body></html>


### PR DESCRIPTION
Implement OIDC SSO with admin configuration and security features

Runtime-configurable OIDC single sign-on, administered from settings.
The identity provider is never named in code — the admin supplies an
issuer URL and discovery derives the rest.

<img width="1699" height="935" alt="Screenshot 2026-08-26 at 9 20 31 PM" src="https://github.com/user-attachments/assets/000c1ac3-c5f2-4af0-abca-27abbe986520" />
