### PR TITLE
fix/missmatch-queue-after-update

### DIFF
--- a/backend/app/services/cluster/run_queue.py
+++ b/backend/app/services/cluster/run_queue.py
@@ -21,7 +21,7 @@ from app.config import settings
 from app.db.models import ActiveWorkflowExecution, ClusterDispatchState, WorkflowRunQueue
 from app.db.session import async_session_maker
 from app.services.cluster import registry
-from app.services.cluster.weights import pick_instance, rescale_counters
+from app.services.cluster.weights import level_counters, pick_instance, rescale_counters
 
 logger = logging.getLogger("cluster")
 
@@ -99,17 +99,19 @@ async def choose_target(placement: str) -> str | None:
         if state is None:
             return None
 
-        counters = rescale_counters(dict(state.counters or {}))
+        pool = registry.candidate_instances(instances, now=now)
+        weights = {i.id: i.weight for i in pool}
+        counters = level_counters(rescale_counters(dict(state.counters or {})), weights)
 
         if placement == "main_only":
             main = registry.find_main(instances)
             target = main.id if main and registry.is_live(main, now=now) else None
         else:
-            pool = registry.candidate_instances(instances, now=now)
-            target = pick_instance({i.id: i.weight for i in pool}, counters=counters)
+            target = pick_instance(weights, counters=counters)
 
         if target is not None:
             counters[target] = counters.get(target, 0) + 1
+        if counters != (state.counters or {}):
             state.counters = counters
         await db.commit()
         return target

--- a/backend/app/services/cluster/weights.py
+++ b/backend/app/services/cluster/weights.py
@@ -5,6 +5,11 @@ forced to take. That single rule is what makes a percentage describe total load:
 forced work spends main's quota, so the next ANYWHERE runs fall to the workers.
 The consequence, which the UI and docs state: main's percentage is a ceiling,
 not a floor.
