### PR TITLE
Revert qdrant-client bump while keeping check_compatibility=False

### DIFF
--- a/backend/app/services/qdrant_pool.py
+++ b/backend/app/services/qdrant_pool.py
@@ -27,11 +27,13 @@ def get_qdrant_client(
                     host=host,
                     port=port,
                     api_key=api_key,
+                    check_compatibility=False,
                 )
             else:
                 _clients[pool_key] = QdrantClient(
                     host=host,
                     port=port,
+                    check_compatibility=False,
                 )
             logger.info("Qdrant client pool created for: %s:%s", host, port)
 

--- a/backend/app/services/vector_store.py
+++ b/backend/app/services/vector_store.py
@@ -130,11 +130,13 @@ class QdrantVectorStoreService:
                 host=qdrant_host,
                 port=qdrant_port,
                 api_key=qdrant_api_key,
+                check_compatibility=False,
             )
         else:
             self.client = QdrantClient(
                 host=qdrant_host,
                 port=qdrant_port,
+                check_compatibility=False,
             )
         if embedding_config is None:
             embedding_config = EmbeddingConfig(api_key=openai_api_key)


### PR DESCRIPTION
## Change Summary

Revert the qdrant-client version bump while keeping the `check_compatibility=False` suppression.

- `backend/pyproject.toml`: qdrant-client dependency restored to `>=1.17.1` (was `>=1.19.0`).
- `backend/uv.lock`: regenerated/verified against the restored specifier — qdrant-client resolves to `1.17.1` with `specifier = ">=1.17.1"`; `uv lock --check` confirms lockfile consistency.
- `backend/app/services/qdrant_pool.py` and `backend/app/services/vector_store.py`: kept `check_compatibility=False` on every `QdrantClient(...)` construction so the startup UserWarning remains suppressed on the older client version.

No UI changes; no screenshots needed.