### PR TITLE
fix/timeline-realtime-view

### DIFF
--- a/backend/alembic/versions/121_add_running_node_start_times.py
+++ b/backend/alembic/versions/121_add_running_node_start_times.py
@@ -1,0 +1,34 @@
+"""persist active running-node start timestamps for live timelines
+
+Revision ID: 121_running_node_start_times
+Revises: 120_queue_chart_return
+Create Date: 2026-08-29 20:34:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "121_running_node_start_times"
+down_revision: Union[str, None] = "120_queue_chart_return"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "active_workflow_executions",
+        sa.Column(
+            "running_node_started_at_ms",
+            sa.JSON(),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("active_workflow_executions", "running_node_started_at_ms")

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import secrets
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -503,6 +504,7 @@ async def portal_execute_stream(
                     {
                         "type": "execution_started",
                         "execution_id": str(execution_id),
+                        "server_now_ms": time.time() * 1000,
                     }
                 )
                 + "\n\n"

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import json
 import logging
+import time
 import uuid
 from collections.abc import Coroutine, Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -1205,6 +1206,7 @@ async def stream_active_workflow_execution(
 
         def derived_catch_up_frames(
             running_node_ids: list[str],
+            running_node_started_at_ms: dict[str, float],
             node_results: list[dict],
         ) -> Iterator[str]:
             """Rebuild node lifecycle frames from a coarse progress snapshot."""
@@ -1214,7 +1216,11 @@ async def stream_active_workflow_execution(
             emitted_result_count = max(emitted_result_count, len(node_results))
             current_running_node_ids = set(running_node_ids)
             for node_id in sorted(current_running_node_ids - emitted_running_node_ids):
-                yield "data: " + json.dumps({"type": "node_start", "node_id": node_id}) + "\n\n"
+                event: dict[str, str | float] = {"type": "node_start", "node_id": node_id}
+                started_at_ms = running_node_started_at_ms.get(node_id)
+                if isinstance(started_at_ms, (int, float)) and not isinstance(started_at_ms, bool):
+                    event["started_at_ms"] = float(started_at_ms)
+                yield "data: " + json.dumps(event) + "\n\n"
             emitted_running_node_ids = current_running_node_ids
 
         yield (
@@ -1224,6 +1230,7 @@ async def stream_active_workflow_execution(
                     "type": "execution_started",
                     "execution_id": str(execution_id),
                     "inputs": initial_inputs,
+                    "server_now_ms": time.time() * 1000,
                 }
             )
             + "\n\n"
@@ -1234,6 +1241,7 @@ async def stream_active_workflow_execution(
                 break
 
             running_node_ids: list[str] = []
+            running_node_started_at_ms: dict[str, float] = {}
             node_results: list[dict] = []
             active_found = False
 
@@ -1257,6 +1265,7 @@ async def stream_active_workflow_execution(
                         # the catch-up, then follow the live events from here on.
                         for frame in derived_catch_up_frames(
                             snapshot.running_node_ids,
+                            snapshot.running_node_started_at_ms,
                             snapshot.node_results,
                         ):
                             yield frame
@@ -1288,6 +1297,7 @@ async def stream_active_workflow_execution(
             if snapshot is not None:
                 active_found = True
                 running_node_ids = snapshot.running_node_ids
+                running_node_started_at_ms = snapshot.running_node_started_at_ms
                 node_results = snapshot.node_results
             else:
                 completed_result = get_completed_execution_result(
@@ -1309,6 +1319,7 @@ async def stream_active_workflow_execution(
                 if active is not None:
                     active_found = True
                     running_node_ids = list(active.running_node_ids or [])
+                    running_node_started_at_ms = dict(active.running_node_started_at_ms or {})
                     node_results = list(active.node_results or [])
 
             if active_found:
@@ -1317,7 +1328,11 @@ async def stream_active_workflow_execution(
                 # Once the runner's own events have been streamed, never fall back to the
                 # coarse snapshot: its node results were already emitted as live events.
                 if stream_mode == "derived":
-                    for frame in derived_catch_up_frames(running_node_ids, node_results):
+                    for frame in derived_catch_up_frames(
+                        running_node_ids,
+                        running_node_started_at_ms,
+                        node_results,
+                    ):
                         yield frame
                         emitted_event = True
                 now = loop.time()
@@ -3922,6 +3937,7 @@ async def execute_workflow_stream(
                     {
                         "type": "execution_started",
                         "execution_id": str(execution_id),
+                        "server_now_ms": time.time() * 1000,
                     }
                 )
                 + "\n\n"

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -613,6 +613,7 @@ class ActiveWorkflowExecution(Base):
     )
     inputs: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
     running_node_ids: Mapped[list] = mapped_column(JSON, default=list, nullable=False)
+    running_node_started_at_ms: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
     node_results: Mapped[list] = mapped_column(JSON, default=list, nullable=False)
     trigger_source: Mapped[str | None] = mapped_column(String(50), nullable=True)
     actor_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/backend/app/services/execution_cancellation.py
+++ b/backend/app/services/execution_cancellation.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import json
 import logging
+import math
 import os
 import queue
 import socket
@@ -74,6 +75,7 @@ class ExecutionCancellationHandle:
     actor_user_id: uuid.UUID | None = None
     recoverable: bool = True
     running_node_ids: set[str] = field(default_factory=set)
+    running_node_started_at_ms: dict[str, float] = field(default_factory=dict)
     node_results: list[dict[str, Any]] = field(default_factory=list)
     progress_version: int = 0
     synced_progress_version: int = 0
@@ -90,6 +92,7 @@ class ActiveExecutionStreamSnapshot:
 
     publishes_progress_events: bool
     running_node_ids: list[str]
+    running_node_started_at_ms: dict[str, float]
     node_results: list[dict[str, Any]]
     events: list[str]
     next_event_seq: int
@@ -274,12 +277,24 @@ def get_active_execution_inputs(
         return dict(handle.inputs)
 
 
-def record_execution_node_started(execution_id: str, node_id: str) -> None:
+def record_execution_node_started(
+    execution_id: str,
+    node_id: str,
+    *,
+    started_at_ms: float | None = None,
+) -> None:
     """Record a node start in the cross-worker live execution snapshot."""
     try:
         parsed_execution_id = uuid.UUID(str(execution_id))
     except (TypeError, ValueError):
         return
+
+    if (
+        isinstance(started_at_ms, bool)
+        or not isinstance(started_at_ms, (int, float))
+        or not math.isfinite(started_at_ms)
+    ):
+        started_at_ms = time.time() * 1000
 
     with _LOCK:
         handle = _ACTIVE_EXECUTIONS.get(parsed_execution_id)
@@ -288,6 +303,10 @@ def record_execution_node_started(execution_id: str, node_id: str) -> None:
         normalized_node_id = str(node_id)
         if normalized_node_id not in handle.running_node_ids:
             handle.running_node_ids.add(normalized_node_id)
+            handle.running_node_started_at_ms[normalized_node_id] = float(started_at_ms)
+            handle.progress_version += 1
+        elif normalized_node_id not in handle.running_node_started_at_ms:
+            handle.running_node_started_at_ms[normalized_node_id] = float(started_at_ms)
             handle.progress_version += 1
 
 
@@ -307,6 +326,7 @@ def record_execution_node_completed(
         if handle is None:
             return
         handle.running_node_ids.discard(str(node_id))
+        handle.running_node_started_at_ms.pop(str(node_id), None)
         handle.node_results.append(node_result)
         handle.progress_version += 1
 
@@ -394,6 +414,7 @@ def get_active_execution_stream_snapshot(
         return ActiveExecutionStreamSnapshot(
             publishes_progress_events=handle.publishes_progress_events,
             running_node_ids=sorted(handle.running_node_ids),
+            running_node_started_at_ms=dict(handle.running_node_started_at_ms),
             node_results=list(handle.node_results),
             events=[payload for _seq, payload in handle.progress_events],
             next_event_seq=handle.next_progress_event_seq,
@@ -491,6 +512,7 @@ def _build_active_execution_upsert(
     actor_user_id: uuid.UUID | None,
     recoverable: bool,
     running_node_ids: list[str],
+    running_node_started_at_ms: dict[str, float],
     node_results: list[dict[str, Any]],
 ) -> Any:
     """Insert-or-refresh one active execution row.