+
+A counter only means something while its instance is a candidate. An instance
+that was not one - Offline, Disabled, or on a version main cannot hand work to -
+must be re-entered at the pool's current position rather than repaid for the
+time it was away; see level_counters.
 """
 
 from __future__ import annotations
@@ -30,6 +35,34 @@ def pick_instance(weights: dict[str, int], *, counters: dict[str, int]) -> str |
         sorted(shares),
         key=lambda instance_id: shares[instance_id] * total - counters.get(instance_id, 0),
     )
+
+
+def level_counters(counters: dict[str, int], weights: dict[str, int]) -> dict[str, int]:
+    """Keep the pool's counters, forget the rest, and enter a joiner level.
+
+    Counters are lifetime totals, so an instance that was not a candidate for a
+    while builds a deficit it never earned, and pick_instance repays it in one
+    burst: after a worker spends a night on a mismatched version, a 70/30 split
+    runs as 0/100 for thousands of runs. Dropping an absent instance's counter
+    is how the next pass knows it was away; it then rejoins carrying the same
+    number of runs per unit of weight the pool already carries, so the split
+    holds from the first run after the rejoin.
+
+    A deficit built while the instance *was* a candidate is left alone - that is
+    the catch-up that makes main's percentage a ceiling.
+    """
+    if not weights:
+        return counters
+    present = {i: counters[i] for i in weights if i in counters}
+    joining = [i for i in weights if i not in present]
+    if not joining:
+        return present
+
+    served_weight = sum(weights[i] for i in present)
+    per_weight = sum(present.values()) / served_weight if served_weight else 0.0
+    for instance_id in joining:
+        present[instance_id] = round(per_weight * weights[instance_id])
+    return present
 
 
 def rescale_counters(counters: dict[str, int]) -> dict[str, int]:

--- a/backend/tests/test_cluster_run_queue.py
+++ b/backend/tests/test_cluster_run_queue.py
@@ -1,9 +1,12 @@
 """Enqueue shape, expiry, and the guarantee that no credential is stored."""
 
+import contextlib
 import unittest
 import uuid
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.services.cluster.run_queue import (
     STATUS_QUEUED,
@@ -129,3 +132,118 @@ class StrandedClaimTests(unittest.TestCase):
                 claimed_at=None, has_active_execution=False, now=self.now, grace_seconds=60
             )
         )
+
+
+def _instance(instance_id: str, *, role: str, weight: int, version: str = "1.0.0", **over: object):
+    from app.services.cluster.registry import InstanceView
+
+    fields: dict = dict(
+        id=instance_id,
+        name=instance_id,
+        role=role,
+        enabled=True,
+        weight=weight,
+        weight_configured=True,
+        version=version,
+        schema_revision="rev",
+        keys_fingerprint="fp",
+        docker_ok=True,
+        db_latency_ms=1.0,
+        heartbeat_at=datetime.now(timezone.utc),
+    )
+    fields.update(over)
+    return InstanceView(**fields)
+
+
+class ChooseTargetTests(unittest.IsolatedAsyncioTestCase):
+    """The 70/30 split must survive a worker being away and coming back.
+
+    Counters are lifetime totals, so a worker that spent a night Offline or on a
+    mismatched version used to return owed every run it missed and take them all
+    back-to-back - a 70/30 cluster running 0/100 for thousands of runs.
+    """
+
+    def setUp(self) -> None:
+        self.state = SimpleNamespace(counters={})
+        self.instances: list = []
+
+    @contextlib.contextmanager
+    def _patched(self):
+        session = MagicMock()
+        session.commit = AsyncMock()
+        session.execute = AsyncMock(
+            return_value=SimpleNamespace(scalar_one_or_none=lambda: self.state)
+        )
+
+        @contextlib.asynccontextmanager
+        async def maker():
+            yield session
+
+        with (
+            patch("app.services.cluster.run_queue.async_session_maker", maker),
+            patch(
+                "app.services.cluster.run_queue.registry.list_instances",
+                AsyncMock(side_effect=lambda **_kw: list(self.instances)),
+            ),
+        ):
+            yield
+
+    async def _dispatch(self, count: int, placement: str = "anywhere") -> dict[str, int]:
+        from app.services.cluster.run_queue import choose_target
+
+        taken: dict[str, int] = {}
+        with self._patched():
+            for _ in range(count):
+                target = await choose_target(placement)
+                taken[target] = taken.get(target, 0) + 1
+        return taken
+
+    async def test_a_worker_that_rejoins_after_a_mismatch_does_not_take_every_run(self) -> None:
+        self.instances = [
+            _instance("main", role="main", weight=70),
+            _instance("worker", role="worker", weight=30, version="0.9.0"),
+        ]
+        away = await self._dispatch(200)
+        self.assertEqual(away, {"main": 200})
+
+        self.instances = [
+            _instance("main", role="main", weight=70),
+            _instance("worker", role="worker", weight=30),
+        ]
+        back = await self._dispatch(100)
+        self.assertEqual(back, {"main": 70, "worker": 30})
+
+    async def test_a_stretch_of_main_only_work_does_not_stale_an_absent_counter(self) -> None:
+        """The counter of an away worker must be forgotten on any dispatch."""
+        self.instances = [
+            _instance("main", role="main", weight=70),
+            _instance("worker", role="worker", weight=30),
+        ]
+        await self._dispatch(10)
+        self.instances[1] = _instance("worker", role="worker", weight=30, version="0.9.0")
+        await self._dispatch(200, placement="main_only")
+
+        self.instances[1] = _instance("worker", role="worker", weight=30)
+        back = await self._dispatch(100)
+        self.assertEqual(back, {"main": 70, "worker": 30})
+
+    async def test_main_only_work_still_spends_mains_quota(self) -> None:
+        """The catch-up that makes main's percentage a ceiling is preserved."""
+        self.instances = [
+            _instance("main", role="main", weight=70),
+            _instance("worker", role="worker", weight=30),
+        ]
+        await self._dispatch(30, placement="main_only")
+        after = await self._dispatch(70)
+        self.assertEqual(after, {"main": 40, "worker": 30})
+
+    async def test_an_offline_worker_receives_nothing_and_rejoins_level(self) -> None:
+        stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+        self.instances = [
+            _instance("main", role="main", weight=70),
+            _instance("worker", role="worker", weight=30, heartbeat_at=stale),
+        ]
+        self.assertEqual(await self._dispatch(500), {"main": 500})
+
+        self.instances[1] = _instance("worker", role="worker", weight=30)
+        self.assertEqual(await self._dispatch(100), {"main": 70, "worker": 30})

