### PR TITLE
Fix HTTP node dropping expression-supplied headers and URLs

### DIFF
--- a/backend/app/services/node_execution/nodes/http_node.py
+++ b/backend/app/services/node_execution/nodes/http_node.py
@@ -70,16 +70,16 @@ def execute(ctx: NodeExecutionContext) -> object:
     node_data = ctx.node_data
 
     curl_template = node_data.get("curl", "")
-    method, url, headers, body, follow_redirects = self.parse_curl(curl_template)
+
+    def render(text: str) -> str:
+        return self.evaluate_message_template(text, inputs, node_id)
+
+    # Resolve while parsing: an expression can supply a whole header line or the
+    # whole URL, and parsing the raw template would drop it. The body is left raw
+    # so it can be rendered JSON-aware below.
+    method, url, headers, body, follow_redirects = self.parse_curl(curl_template, resolve=render)
     if not url:
         raise ValueError("HTTP node requires a URL")
-    url = self.evaluate_message_template(url, inputs, node_id)
-    headers = {
-        self.evaluate_message_template(key, inputs, node_id): self.evaluate_message_template(
-            value, inputs, node_id
-        )
-        for key, value in headers.items()
-    }
     # Refuse targets that resolve to internal/metadata addresses before dialing
     # (SSRF, GHSA-8wj7-v2w6-wfcx). The guarded client additionally pins the
     # resolved IP so redirects and DNS rebinding cannot reach internal hosts.

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -6579,13 +6579,30 @@ class WorkflowExecutor:
             except ValueError:
                 raise original_error from None
 
-    def parse_curl(self, curl_command: str) -> tuple[str, str, dict[str, str], str | None, bool]:
+    def parse_curl(
+        self,
+        curl_command: str,
+        resolve: Callable[[str], str] | None = None,
+    ) -> tuple[str, str, dict[str, str], str | None, bool]:
+        """Parse a curl DSL command into its request parts.
+
+        ``resolve`` renders ``$…`` spans in every token except the ``-d`` payload,
+        which callers render themselves so JSON bodies keep their types. It must be
+        applied before the token is interpreted: a header-type credential resolves to
+        a whole ``key: value`` line and a URL can come entirely from an expression,
+        so parsing the raw template would drop the header and lose the URL.
+        """
         if not curl_command:
             return "GET", "", {}, None, False
         normalized_cmd = curl_command.replace("\\\n", " ").replace("\\\r\n", " ")
         tokens = self._split_curl_tokens(normalized_cmd)
         if tokens and tokens[0].lower() == "curl":
             tokens = tokens[1:]
+
+        def rendered(token: str) -> str:
+            if resolve is None or "$" not in token:
+                return token
+            return resolve(token)
 
         method = "GET"
         headers: dict[str, str] = {}
@@ -6597,10 +6614,10 @@ class WorkflowExecutor:
             token = tokens[i]
             if token in ("-X", "--request") and i + 1 < len(tokens):
                 i += 1
-                method = tokens[i].upper()
+                method = rendered(tokens[i]).upper()
             elif token in ("-H", "--header") and i + 1 < len(tokens):
                 i += 1
-                header = tokens[i]
+                header = rendered(tokens[i])
                 if ":" in header:
                     key, value = header.split(":", 1)
                     headers[key.strip()] = value.strip()
@@ -6619,15 +6636,20 @@ class WorkflowExecutor:
                     method = "POST"
             elif token == "--url" and i + 1 < len(tokens):
                 i += 1
-                url = tokens[i]
-            elif token.startswith("http://") or token.startswith("https://"):
-                url = token
+                url = rendered(tokens[i])
+            elif not token.startswith("-"):
+                candidate = rendered(token)
+                if candidate.startswith(("http://", "https://")):
+                    url = candidate
             i += 1
 
         if not url:
             for token in reversed(tokens):
-                if token.startswith("http://") or token.startswith("https://"):
-                    url = token
+                if token is data:
+                    continue
+                candidate = rendered(token)
+                if candidate.startswith(("http://", "https://")):
+                    url = candidate
                     break
 
         return method, url, headers, data, follow_redirects