@@ -513,6 +535,7 @@ def _build_active_execution_upsert(
         "trigger_source": trigger_source,
         "actor_user_id": actor_user_id,
         "running_node_ids": running_node_ids,
+        "running_node_started_at_ms": running_node_started_at_ms,
         "node_results": node_results,
     }
     return (
@@ -637,6 +660,7 @@ class ActiveExecutionRegistry:
                 actor_user_id=command.actor_user_id,
                 recoverable=command.recoverable,
                 running_node_ids=[],
+                running_node_started_at_ms={},
                 node_results=[],
             )
         )
@@ -730,6 +754,7 @@ class ActiveExecutionRegistry:
             if _ACTIVE_EXECUTIONS.get(execution_id) is not handle:
                 return None
             running_node_ids = sorted(handle.running_node_ids)
+            running_node_started_at_ms = dict(handle.running_node_started_at_ms)
             node_results = list(handle.node_results)
             version = handle.progress_version
         await session.execute(
@@ -743,6 +768,7 @@ class ActiveExecutionRegistry:
                 actor_user_id=handle.actor_user_id,
                 recoverable=handle.recoverable,
                 running_node_ids=running_node_ids,
+                running_node_started_at_ms=running_node_started_at_ms,
                 node_results=node_results,
             )
         )
@@ -763,7 +789,14 @@ class ActiveExecutionRegistry:
         execution_ids = list(handles_by_id)
         progress_snapshots: dict[
             uuid.UUID,
-            tuple[ExecutionCancellationHandle, list[str], list[dict[str, Any]], int, bool],
+            tuple[
+                ExecutionCancellationHandle,
+                list[str],
+                dict[str, float],
+                list[dict[str, Any]],
+                int,
+                bool,
+            ],
         ] = {}
         with _LOCK:
             for execution_id, listed_handle in handles_by_id.items():