--- a/backend/tests/test_cluster_weights.py
+++ b/backend/tests/test_cluster_weights.py
@@ -4,6 +4,7 @@ import unittest
 
 from app.services.cluster.weights import (
     COUNTER_RESCALE_THRESHOLD,
+    level_counters,
     normalized_weights,
     pick_instance,
     rescale_counters,
@@ -146,3 +147,51 @@ class SeedWeightsTests(unittest.TestCase):
         seeded = seed_weights({"main": (False, 0)})
         assert seeded is not None
         self.assertEqual(seeded, {"main": 100})
+
+
+class RejoinTests(unittest.TestCase):
+    """A machine that was not a candidate must not be repaid for that time.
+
+    Counters are lifetime totals. While an instance is Offline, Disabled or on a
+    version main cannot hand work to, every run charges the others, and the
+    absent machine builds a deficit it never earned. Repaying it sends it every
+    run until the debt clears.
+    """
+
+    def test_a_rejoining_worker_does_not_take_every_run(self) -> None:
+        """main ran a night alone; the worker updates and rejoins at 70/30."""
+        counters = level_counters({"main": 10_000}, {"main": 70, "worker": 30})
+        taken = {"main": 0, "worker": 0}
+        for _ in range(100):
+            winner = pick_instance({"main": 70, "worker": 30}, counters=counters)
+            counters[winner] = counters.get(winner, 0) + 1
+            taken[winner] += 1
+        self.assertEqual(taken, {"main": 70, "worker": 30})
+
+    def test_a_brand_new_worker_joins_a_busy_main_at_the_split(self) -> None:
+        counters = level_counters({"main": 5_000}, {"main": 70, "worker": 30})
+        first_ten = []
+        for _ in range(10):
+            winner = pick_instance({"main": 70, "worker": 30}, counters=counters)
+            counters[winner] = counters.get(winner, 0) + 1
+            first_ten.append(winner)
+        self.assertEqual(first_ten.count("main"), 7)
+
+    def test_a_joiner_enters_at_the_pools_own_position(self) -> None:
+        leveled = level_counters({"main": 700}, {"main": 70, "worker": 30})
+        self.assertEqual(leveled, {"main": 700, "worker": 300})
+
+    def test_an_instance_outside_the_pool_is_forgotten(self) -> None:
+        """Dropping the key is how the next pass knows it was away."""
+        self.assertEqual(level_counters({"main": 700, "gone": 300}, {"main": 70}), {"main": 700})
+
+    def test_a_present_instance_keeps_its_deficit(self) -> None:
+        """main_only runs still spend main's quota; that catch-up is the point."""
+        leveled = level_counters({"main": 90, "worker": 0}, {"main": 70, "worker": 30})
+        self.assertEqual(leveled, {"main": 90, "worker": 0})
+
+    def test_an_empty_pool_leaves_the_counters_alone(self) -> None:
+        self.assertEqual(level_counters({"main": 700}, {}), {"main": 700})
+
+    def test_a_pool_of_only_joiners_starts_at_zero(self) -> None:
+        self.assertEqual(level_counters({}, {"main": 70, "worker": 30}), {"main": 0, "worker": 0})

--- a/frontend/src/docs/content/reference/cluster.md
+++ b/frontend/src/docs/content/reference/cluster.md
@@ -50,6 +50,8 @@ So with a strong main and a smaller worker, start nearer 60/40 than the machines
 
 Weights are renormalized across the instances that are currently live and enabled. With `main=70, A=15, B=15`, if A goes offline the split becomes 70/85 and 15/85 between main and B, and returns to 70/15/15 when A comes back.
 
+**An instance that comes back is not owed the runs it missed.** Time spent Offline, Disabled or on a mismatched version is not counted against it, so a worker that spends a night unavailable rejoins at the pool's current position and the split reads 70/30 again from its first run — it does not absorb every run until it has caught up. A worker that was available the whole time still catches up, which is what makes main's percentage a ceiling.
+
 ### A new instance joins at zero
 
 An instance that has never been given a weight starts at 0, which would leave it Live, Enabled and receiving nothing. **Give new instances a share automatically** — on by default, under the instances table — fixes that: on the leader's next pass the newcomer is given an equal share of the pool, and the existing weights are scaled down keeping their ratios to each other, so a deliberate 70/30 still reads as roughly 70/30 afterwards. The total stays exactly 100.


### PR DESCRIPTION
Refactor run queue instance selection logic and introduce level_counters function

- Updated the instance selection process in run_queue.py to utilize the new level_counters function, which adjusts counters for instances that have been offline or mismatched.
- Enhanced the weights management in weights.py to include the level_counters function, ensuring that absent instances do not accumulate unearned runs.
- Added comprehensive unit tests in test_cluster_run_queue.py and test_cluster_weights.py to validate the behavior of instance rejoining and counter management.
- Updated documentation to clarify the behavior of instances that rejoin the pool after being offline.