### PR TITLE
Mask expressions before tokenizing the HTTP node curl command

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -6579,6 +6579,43 @@ class WorkflowExecutor:
             except ValueError:
                 raise original_error from None
 
+    def _mask_curl_expressions(self, command: str) -> tuple[str, list[str]]:
+        """Replace every ``$…`` span with an inert placeholder before shell tokenizing.
+
+        Quotes, spaces and backslashes inside an expression are its own syntax, not
+        shell quoting: ``$url.text.replaceAll("\\n", "")`` is one value. ``shlex``
+        reads them as shell metacharacters and strips them, so the expression that
+        reaches the resolver is no longer the one the user wrote. Masking hides those
+        spans from the tokenizer and restores them verbatim afterwards.
+        """
+        spans = self._find_expressions(command)
+        if not spans:
+            return command, []
+        marker = "HEYMEXPR"
+        while marker in command:
+            marker += "X"
+        masked: list[str] = []
+        expressions: list[str] = []
+        last_end = 0
+        for start, end, expression in spans:
+            masked.append(command[last_end:start])
+            masked.append(f"{marker}{len(expressions)}{marker}")
+            expressions.append(expression)
+            last_end = end
+        masked.append(command[last_end:])
+        return "".join(masked), [marker, *expressions]
+
+    def _unmask_curl_expressions(self, token: str, masked: list[str]) -> str:
+        """Restore the expression spans hidden by :meth:`_mask_curl_expressions`."""
+        if not masked:
+            return token
+        marker, *expressions = masked
+        if marker not in token:
+            return token
+        for index, expression in enumerate(expressions):
+            token = token.replace(f"{marker}{index}{marker}", expression)
+        return token
+
     def parse_curl(
         self,
         curl_command: str,
@@ -6595,7 +6632,11 @@ class WorkflowExecutor:
         if not curl_command:
             return "GET", "", {}, None, False
         normalized_cmd = curl_command.replace("\\\n", " ").replace("\\\r\n", " ")
-        tokens = self._split_curl_tokens(normalized_cmd)
+        masked_cmd, masked_expressions = self._mask_curl_expressions(normalized_cmd)
+        tokens = [
+            self._unmask_curl_expressions(token, masked_expressions)
+            for token in self._split_curl_tokens(masked_cmd)
+        ]
         if tokens and tokens[0].lower() == "curl":
             tokens = tokens[1:]
 

--- a/backend/tests/test_http_node_curl_expressions.py
+++ b/backend/tests/test_http_node_curl_expressions.py
@@ -102,6 +102,38 @@ class HttpNodeCurlExpressionTests(unittest.TestCase):
 
         self.assertEqual(request.content.decode("utf-8"), "price is $total.amount")
 
+    def test_expression_arguments_keep_their_quotes(self) -> None:
+        """Quotes inside an expression are its syntax, not shell quoting."""
+        request = _run_curl(
+            'curl "https://r.jina.ai/$url.text.replaceAll("\\n", "").strip()" '
+            '-H "Authorization: $credentials.jina"',
+            inputs={"url": {"text": " https://heym.run\n"}},
+            credentials={"jina": "Bearer jina-secret"},
+        )
+
+        self.assertEqual(str(request.url), "https://r.jina.ai/https://heym.run")
+        self.assertEqual(request.headers["authorization"], "Bearer jina-secret")
+
+    def test_expression_argument_containing_a_space_is_one_token(self) -> None:
+        """A space inside an expression argument must not split the curl token."""
+        request = _run_curl(
+            'curl "https://api.example.com/?q=$q.text.replaceAll(", ", "+")"',
+            inputs={"q": {"text": "a, b, c"}},
+        )
+
+        self.assertEqual(str(request.url), "https://api.example.com/?q=a+b+c")
+
+    def test_json_body_expression_with_quoted_arguments(self) -> None:
+        """A quoted-argument expression in a JSON body still renders JSON-safely."""
+        request = _run_curl(
+            "curl -X POST https://api.example.com/data "
+            '-H "Content-Type: application/json" '
+            '-d \'{"text": $payload.text.replaceAll("\\n", " ")}\'',
+            inputs={"payload": {"text": "line1\nline2"}},
+        )
+
+        self.assertEqual(request.content.decode("utf-8"), '{"text": "line1 line2"}')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/src/docs/content/nodes/http-node.md
+++ b/frontend/src/docs/content/nodes/http-node.md
@@ -53,6 +53,12 @@ Use cURL syntax with `-H` for headers, `-d` for POST body, etc. Expressions can 
 curl -X GET "https://api.example.com/search?q=$query.body.text.urlEncode()" -H "$credentials.MyApiKey"
 ```
 
+Quotes and spaces inside an expression belong to the expression, not to the cURL command, so methods that take string arguments work inline:
+
+```
+curl "https://r.jina.ai/$url.text.replaceAll("\n", "").strip()" -H "Authorization: $credentials.Jina"
+```
+
 ## Egress Safety
 
 - By default, the URL must use `http://` or `https://` and resolve only to public addresses. Loopback, private, link-local, multicast, and cloud-metadata destinations are blocked.


### PR DESCRIPTION
## Problem

Third bug in the HTTP node curl path, independent of the two fixed last week (#511-adjacent `5d361bdd` and #512 `a3d929fc`). This one is in the place neither earlier fix touched: **the tokenizer**.

`parse_curl` splits the curl DSL with `shlex.split`, a *shell* tokenizer. But quotes, spaces and backslashes inside a Heym expression are the **expression's** syntax, not shell quoting, so `shlex` stripped them:

```
in:  "https://r.jina.ai/$url.text.replaceAll("\n", "").strip()"
out: https://r.jina.ai/$url.text.replaceAll(n, ).strip()
```

The expression that reached the resolver was no longer the one the user wrote. `replaceAll(n, )` does not resolve, so the literal text was URL-encoded and sent verbatim:

`https://r.jina.ai/$url.text.replaceAll(n,%20).strip()`

Jina replies:

```json
{ "code": 400, "name": "ParamValidationError",
  "readableMessage": "ParamValidationError(url): TypeError: Invalid URL" }
```

A space inside an argument (`replaceAll(", ", "+")`) split the token outright.

This is exactly the **executor vs dialog drift** AGENTS.md warns about: the evaluate dialog renders the whole string with `evaluate_message_template` and never tokenizes, so the preview showed the correct URL while the run sent a broken one.

## Fix

`parse_curl` now masks every `$…` span with an inert placeholder before splitting and restores it verbatim afterwards, so the tokenizer never sees expression-internal quotes. Placeholder collisions are avoided by extending the marker until it is absent from the command.

## No regression of the previous two fixes

The masking is identity-preserving, so both earlier invariants hold structurally, not just by luck:

- **`5d361bdd` (JSON body typing)** — the `-d` payload still comes back raw and unresolved for the node's JSON-aware renderer.
- **`a3d929fc` (resolve before parse)** — `resolve` still runs per token, so whole-header credentials (`-H "$credentials.Name"`) and whole-URL expressions still work.

All four of their regression tests pass untouched. The new `test_json_body_expression_with_quoted_arguments` is a deliberate guard on the first one under the new masking.

## Verification

- `test_http_node_curl_expressions.py` 7/7 (4 existing + 3 new).
- 264 passed across the SSRF guard, expression evaluator and operator smoke suites.
- Full `./check.sh`: 3795 tests, 23 failed. Re-ran on clean `main`: **identical 23 failures in the same 6 suites** (`test_cron_scheduler`, `test_workflow_execution_api`, `test_html_response_api`, `test_mcp_stdio_sandbox`, `test_cancellation_by_trigger`, `test_workflow_http_method`) — all pre-existing and unrelated. This change adds 3 tests and introduces zero new failures.
- `ruff format --check` and `ruff check` clean.
- End-to-end against the reported workflow: URL `https://r.jina.ai/https://heym.run`, header `Authorization: Bearer …` — matching the preview.

## Docs

One line in `http-node.md` noting that quotes and spaces inside an expression belong to the expression. No release tour entry — bug fix with no new visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)