--- a/backend/tests/test_http_node_curl_expressions.py
+++ b/backend/tests/test_http_node_curl_expressions.py
@@ -1,0 +1,107 @@
+"""Regression tests for expressions that shape the parsed curl command.
+
+Expressions may supply a whole header line (`-H "$credentials.Name"` with a
+header-type credential resolving to `key: value`) or a whole URL. Those spans
+have to be resolved before the curl tokens are interpreted, otherwise the
+header is dropped and the URL is not recognised.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import httpx
+
+from app.services.node_execution.base import NodeExecutionContext
+from app.services.node_execution.nodes import http_node
+from app.services.workflow_executor import WorkflowExecutor
+
+
+def _run_curl(
+    curl: str,
+    *,
+    inputs: dict | None = None,
+    credentials: dict[str, str] | None = None,
+) -> httpx.Request:
+    """Execute an http node against a mock transport and return the sent request."""
+    received: list[httpx.Request] = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        received.append(request)
+        return httpx.Response(200, json={"ok": True}, request=request)
+
+    context = NodeExecutionContext(
+        executor=WorkflowExecutor(nodes=[], edges=[], credentials_context=credentials),
+        node_id="http1",
+        inputs=inputs or {},
+        allow_branch_skip=True,
+        start_time=0.0,
+        node={},
+        node_type="http",
+        node_data={"curl": curl},
+        node_label="request",
+    )
+    with httpx.Client(transport=httpx.MockTransport(handle_request)) as client:
+        with (
+            patch("app.services.ssrf_guard.guard_http_url"),
+            patch("app.services.ssrf_guard.get_guarded_http_client", return_value=client),
+        ):
+            http_node.execute(context)
+
+    assert len(received) == 1
+    return received[0]
+
+
+class HttpNodeCurlExpressionTests(unittest.TestCase):
+    """Expressions that contribute curl syntax must survive parsing."""
+
+    def test_header_credential_supplies_whole_header_line(self) -> None:
+        """A header-type credential resolves to `key: value` and must be sent."""
+        curl = (
+            'curl -X GET "https://api.search.brave.com/res/v1/web/search'
+            '?q=$searchQuery.body.text.urlEncode()" '
+            '-H "Accept: application/json" -H "$credentials.brave"'
+        )
+        request = _run_curl(
+            curl,
+            inputs={"searchQuery": {"body": {"text": "ai agent audit log"}}},
+            credentials={"brave": "x-subscription-token: BSA-secret"},
+        )
+
+        self.assertEqual(request.headers["x-subscription-token"], "BSA-secret")
+        self.assertEqual(request.headers["accept"], "application/json")
+        self.assertEqual(
+            str(request.url),
+            "https://api.search.brave.com/res/v1/web/search?q=ai%20agent%20audit%20log",
+        )
+
+    def test_header_value_expression_still_resolves(self) -> None:
+        """The common `Key: $credentials.Name` form keeps working."""
+        request = _run_curl(
+            'curl -X GET https://api.example.com/data -H "Authorization: $credentials.token"',
+            credentials={"token": "Bearer abc123"},
+        )
+
+        self.assertEqual(request.headers["authorization"], "Bearer abc123")
+
+    def test_url_from_expression_is_recognised(self) -> None:
+        """A URL supplied entirely by an expression is not lost during parsing."""
+        request = _run_curl(
+            "curl -X GET $api.base/data",
+            inputs={"api": {"base": "https://api.example.com"}},
+        )
+
+        self.assertEqual(str(request.url), "https://api.example.com/data")
+
+    def test_body_expression_is_resolved_once(self) -> None:
+        """A resolved body value containing a `$` is not resolved a second time."""
+        request = _run_curl(
+            "curl -X POST https://api.example.com/data "
+            "-H 'Content-Type: text/plain' -d '$payload.text'",
+            inputs={"payload": {"text": "price is $total.amount"}},
+        )
+
+        self.assertEqual(request.content.decode("utf-8"), "price is $total.amount")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/docs/content/nodes/http-node.md
+++ b/frontend/src/docs/content/nodes/http-node.md
@@ -47,7 +47,11 @@ The **HTTP** node makes HTTP requests using cURL syntax. It can be a workflow st
 }
 ```
 
-Use cURL syntax with `-H` for headers, `-d` for POST body, etc. Expressions can be used in the curl string for dynamic URLs.
+Use cURL syntax with `-H` for headers, `-d` for POST body, etc. Expressions can be used anywhere in the curl string, including the URL, a header, or a whole header line. A [Header credential](../reference/credentials.md) resolves to `key: value`, so `-H "$credentials.MyApiKey"` sends the complete header:
+
+```
+curl -X GET "https://api.example.com/search?q=$query.body.text.urlEncode()" -H "$credentials.MyApiKey"
+```
 
 ## Egress Safety
 

--- a/frontend/src/docs/content/reference/credentials.md
+++ b/frontend/src/docs/content/reference/credentials.md
@@ -69,6 +69,7 @@ Jira credentials are also excluded from `$credentials`. The [Jira node](../nodes
 | Credential type | Value exposed to `$credentials.Name` |
 |-----------------|--------------------------------------|
 | Bearer | Bearer token string |
+| Header | Complete `header key: header value` line, ready to drop into a cURL `-H` argument |
 | GitHub | Personal access token |
 | Notion | Internal `api_token` or OAuth `access_token` (Bearer token for Notion API calls) |
 | Sentry | Sentry auth token |


### PR DESCRIPTION
## Problem

An HTTP node whose curl uses a header-type credential stopped authenticating:

```
curl -X GET "https://api.search.brave.com/res/v1/web/search?q=$searchQuery.body.text.urlEncode()" \
  -H "Accept: application/json" -H "$credentials.brave"
```

Brave answered `422 Unable to validate request parameter(s) — header x-subscription-token: Field required`, and the run's own `request.headers` showed only `accept` and `accept-encoding`. The `x-subscription-token` header was never sent.

## Root cause

`5d361bdd` ("Enhance HTTP node execution with JSON body handling") moved expression resolution from **before** `parse_curl` to **after** it, so the JSON body could be rendered with JSON-safe types:

```python
# before
curl_command = self.evaluate_message_template(curl_command, ...)
method, url, headers, body, ... = self.parse_curl(curl_command)

# after
method, url, headers, body, ... = self.parse_curl(curl_template)
url = self.evaluate_message_template(url, ...)
```

The JSON body handling itself is correct, but parsing the raw template breaks any expression that contributes curl *syntax* rather than just a value:

1. **Headers.** A `header`-type credential resolves to a whole `key: value` line (`get_credentials_context` in `app/api/workflows.py`). `parse_curl` only keeps a `-H` token that already contains a literal `:`, so `-H "$credentials.Name"` was discarded before it could resolve.
2. **URLs.** A URL supplied entirely by an expression (`curl -X GET $api.base/data`) no longer starts with `http`, so no token matched and the node raised `HTTP node requires a URL`.

URL encoding was never broken — the failing run shows `q=ai%20agent%20audit%20log%20…` resolved correctly.

## Fix

`parse_curl` takes an optional `resolve` callable and applies it to every token **except** the `-d` payload, which the node still renders itself so JSON bodies keep their types. The node drops its own post-parse resolution pass, so a resolved value containing a `$` is not resolved a second time.

## Tests

`backend/tests/test_http_node_curl_expressions.py` — four regression tests, two of which fail on `main`:

- a header credential supplying a whole header line reaches the request (plus the URL is still percent-encoded)
- the common `Key: $credentials.Name` form keeps working
- a URL supplied entirely by an expression is recognised
- a body expression resolving to text containing `$` is not resolved twice

Verified end to end against the live Brave API with the real stored credential: `200`, correct `?q=` encoding, `x-subscription-token` present.

Backend suite: 3769/3792 pass. The 23 failures (cron scheduler, cancellation, DB event-loop teardown) reproduce identically on clean `main` and are unrelated.

## Docs

`http-node.md` and `credentials.md` now state that a Header credential resolves to a complete `key: value` line and can be dropped straight into `-H`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