@@ -776,6 +809,7 @@ class ActiveExecutionRegistry:
                 progress_snapshots[execution_id] = (
                     current_handle,
                     sorted(current_handle.running_node_ids) if progress_changed else [],
+                    dict(current_handle.running_node_started_at_ms) if progress_changed else {},
                     list(current_handle.node_results) if progress_changed else [],
                     current_handle.progress_version,
                     progress_changed,
@@ -801,7 +835,14 @@ class ActiveExecutionRegistry:
                 self._failures.success("cancel poll")
 
             for execution_id, snapshot in progress_snapshots.items():
-                handle, running_node_ids, node_results, version, progress_changed = snapshot
+                (
+                    handle,
+                    running_node_ids,
+                    running_node_started_at_ms,
+                    node_results,
+                    version,
+                    progress_changed,
+                ) = snapshot
                 update_values: dict[str, Any] = {
                     "heartbeat_at": now,
                     "worker_id": _WORKER_ID,
@@ -809,6 +850,7 @@ class ActiveExecutionRegistry:
                 if progress_changed:
                     update_values.update(
                         running_node_ids=running_node_ids,
+                        running_node_started_at_ms=running_node_started_at_ms,
                         node_results=node_results,
                     )
                 # Each row gets its own savepoint: a single unwritable row (a corrupt

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -1779,6 +1779,24 @@ def _serialize_node_results(results: list[NodeResult]) -> list[dict]:
     return [_serialize_node_result(result) for result in results]
 
 
+def _build_node_start_event(
+    node_id: str,
+    node_label: str,
+    *,
+    message: str | None = None,
+) -> dict[str, object]:
+    """Build a node-start event with the timeline's authoritative wall-clock anchor."""
+    event: dict[str, object] = {
+        "type": "node_start",
+        "node_id": node_id,
+        "node_label": node_label,
+        "started_at_ms": time.time() * 1000,
+    }
+    if message is not None:
+        event["message"] = message
+    return event
+
+
 def _build_node_complete_event(result: NodeResult, output: dict | None = None) -> dict:
     output_payload = result.output if output is None else output
     return {
@@ -2006,10 +2024,16 @@ class WorkflowExecutor:
                 if label in sub_agent_labels:
                     self.skipped_nodes.add(node_id)
 
+        # Orphan outputs are skipped when other executable nodes exist (disconnected
+        # terminals). A lone output on the canvas — sticky notes aside — still runs so a
+        # static message workflow works without an upstream node.
+        executable_node_count = sum(
+            1 for node in self.nodes.values() if node.get("type") != "sticky"
+        )
         for node_id, node in self.nodes.items():
             if node.get("type") == "output":
                 has_input = any(edge["target"] == node_id for edge in self.edges)
-                if not has_input:
+                if not has_input and executable_node_count > 1:
                     self.skipped_nodes.add(node_id)
 
     def _get_accessible_credential(self, db, credential_id: object):
@@ -3706,11 +3730,7 @@ class WorkflowExecutor:
         sub_agent_label_display = target_node_data.get("label", sub_agent_label)
         if self.agent_progress_queue is not None:
             self.agent_progress_queue.put(
-                {
-                    "type": "node_start",
-                    "node_id": target_node_id,
-                    "node_label": sub_agent_label_display,
-                }
+                _build_node_start_event(target_node_id, sub_agent_label_display)
             )
         start_ms = time.time() * 1000
         try:
@@ -4736,7 +4756,7 @@ class WorkflowExecutor:
         node_label = original_data.get("label", node_id)
         _queue = getattr(self, "agent_progress_queue", None)
         if _queue is not None:
-            _queue.put({"type": "node_start", "node_id": node_id, "node_label": node_label})
+            _queue.put(_build_node_start_event(node_id, node_label))
 
         node["data"] = merged_data
         try:
@@ -8479,13 +8499,7 @@ def execute_llm_batch_notification_branch(
         if agent_progress_queue is None:
             return
         node_label = wf_executor.get_node_label(node_id)
-        agent_progress_queue.put(
-            {
-                "type": "node_start",
-                "node_id": node_id,
-                "node_label": node_label,
-            }
-        )
+        agent_progress_queue.put(_build_node_start_event(node_id, node_label))
 
     def _submit_node(node_id: str, node_inputs: dict | None = None) -> None:
         already_running = any(
@@ -8906,11 +8920,7 @@ def _execute_error_flow_streaming(
                             queue.append(target)
             continue
 
-        yield {
-            "type": "node_start",
-            "node_id": node_id,
-            "node_label": node_label,
-        }
+        yield _build_node_start_event(node_id, node_label)
 
         if node_type == "errorHandler":
             inputs = {"error": error_payload}
@@ -9166,14 +9176,12 @@ def _execute_workflow_streaming_impl(
         node = wf_executor.nodes[node_id]
         node_label = node.get("data", {}).get("label", node_id)
 
-        node_start_event: dict[str, object] = {
-            "type": "node_start",
-            "node_id": node_id,
-            "node_label": node_label,
-        }
         start_message = build_node_start_message(node_id, node_label, sse_node_config)
-        if start_message is not None:
-            node_start_event["message"] = start_message
+        node_start_event = _build_node_start_event(
+            node_id,
+            node_label,
+            message=start_message,
+        )
         event_queue.put(node_start_event)
 
         if node_inputs is None:

--- a/backend/tests/test_active_executions_api.py
+++ b/backend/tests/test_active_executions_api.py
@@ -390,6 +390,27 @@ class LiveExecutionSnapshotTests(unittest.IsolatedAsyncioTestCase):
         finally:
             clear_execution(execution_id)
 
+    def test_preserves_running_node_start_time_for_live_observers(self) -> None:
+        workflow_id = uuid.uuid4()
+        execution_id = uuid.uuid4()
+        register_execution(workflow_id=workflow_id, execution_id=execution_id)
+        try:
+            record_execution_node_started(
+                str(execution_id),
+                "node-1",
+                started_at_ms=1_000.0,
+            )
+
+            snapshot = get_active_execution_stream_snapshot(
+                execution_id,
+                workflow_id=workflow_id,
+            )
+
+            self.assertIsNotNone(snapshot)
+            self.assertEqual(snapshot.running_node_started_at_ms, {"node-1": 1_000.0})
+        finally:
+            clear_execution(execution_id)
+
     async def test_registry_writes_progress_only_after_node_state_changes(self) -> None:
         workflow_id = uuid.uuid4()
         execution_id = uuid.uuid4()
@@ -456,7 +477,11 @@ class LiveExecutionSnapshotTests(unittest.IsolatedAsyncioTestCase):
                 "error": None,
             },
         )
-        record_execution_node_started(str(execution_id), "wait")
+        record_execution_node_started(
+            str(execution_id),
+            "wait",
+            started_at_ms=1_000.0,
+        )
 
         workflow = MagicMock()
         workflow.id = workflow_id
@@ -487,10 +512,13 @@ class LiveExecutionSnapshotTests(unittest.IsolatedAsyncioTestCase):
 
             self.assertIn('"type": "execution_started"', started)
             self.assertIn('"inputs": {"text": "live input"}', started)
+            started_payload = json.loads(started.removeprefix("data: "))
+            self.assertIsInstance(started_payload.get("server_now_ms"), float)
             self.assertIn('"type": "node_complete"', completed)
             self.assertIn('"message": "hello"', completed)
             self.assertIn('"type": "node_start"', running)
             self.assertIn('"node_id": "wait"', running)
+            self.assertIn('"started_at_ms": 1000.0', running)
         finally:
             clear_execution(execution_id)
 

--- a/backend/tests/test_alembic_migrations.py
+++ b/backend/tests/test_alembic_migrations.py
@@ -15,7 +15,7 @@ class AlembicMigrationGraphTest(unittest.TestCase):
         self.script = ScriptDirectory.from_config(config)
 
     def test_revision_graph_has_one_head(self) -> None:
-        self.assertEqual(self.script.get_heads(), ["120_queue_chart_return"])
+        self.assertEqual(self.script.get_heads(), ["121_running_node_start_times"])
 
     def test_folder_icon_revision_follows_oauth_token_hashes(self) -> None:
         folder_icon_revision = self.script.get_revision("112_add_folder_icon")

--- a/backend/tests/test_orphan_output_skip.py
+++ b/backend/tests/test_orphan_output_skip.py
@@ -1,0 +1,64 @@
+"""Orphan output nodes: skip only when other executable nodes exist on the canvas."""
+
+import unittest
+import uuid
+
+from app.services.workflow_executor import WorkflowExecutor
+
+
+class TestOrphanOutputSkip(unittest.TestCase):
+    def test_solo_output_without_incoming_edge_is_not_skipped(self) -> None:
+        nodes = [
+            {
+                "id": "out1",
+                "type": "output",
+                "data": {"label": "out", "message": "hi"},
+            },
+        ]
+        executor = WorkflowExecutor(nodes=nodes, edges=[])
+        result = executor.execute(
+            workflow_id=uuid.uuid4(),
+            initial_inputs={"headers": {}, "query": {}, "body": {}},
+        )
+        self.assertNotIn("out1", executor.skipped_nodes)
+        by_id = {nr["node_id"]: nr for nr in result.node_results}
+        self.assertEqual(by_id["out1"]["status"], "success")
+        self.assertEqual(by_id["out1"]["output"], {"result": "hi"})
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.outputs, {"out": {"result": "hi"}})
+
+    def test_solo_output_with_sticky_note_is_not_skipped(self) -> None:
+        nodes = [
+            {
+                "id": "out1",
+                "type": "output",
+                "data": {"label": "out", "message": "hi"},
+            },
+            {
+                "id": "note1",
+                "type": "sticky",
+                "data": {"label": "note", "text": "reminder"},
+            },
+        ]
+        executor = WorkflowExecutor(nodes=nodes, edges=[])
+        self.assertNotIn("out1", executor.skipped_nodes)
+
+    def test_orphan_output_with_sibling_node_is_skipped(self) -> None:
+        nodes = [
+            {
+                "id": "in1",
+                "type": "textInput",
+                "data": {"label": "userInput", "inputFields": [{"key": "text"}]},
+            },
+            {
+                "id": "out1",
+                "type": "output",
+                "data": {"label": "out", "message": "hi"},
+            },
+        ]
+        executor = WorkflowExecutor(nodes=nodes, edges=[])
+        self.assertIn("out1", executor.skipped_nodes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_sse_streaming.py
+++ b/backend/tests/test_sse_streaming.py
@@ -213,6 +213,7 @@ class ExecuteWorkflowStreamingSseTests(unittest.TestCase):
 
         node_start = next(event for event in events if event.get("type") == "node_start")
         self.assertEqual(node_start.get("message"), "[START] LLM")
+        self.assertIsInstance(node_start.get("started_at_ms"), float)
 
     def test_node_start_no_message_when_send_start_false(self) -> None:
         events = self._collect_events({"node-1": {"send_start": False, "start_message": None}})

--- a/frontend/src/components/Panels/DebugPanel.vue
+++ b/frontend/src/components/Panels/DebugPanel.vue
@@ -2815,7 +2815,7 @@ function renderContent(content: string): string {
           <Download class="w-3.5 h-3.5" />
         </Button>
         <Button
-          v-if="executionResult || nodeResults.length > 0"
+          v-if="isExecuting || executionResult || nodeResults.length > 0"
           :variant="showTimeline ? 'secondary' : 'ghost'"
           size="icon"
           class="h-11 w-11 min-h-[44px] min-w-[44px] md:h-7 md:w-7"
@@ -3654,6 +3654,7 @@ function renderContent(content: string): string {
       :node-results="timelineResults"
       :total-time-ms="executionResult?.execution_time_ms ?? 0"
       :sub-agent-label-to-parent-id="subAgentLabelToParentId"
+      :server-clock-offset-ms="workflowStore.serverClockOffsetMs"
       @select-node="selectCanvasNodeFromTimeline"
     />
 

--- a/frontend/src/components/Panels/ExecutionSpanDetails.test.ts
+++ b/frontend/src/components/Panels/ExecutionSpanDetails.test.ts
@@ -16,7 +16,9 @@ describe("execution span details", () => {
       source.indexOf('title="Execution timeline"'),
     );
 
-    expect(timelineButton).toContain('v-if="executionResult || nodeResults.length > 0"');
+    expect(timelineButton).toContain(
+      'v-if="isExecuting || executionResult || nodeResults.length > 0"',
+    );
     expect(timelineButton).not.toContain("!isExecuting");
   });
 });

--- a/frontend/src/components/Panels/ExecutionTimeline.vue
+++ b/frontend/src/components/Panels/ExecutionTimeline.vue
@@ -13,6 +13,7 @@ import {
   buildTimelineModel,
   formatTimelineMs,
   getTimelineRowKey,
+  getServerAlignedNowMs,
   LIVE_TIMELINE_REFRESH_INTERVAL_MS,
   summarizeTimelineModel,
 } from "@/components/Panels/executionTimeline";
@@ -22,6 +23,7 @@ interface Props {
   nodeResults: TimelineEntry[];
   totalTimeMs: number;
   subAgentLabelToParentId: Map<string, string>;
+  serverClockOffsetMs?: number;
 }
 
 const props = defineProps<Props>();
@@ -79,7 +81,24 @@ function onRowLabelClick(row: SpanRow, event: MouseEvent): void {
   emitSelectNode({ nodeId: row.nodeId, resultListIndex: null }, event);
 }
 
-const timelineNowMs = ref(Date.now());
+let timelineClockOffsetMs = props.serverClockOffsetMs ?? 0;
+let timelineClockAnchorMs = getServerAlignedNowMs(Date.now(), timelineClockOffsetMs);
+let timelineClockMonotonicAnchorMs = performance.now();
+
+function synchronizeTimelineClock(): void {
+  timelineClockOffsetMs = props.serverClockOffsetMs ?? 0;
+  timelineClockAnchorMs = getServerAlignedNowMs(Date.now(), timelineClockOffsetMs);
+  timelineClockMonotonicAnchorMs = performance.now();
+}
+
+function getTimelineNowMs(): number {
+  if (timelineClockOffsetMs !== (props.serverClockOffsetMs ?? 0)) {
+    synchronizeTimelineClock();
+  }
+  return timelineClockAnchorMs + (performance.now() - timelineClockMonotonicAnchorMs);
+}
+
+const timelineNowMs = ref(getTimelineNowMs());
 let timelineNowTimer: ReturnType<typeof setInterval> | null = null;
 
 const hasLiveHitlWait = computed(() =>
@@ -101,10 +120,10 @@ const hasLiveTimelineSpan = computed(
 
 function syncTimelineNowTimer(): void {
   if (hasLiveTimelineSpan.value) {
-    timelineNowMs.value = Date.now();
+    timelineNowMs.value = getTimelineNowMs();
     if (timelineNowTimer === null) {
       timelineNowTimer = setInterval(() => {
-        timelineNowMs.value = Date.now();
+        timelineNowMs.value = getTimelineNowMs();
       }, LIVE_TIMELINE_REFRESH_INTERVAL_MS);
     }
     return;
@@ -129,6 +148,13 @@ onBeforeUnmount(() => {
 watch(hasLiveTimelineSpan, () => {
   syncTimelineNowTimer();
 });
+watch(
+  () => props.serverClockOffsetMs,
+  () => {
+    synchronizeTimelineClock();
+    timelineNowMs.value = getTimelineNowMs();
+  },
+);
 
 const fullTimelineModel = computed(() =>
   buildTimelineModel(

--- a/frontend/src/components/Panels/executionTimeline.test.ts
+++ b/frontend/src/components/Panels/executionTimeline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { TimelineEntry } from "@/components/Panels/executionTimeline";
+import * as executionTimeline from "@/components/Panels/executionTimeline";
 import {
   buildTimelineModel,
   LIVE_TIMELINE_REFRESH_INTERVAL_MS,
@@ -148,6 +149,16 @@ describe("buildTimelineModel HITL wait spans", () => {
 });
 
 describe("buildTimelineModel running spans", () => {
+  it("aligns a client clock ahead by one hour with the server clock", () => {
+    const alignNow = (
+      executionTimeline as typeof executionTimeline & {
+        getServerAlignedNowMs?: (clientNowMs: number, serverClockOffsetMs: number) => number;
+      }
+    ).getServerAlignedNowMs;
+
+    expect(alignNow?.(3_601_000, -3_600_000)).toBe(1_000);
+  });
+
   it("extends an open running span to the current timeline time", () => {
     const results: TimelineEntry[] = [
       entry({

--- a/frontend/src/components/Panels/executionTimeline.ts
+++ b/frontend/src/components/Panels/executionTimeline.ts
@@ -120,6 +120,14 @@ const GC_PAUSE_DISPLAY_MIN_MS = 20;
 /** Refresh open running spans while the execution timeline is visible. */
 export const LIVE_TIMELINE_REFRESH_INTERVAL_MS = 50;
 
+/** Convert the browser clock into the server's wall-clock domain for live spans. */
+export function getServerAlignedNowMs(clientNowMs: number, serverClockOffsetMs: number): number {
+  if (!Number.isFinite(clientNowMs) || !Number.isFinite(serverClockOffsetMs)) {
+    return clientNowMs;
+  }
+  return clientNowMs + serverClockOffsetMs;
+}
+
 function nodeColorVar(nodeType: string): string {
   const def = NODE_DEFINITIONS[nodeType as NodeType];
   return def?.color ?? "primary";

--- a/frontend/src/docs/content/reference/sse-streaming.md
+++ b/frontend/src/docs/content/reference/sse-streaming.md
@@ -25,8 +25,8 @@ Each SSE frame is newline-delimited JSON prefixed with `data: `.
 
 | Event type | When it is emitted | Key fields |
 |------------|--------------------|------------|
-| `execution_started` | Immediately after the request is accepted | `execution_id` |
-| `node_start` | Right before a node begins execution | `node_id`, `node_label`, optional `message` |
+| `execution_started` | Immediately after the request is accepted | `execution_id`, `server_now_ms` |
+| `node_start` | Right before a node begins execution | `node_id`, `node_label`, `started_at_ms`, optional `message` |
 | `node_retry` | When a node retries | `node_id`, `attempt`, `max_attempts` |
 | `node_complete` | After a node finishes | `node_id`, `node_label`, `status`, `output`, `execution_time_ms` |
 | `final_output` | When an Output node returns early | `node_label`, `output` |
@@ -70,9 +70,9 @@ curl -X POST --no-buffer \
 Sample event stream:
 
 ```text
-data: {"type":"execution_started","execution_id":"..."}
+data: {"type":"execution_started","execution_id":"...","server_now_ms":1735660800000}
 
-data: {"type":"node_start","node_id":"...","node_label":"LLM","message":"[START] LLM"}
+data: {"type":"node_start","node_id":"...","node_label":"LLM","started_at_ms":1735660800000,"message":"[START] LLM"}
 
 data: {"type":"node_complete","node_id":"...","node_label":"LLM","status":"success","output":{"text":"Hello world"},"execution_time_ms":312}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -726,8 +726,9 @@ export const workflowApi = {
     onExecutionStarted: (data: {
       execution_id: string;
       inputs: Record<string, unknown>;
+      server_now_ms?: number;
     }) => void,
-    onNodeStart: (nodeId: string) => void,
+    onNodeStart: (data: { node_id: string; started_at_ms?: number }) => void,
     onNodeComplete: (data: {
       node_id: string;
       node_label?: string;
@@ -792,9 +793,15 @@ export const workflowApi = {
                   data.inputs && typeof data.inputs === "object" && !Array.isArray(data.inputs)
                     ? data.inputs
                     : {},
+                server_now_ms:
+                  typeof data.server_now_ms === "number" ? data.server_now_ms : undefined,
               });
             } else if (data.type === "node_start") {
-              onNodeStart(data.node_id);
+              onNodeStart({
+                node_id: data.node_id,
+                started_at_ms:
+                  typeof data.started_at_ms === "number" ? data.started_at_ms : undefined,
+              });
             } else if (data.type === "node_retry" && onNodeRetry) {
               onNodeRetry(data);
             } else if (data.type === "agent_progress" && onAgentProgress) {
@@ -935,8 +942,8 @@ export const workflowApi = {
   executeStream: (
     id: string,
     body: unknown,
-    onExecutionStarted: (data: { execution_id: string }) => void,
-    onNodeStart: (nodeId: string) => void,
+    onExecutionStarted: (data: { execution_id: string; server_now_ms?: number }) => void,
+    onNodeStart: (data: { node_id: string; started_at_ms?: number }) => void,
     onNodeComplete: (data: {
       node_id: string;
       node_label?: string;
@@ -1014,9 +1021,17 @@ export const workflowApi = {
               const data = JSON.parse(line.slice(6));
 
               if (data.type === "execution_started") {
-                onExecutionStarted({ execution_id: data.execution_id });
+                onExecutionStarted({
+                  execution_id: data.execution_id,
+                  server_now_ms:
+                    typeof data.server_now_ms === "number" ? data.server_now_ms : undefined,
+                });
               } else if (data.type === "node_start") {
-                onNodeStart(data.node_id);
+                onNodeStart({
+                  node_id: data.node_id,
+                  started_at_ms:
+                    typeof data.started_at_ms === "number" ? data.started_at_ms : undefined,
+                });
               } else if (data.type === "node_retry" && onNodeRetry) {
                 onNodeRetry(data);
               } else if (data.type === "agent_progress" && onAgentProgress) {

--- a/frontend/src/stores/workflow.test.ts
+++ b/frontend/src/stores/workflow.test.ts
@@ -184,6 +184,70 @@ describe("workflow execution state", () => {
     expect(store.isExecuting).toBe(false);
   });
 
+  it("uses the streamed start timestamp for a running canvas node", async () => {
+    const workflow = makeWorkflow("workflow-a");
+    const getWorkflow = vi.mocked(workflowApi.get);
+    const executeStream = vi.mocked(workflowApi.executeStream);
+    const stream = {
+      started: null as ((data: { execution_id: string; server_now_ms?: number }) => void) | null,
+      nodeStart: null as ((data: { node_id: string; started_at_ms: number }) => void) | null,
+      complete: null as ((result: ExecutionResult) => void) | null,
+    };
+
+    getWorkflow.mockResolvedValue(workflow);
+    executeStream.mockImplementation(
+      (
+        _id,
+        _body,
+        onExecutionStarted,
+        onNodeStart,
+        _onNodeComplete,
+        onComplete,
+      ): void => {
+        stream.started = onExecutionStarted as unknown as typeof stream.started;
+        stream.nodeStart = onNodeStart as unknown as typeof stream.nodeStart;
+        stream.complete = onComplete;
+      },
+    );
+
+    const store = useWorkflowStore();
+    await store.loadWorkflow(workflow.id);
+
+    const execution = store.executeWorkflow({});
+    await vi.waitFor(() => expect(executeStream).toHaveBeenCalledOnce());
+    vi.spyOn(Date, "now").mockReturnValue(3_601_000);
+    stream.started?.({
+      execution_id: "execution-a",
+      server_now_ms: 1_000,
+    });
+    expect(store.serverClockOffsetMs).toBe(-3_600_000);
+    stream.nodeStart?.({
+      node_id: `${workflow.id}-node`,
+      started_at_ms: 1_000,
+    });
+
+    expect(store.nodeResults).toMatchObject([
+      {
+        node_id: `${workflow.id}-node`,
+        status: "running",
+        metadata: {
+          started_at_ms: 1_000,
+          ended_at_ms: 1_000,
+        },
+      },
+    ]);
+
+    stream.complete?.({
+      workflow_id: workflow.id,
+      status: "success",
+      outputs: {},
+      execution_time_ms: 0,
+      node_results: [],
+      highlight: { records: [] },
+    });
+    await execution;
+  });
+
   it("applies the completion of a live execution opened in another tab", async () => {
     const workflow = makeWorkflow("workflow-a");
     const getWorkflow = vi.mocked(workflowApi.get);
@@ -191,6 +255,7 @@ describe("workflow execution state", () => {
     const streamActiveExecution = vi.mocked(workflowApi.streamActiveExecution);
     const stream = {
       started: null as ((data: { execution_id: string; inputs: Record<string, unknown> }) => void) | null,
+      nodeStart: null as ((data: { node_id: string; started_at_ms: number }) => void) | null,
       complete: null as ((result: ExecutionResult) => void) | null,
     };
 
@@ -211,11 +276,12 @@ describe("workflow execution state", () => {
         _workflowId,
         _executionId,
         onExecutionStarted,
-        _onNodeStart,
+        onNodeStart,
         _onNodeComplete,
         onComplete,
       ): void => {
         stream.started = onExecutionStarted;
+        stream.nodeStart = onNodeStart as unknown as typeof stream.nodeStart;
         stream.complete = onComplete;
       },
     );
@@ -226,6 +292,14 @@ describe("workflow execution state", () => {
     const observation = store.observeExecution("execution-a");
     await vi.waitFor(() => expect(streamActiveExecution).toHaveBeenCalledOnce());
     stream.started?.({ execution_id: "execution-a", inputs: {} });
+    stream.nodeStart?.({
+      node_id: `${workflow.id}-node`,
+      started_at_ms: 1_000,
+    });
+    expect(store.nodeResults[0]?.metadata).toMatchObject({
+      started_at_ms: 1_000,
+      ended_at_ms: 1_000,
+    });
     await stream.complete?.({
       workflow_id: workflow.id,
       status: "success",

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -70,6 +70,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
   const currentExecutionWorkflowId = ref<string | null>(null);
   const isExecuting = ref(false);
   const isObservingExecution = ref(false);
+  const serverClockOffsetMs = ref(0);
   const isSaving = ref(false);
   const hasUnsavedChanges = ref(false);
   const workflowLoadedAt = ref<string | null>(null);
@@ -1279,14 +1280,17 @@ export const useWorkflowStore = defineStore("workflow", () => {
     }
   }
 
-  function appendLiveRunningNodeResult(nodeId: string): void {
+  function appendLiveRunningNodeResult(nodeId: string, startedAtMs?: number): void {
     const existingRunningResult = nodeResults.value.some(
       (result) => result.node_id === nodeId && result.status === "running",
     );
     if (existingRunningResult) return;
 
     const node = nodes.value.find((candidate) => candidate.id === nodeId);
-    const startedAtMs = Date.now();
+    const resolvedStartedAtMs =
+      typeof startedAtMs === "number" && Number.isFinite(startedAtMs)
+        ? startedAtMs
+        : Date.now();
     nodeResults.value = [
       ...nodeResults.value,
       {
@@ -1298,11 +1302,18 @@ export const useWorkflowStore = defineStore("workflow", () => {
         execution_time_ms: 0,
         error: null,
         metadata: {
-          started_at_ms: startedAtMs,
-          ended_at_ms: startedAtMs,
+          started_at_ms: resolvedStartedAtMs,
+          ended_at_ms: resolvedStartedAtMs,
         },
       },
     ];
+  }
+
+  function synchronizeServerClock(serverNowMs?: number): void {
+    serverClockOffsetMs.value =
+      typeof serverNowMs === "number" && Number.isFinite(serverNowMs)
+        ? serverNowMs - Date.now()
+        : 0;
   }
 
   function replaceLiveRunningNodeResult(nodeResult: NodeResult): void {
@@ -1449,6 +1460,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     abortController.value = new AbortController();
     const streamAbort = abortController.value;
     currentExecutionId.value = null;
+    serverClockOffsetMs.value = 0;
 
     try {
       nodes.value.forEach((node) => {
@@ -1473,11 +1485,12 @@ export const useWorkflowStore = defineStore("workflow", () => {
           (data) => {
             if (!isActiveExecutionStream(wf.id, streamAbort)) return;
             currentExecutionId.value = data.execution_id;
+            synchronizeServerClock(data.server_now_ms);
           },
-          (nodeId) => {
+          (data) => {
             if (!isActiveExecutionStream(wf.id, streamAbort)) return;
-            setNodeStatus(nodeId, "running");
-            appendLiveRunningNodeResult(nodeId);
+            setNodeStatus(data.node_id, "running");
+            appendLiveRunningNodeResult(data.node_id, data.started_at_ms);
           },
           (data) => {
             if (!isActiveExecutionStream(wf.id, streamAbort)) return;
@@ -1733,6 +1746,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     const streamAbort = abortController.value;
     isExecuting.value = true;
     isObservingExecution.value = true;
+    serverClockOffsetMs.value = 0;
     currentExecutionId.value = executionId;
     currentExecutionWorkflowId.value = workflowId;
     executionResult.value = null;
@@ -1754,6 +1768,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
           executionId,
           (data) => {
             currentExecutionId.value = data.execution_id;
+            synchronizeServerClock(data.server_now_ms);
             loadHistoryInputs(data.inputs);
             nodeResults.value = [];
             // Each (re)connect replays the run's live events from the start, so the
@@ -1763,9 +1778,9 @@ export const useWorkflowStore = defineStore("workflow", () => {
             clearNodeStatuses();
             nodes.value.forEach((node) => setNodeStatus(node.id, "pending"));
           },
-          (nodeId) => {
-            setNodeStatus(nodeId, "running");
-            appendLiveRunningNodeResult(nodeId);
+          (data) => {
+            setNodeStatus(data.node_id, "running");
+            appendLiveRunningNodeResult(data.node_id, data.started_at_ms);
           },
           (data) => {
             setNodeStatus(
@@ -3548,6 +3563,7 @@ export const useWorkflowStore = defineStore("workflow", () => {
     applyExecutionResultSnapshot,
     isExecuting,
     isObservingExecution,
+    serverClockOffsetMs,
     isSaving,
     hasUnsavedChanges,
     runningNodeIds,


### PR DESCRIPTION
Enhance execution event data with timestamps

- Added `server_now_ms` to `execution_started` events in `portal.py`, `workflows.py`, and `execute_workflow_stream` to provide a server-side timestamp.
- Introduced `started_at_ms` in `node_start` events to track when nodes begin execution, updating relevant functions and data structures across multiple files including `execution_cancellation.py`, `workflow_executor.py`, and `models.py`.
- Updated tests to verify the correct handling of these new timestamp fields in both backend and frontend components, ensuring accurate synchronization of execution times.
- Adjusted API interfaces to accommodate the new timestamp parameters for event handling in the workflow execution context.