### PR TITLE
impl/rag-operations-expression-dialog-and-subworkflow-running-status

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -3819,7 +3819,38 @@ async def execute_workflow_stream(
     final_result: dict = {}
     executor_holder: dict = {}
     was_cancelled: bool = False
+    run_released = False
     query_params = dict(request.query_params)
+
+    def release_run() -> None:
+        """End the client stream and hand observers this run's terminal payload.
+
+        Called before draining fire-and-forget sub-workflows: the parent's own run is
+        over once its nodes finish, and a dispatched sub-workflow must not keep the
+        parent reported as running. Persistence is unaffected — ``finalize_execution``
+        awaits the whole thread, drain included.
+
+        The payload has to be handed over rather than the handle simply cleared:
+        ``execution_complete`` is never buffered as a progress event, so an observer
+        that loses the handle before the history row exists has no way left to learn
+        the run ended. That window is normally tiny; a dispatched sub-workflow makes
+        it as long as the sub-workflow runs.
+        """
+        nonlocal run_released
+        if run_released:
+            return
+        run_released = True
+        event_queue.put(None)
+        if final_result:
+            complete_active_execution(
+                execution_id,
+                workflow_id=workflow.id,
+                result={
+                    key: value for key, value in final_result.items() if not key.startswith("_")
+                },
+            )
+        else:
+            clear_active_execution(execution_id)
 
     def run_executor():
         nonlocal final_result, was_cancelled
@@ -3845,8 +3876,9 @@ async def execute_workflow_stream(
                 event_queue.put(event)
                 if event.get("type") == "execution_complete":
                     final_result = event
-            # Drain executeDoNotWait background sub-workflows AFTER execution_complete
-            # has been put on the queue (client already got the response).
+            # Drain executeDoNotWait background sub-workflows AFTER the run has been
+            # released, so a dispatched sub-workflow never holds the parent open.
+            release_run()
             wf_exec = executor_holder.get("executor")
             if wf_exec is not None:
                 wf_exec.drain_bg_futures()
@@ -3876,17 +3908,7 @@ async def execute_workflow_stream(
             was_cancelled = True
             return
         finally:
-            event_queue.put(None)
-            if test_run and final_result:
-                complete_active_execution(
-                    execution_id,
-                    workflow_id=workflow.id,
-                    result={
-                        key: value for key, value in final_result.items() if not key.startswith("_")
-                    },
-                )
-            else:
-                clear_active_execution(execution_id)
+            release_run()
 
     async def persist_terminal_result() -> None:
         async with async_session_maker() as session:

--- a/backend/app/services/node_execution/nodes/execute_node.py
+++ b/backend/app/services/node_execution/nodes/execute_node.py
@@ -5,7 +5,48 @@ from concurrent.futures import Future
 from importlib import import_module
 from threading import Event, Thread
 
+from app.services.execution_cancellation import clear_execution, complete_execution
 from app.services.node_execution.base import NodeExecutionContext
+
+
+def _finish_sub_execution(
+    execution_id: uuid.UUID,
+    workflow_id: str,
+    *,
+    result: object = None,
+    error: BaseException | None = None,
+) -> None:
+    """Hand anyone watching the sub-workflow a terminal event, then drop the handle.
+
+    Without this the handle simply vanishes and the observer stream has nothing to find:
+    the sub-workflow's history row is written under a different id by the parent's run.
+    """
+    if error is not None or result is None:
+        payload: dict = {
+            "type": "execution_complete",
+            "workflow_id": workflow_id,
+            "status": "error",
+            "outputs": {"error": str(error) if error is not None else "Sub-workflow did not run"},
+            "execution_time_ms": 0,
+            "node_results": [],
+        }
+    else:
+        payload = {
+            "type": "execution_complete",
+            "workflow_id": workflow_id,
+            "status": result.status,
+            "outputs": result.outputs,
+            "execution_time_ms": result.execution_time_ms,
+            "node_results": result.node_results,
+        }
+    try:
+        complete_execution(
+            execution_id,
+            workflow_id=uuid.UUID(workflow_id),
+            result=payload,
+        )
+    except Exception:
+        clear_execution(execution_id)
 
 
 def execute(ctx: NodeExecutionContext) -> object:
@@ -14,7 +55,6 @@ def execute(ctx: NodeExecutionContext) -> object:
     SubWorkflowExecution = _workflow_executor.SubWorkflowExecution  # noqa: N806
     WorkflowExecutor = _workflow_executor.WorkflowExecutor  # noqa: N806
     _SHARED_EXECUTOR = _workflow_executor._SHARED_EXECUTOR  # noqa: N806
-    _clear_sub_execution = _workflow_executor._clear_sub_execution
     _register_sub_execution = _workflow_executor._register_sub_execution
     self = ctx.executor
     node_id = ctx.node_id
@@ -67,6 +107,7 @@ def execute(ctx: NodeExecutionContext) -> object:
             if self._merged_global_context_cache is not None
             else {}
         )
+        _sub_exec_id = uuid.uuid4()
         _exec_node_cancel_event = Event()
         if self.cancel_event is not None:
             _exec_node_parent = self.cancel_event
@@ -89,6 +130,7 @@ def execute(ctx: NodeExecutionContext) -> object:
             sub_workflow_invocation_depth=self._sub_workflow_invocation_depth + 1,
             cancel_event=_exec_node_cancel_event,
             invoked_by_agent=self._invoked_by_agent,
+            execution_id=str(_sub_exec_id),
         )
         enriched_execute_inputs = {
             "headers": {},
@@ -100,6 +142,15 @@ def execute(ctx: NodeExecutionContext) -> object:
             wf_name = target_workflow.get("name", "")
             inputs_snap = dict(execute_inputs)
             bg_callback_done = Event()
+            # Registered before submit so the dispatched run shows as running from its
+            # first moment; without it the sub-workflow stays invisible until it ends.
+            _register_sub_execution(
+                workflow_id=uuid.UUID(execute_workflow_id),
+                execution_id=_sub_exec_id,
+                event=_exec_node_cancel_event,
+                inputs=enriched_execute_inputs,
+                recoverable=False,
+            )
 
             def _on_execute_do_not_wait_done(f: Future) -> None:
                 try:
@@ -107,6 +158,13 @@ def execute(ctx: NodeExecutionContext) -> object:
                         f, self, execute_workflow_id, wf_name, inputs_snap
                     )
                 finally:
+                    bg_error = f.exception()
+                    _finish_sub_execution(
+                        _sub_exec_id,
+                        execute_workflow_id,
+                        result=None if bg_error else f.result(),
+                        error=bg_error,
+                    )
                     bg_callback_done.set()
 
             bg_future = _SHARED_EXECUTOR.submit(
@@ -127,13 +185,13 @@ def execute(ctx: NodeExecutionContext) -> object:
                 )
             output = {"status": "dispatched", "workflow_id": execute_workflow_id}
         else:
-            _sub_exec_id = uuid.uuid4()
             _register_sub_execution(
                 workflow_id=uuid.UUID(execute_workflow_id),
                 execution_id=_sub_exec_id,
                 event=_exec_node_cancel_event,
                 recoverable=False,
             )
+            sub_error: BaseException | None = None
             try:
                 sub_result = sub_executor.execute(
                     workflow_id=uuid.UUID(execute_workflow_id),
@@ -141,8 +199,17 @@ def execute(ctx: NodeExecutionContext) -> object:
                 )
                 if sub_result.allow_downstream_pending:
                     sub_result.join_allow_downstream()
+            except BaseException as exc:
+                sub_error = exc
+                raise
             finally:
-                _clear_sub_execution(_sub_exec_id)
+                # `sub_result` is only read when nothing was raised, so it is always bound.
+                _finish_sub_execution(
+                    _sub_exec_id,
+                    execute_workflow_id,
+                    result=None if sub_error else sub_result,
+                    error=sub_error,
+                )
             if sub_result.status == "pending":
                 raise ValueError("HITL is not supported inside Execute node sub-workflows.")
 

--- a/backend/app/services/node_execution/nodes/rag_node.py
+++ b/backend/app/services/node_execution/nodes/rag_node.py
@@ -37,6 +37,20 @@ def _resolve_metadata_expressions(executor, value: object, inputs: dict, node_id
     return executor._resolve_value_with_dollar_refs(value, inputs, node_id)
 
 
+def _resolve_filter_expressions(
+    executor, parsed: object, inputs: dict, node_id: str
+) -> dict | None:
+    """Search filter JSON with ``$`` expressions resolved, using the document metadata rules.
+
+    Sharing the resolver keeps a whole-string expression's type, so a numeric filter value
+    stays a number and still matches the number stored by an insert.
+    """
+    resolved = executor._unwrap_value(
+        _resolve_metadata_expressions(executor, parsed, inputs, node_id)
+    )
+    return resolved if isinstance(resolved, dict) else None
+
+
 def _with_workflow_source(executor, metadata: dict) -> dict:
     """Name the workflow as the source when the author supplied none of their own."""
     from app.services.vector_store import WORKFLOW_SOURCE_PREFIX
@@ -172,6 +186,8 @@ def execute(ctx: NodeExecutionContext) -> object:
                 metadata_filter = metadata_filter_json or None
         except Exception:
             metadata_filter = None
+        if metadata_filter is not None:
+            metadata_filter = _resolve_filter_expressions(self, metadata_filter, inputs, node_id)
 
         enable_reranker = node_data.get("enableReranker", False)
         reranker_credential_id = node_data.get("rerankerCredentialId")

--- a/backend/app/services/workflow_dsl_prompt.py
+++ b/backend/app/services/workflow_dsl_prompt.py
@@ -2087,7 +2087,7 @@ The last node in the iteration body MUST connect BACK to the loop node's `loop` 
   - `documentId`: Value of that unique id (for "upsert" and "delete", supports expressions)
   - `queryText`: Search query text (only for "search" operation, supports expressions)
   - `searchLimit`: Maximum number of results to return (only for "search" operation, default: 3)
-  - `metadataFilters`: JSON object with metadata filters for search (only for "search" operation)
+  - `metadataFilters`: JSON object with metadata filters for search (only for "search" operation). String values support expressions and are resolved after the JSON is parsed, so `{"url": "$start.url"}` filters on the resolved value, and a whole-string expression keeps its type (`{"count": "$start.count"}` matches a stored number)
 
 **SETUP**: Requires a Vector Store created in the Vector Stores tab with a "RAG: Qdrant + OpenAI" credential (external Qdrant server), a "RAG: Psql + OpenAI" credential (vectors stored in Heym's own Postgres database via pgvector — no external service), or a "RAG: Custom Embeddings" credential (any OpenAI-compatible embedding endpoint by URL, targeting either backend). The same RAG operations, metadata filters, and reranking work identically with every backend.
 

--- a/backend/tests/test_execute_do_not_wait_stream_release.py
+++ b/backend/tests/test_execute_do_not_wait_stream_release.py
@@ -1,0 +1,194 @@
+"""The streaming endpoint must not stay open for a fire-and-forget sub-workflow.
+
+`executeDoNotWait` dispatches a sub-workflow and the parent's own run ends immediately.
+The parent's SSE stream and its active-execution registration have to end with the run,
+not with the dispatched work: the API layer still drains that work afterwards so its
+history is recorded, and that drain used to hold both open.
+"""
+
+import json
+import time
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.execution_cancellation import (
+    get_completed_execution_result,
+    list_active_executions,
+)
+
+TARGET_WF_ID = "22222222-2222-2222-2222-222222222222"
+
+# 1500 ms is long enough that a stream held open by the drain is unmistakable, and short
+# enough to keep the test quick.
+_TARGET_WORKFLOW = {
+    "nodes": [
+        {
+            "id": "t1",
+            "type": "textInput",
+            "data": {"label": "input", "inputFields": [{"key": "text"}]},
+        },
+        {"id": "t2", "type": "wait", "data": {"label": "wait", "duration": 1500}},
+        {"id": "t3", "type": "output", "data": {"label": "output"}},
+    ],
+    "edges": [
+        {"id": "te1", "source": "t1", "target": "t2"},
+        {"id": "te2", "source": "t2", "target": "t3"},
+    ],
+    "name": "Target",
+}
+
+_PARENT_NODES = [
+    {
+        "id": "n1",
+        "type": "textInput",
+        "data": {"label": "userInput", "inputFields": [{"key": "text"}]},
+    },
+    {
+        "id": "n2",
+        "type": "execute",
+        "data": {
+            "label": "callWorkflow",
+            "executeWorkflowId": TARGET_WF_ID,
+            "executeInput": "$userInput.body.text",
+            "executeDoNotWait": True,
+        },
+    },
+]
+_PARENT_EDGES = [{"id": "e1", "source": "n1", "target": "n2"}]
+
+
+class _ScalarResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+class DoNotWaitStreamReleaseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_stream_ends_before_the_dispatched_sub_workflow_does(self) -> None:
+        from app.api.workflows import execute_workflow_stream
+
+        wf_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=wf_id,
+            owner_id=uuid.uuid4(),
+            name="Parent",
+            nodes=_PARENT_NODES,
+            edges=_PARENT_EDGES,
+            sse_enabled=True,
+            rate_limit_requests=None,
+            rate_limit_window_seconds=None,
+            cache_ttl_seconds=None,
+            sse_node_config={},
+            workflow_timeout_seconds=None,
+        )
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_ScalarResult(workflow))
+
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {}
+        request.query_params = {}
+        request.base_url = "http://localhost/"
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "app.api.workflows.parse_execute_body",
+                AsyncMock(return_value=({"text": "hello"}, False, "API", False)),
+            ),
+            patch("app.api.workflows.validate_workflow_auth", AsyncMock(return_value=None)),
+            patch("app.api.workflows.enforce_workflow_http_method", MagicMock()),
+            patch(
+                "app.api.workflows.collect_referenced_workflows",
+                AsyncMock(return_value={TARGET_WF_ID: _TARGET_WORKFLOW}),
+            ),
+            patch("app.api.workflows.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.build_public_base_url", return_value="http://localhost"),
+            patch(
+                "app.api.workflows.persist_stream_execution_result", AsyncMock(return_value=False)
+            ),
+        ):
+            response = await execute_workflow_stream(
+                workflow_id=wf_id,
+                request=request,
+                current_user=None,
+                db=db,
+            )
+
+            started_at = time.monotonic()
+            frames = [chunk async for chunk in response.body_iterator]
+            stream_seconds = time.monotonic() - started_at
+
+        payload = "".join(chunk.decode() if isinstance(chunk, bytes) else chunk for chunk in frames)
+        self.assertIn("execution_complete", payload)
+
+        started = next(
+            line for line in payload.splitlines() if '"type": "execution_started"' in line
+        )
+        execution_id = json.loads(started[len("data: ") :])["execution_id"]
+
+        # The parent's own nodes are instant; only the dispatched sub-workflow is slow.
+        self.assertLess(
+            stream_seconds,
+            1.0,
+            "the parent's stream was held open by the dispatched sub-workflow",
+        )
+
+        parent_still_active = [
+            handle for handle in list_active_executions() if handle.workflow_id == wf_id
+        ]
+        self.assertEqual(
+            parent_still_active,
+            [],
+            "the parent stayed in the active registry while its dispatch ran",
+        )
+
+        # The dispatched run is genuinely still going, so the assertions above are not
+        # passing merely because everything already finished.
+        target_active = [
+            handle for handle in list_active_executions() if str(handle.workflow_id) == TARGET_WF_ID
+        ]
+        self.assertEqual(len(target_active), 1)
+
+        # Releasing the run must hand observers its terminal payload. `execution_complete`
+        # is never buffered as a progress event, and the history row is only written once
+        # the dispatch is drained, so clearing the handle without this leaves a watcher of
+        # the parent with no way at all to learn the run ended.
+        completed = get_completed_execution_result(
+            uuid.UUID(execution_id),
+            workflow_id=wf_id,
+        )
+        self.assertIsNotNone(
+            completed,
+            "an observer of the parent has no terminal event while the dispatch runs",
+        )
+        assert completed is not None
+        self.assertEqual(completed["type"], "execution_complete")
+        self.assertEqual(completed["status"], "success")
+        self.assertEqual(
+            [item["node_id"] for item in completed["node_results"]],
+            ["n1", "n2"],
+            "the terminal payload must carry the run's node results",
+        )
+
+        # Let the dispatch finish before the test ends, so it does not run on into the
+        # next test (or into interpreter shutdown, where the shared pool is closed).
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if not [
+                handle
+                for handle in list_active_executions()
+                if str(handle.workflow_id) == TARGET_WF_ID
+            ]:
+                break
+            time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_execute_node_do_not_wait.py
+++ b/backend/tests/test_execute_node_do_not_wait.py
@@ -2,8 +2,13 @@
 
 import time
 import unittest
+import unittest.mock
 import uuid
 
+from app.services.execution_cancellation import (
+    get_completed_execution_result,
+    list_active_executions,
+)
 from app.services.workflow_executor import WorkflowExecutor
 
 TARGET_WF_ID = "11111111-1111-1111-1111-111111111111"
@@ -31,6 +36,32 @@ _WORKFLOW_CACHE = {
         "name": "Target",
     }
 }
+
+_SLOW_TARGET_NODES = [
+    {"id": "t1", "type": "textInput", "data": {"label": "input", "inputFields": [{"key": "text"}]}},
+    {"id": "t2", "type": "wait", "data": {"label": "wait", "duration": 400}},
+    {"id": "t3", "type": "output", "data": {"label": "output"}},
+]
+_SLOW_TARGET_EDGES = [
+    {"id": "te1", "source": "t1", "target": "t2"},
+    {"id": "te2", "source": "t2", "target": "t3"},
+]
+_SLOW_WORKFLOW_CACHE = {
+    TARGET_WF_ID: {
+        "nodes": _SLOW_TARGET_NODES,
+        "edges": _SLOW_TARGET_EDGES,
+        "name": "Target",
+    }
+}
+
+
+def _active_target_handles() -> list:
+    """Registered, not-yet-cancelled active executions for the dispatched workflow."""
+    return [
+        handle
+        for handle in list_active_executions()
+        if str(handle.workflow_id) == TARGET_WF_ID and not handle.event.is_set()
+    ]
 
 
 def _make_parent_nodes(do_not_wait: bool) -> list[dict]:
@@ -200,6 +231,107 @@ class ExecuteNodeDoNotWaitTests(unittest.TestCase):
             [item["node_id"] for item in sub_exec.node_results],
             ["t1", "t2", "t3", "t4"],
         )
+
+    def test_do_not_wait_registers_active_execution_while_running(self) -> None:
+        """A dispatched sub-workflow is visible as running before it finishes."""
+        executor = WorkflowExecutor(
+            nodes=_make_parent_nodes(do_not_wait=True),
+            edges=_PARENT_EDGES,
+            workflow_cache=dict(_SLOW_WORKFLOW_CACHE),
+        )
+        self.assertEqual(_active_target_handles(), [])
+
+        executor.execute(workflow_id=uuid.uuid4(), initial_inputs=_INITIAL_INPUTS)
+
+        handles = _active_target_handles()
+        self.assertEqual(len(handles), 1)
+        self.assertEqual(handles[0].inputs, {"headers": {}, "query": {}, "body": {"text": "hello"}})
+
+        deadline = time.time() + 5
+        while _active_target_handles() and time.time() < deadline:
+            time.sleep(0.05)
+        self.assertEqual(_active_target_handles(), [])
+
+    def test_do_not_wait_reports_progress_against_the_registered_id(self) -> None:
+        """The sub-executor records node progress on the handle a watcher polls.
+
+        The sub-workflow's own execution id has to be the registered one; when it mints
+        its own instead, every node start lands on a handle nobody is looking at.
+        """
+        executor = WorkflowExecutor(
+            nodes=_make_parent_nodes(do_not_wait=True),
+            edges=_PARENT_EDGES,
+            workflow_cache=dict(_SLOW_WORKFLOW_CACHE),
+        )
+        executor.execute(workflow_id=uuid.uuid4(), initial_inputs=_INITIAL_INPUTS)
+
+        handles = _active_target_handles()
+        self.assertEqual(len(handles), 1)
+        handle = handles[0]
+
+        deadline = time.time() + 5
+        while not (handle.running_node_ids or handle.node_results) and time.time() < deadline:
+            time.sleep(0.05)
+        self.assertTrue(
+            handle.running_node_ids or handle.node_results,
+            "sub-workflow node progress never reached the registered handle",
+        )
+
+    def test_do_not_wait_leaves_a_terminal_event_for_a_watcher(self) -> None:
+        """When the dispatched run ends, a watcher gets execution_complete, not silence."""
+        executor = WorkflowExecutor(
+            nodes=_make_parent_nodes(do_not_wait=True),
+            edges=_PARENT_EDGES,
+            workflow_cache=dict(_SLOW_WORKFLOW_CACHE),
+        )
+        executor.execute(workflow_id=uuid.uuid4(), initial_inputs=_INITIAL_INPUTS)
+
+        handles = _active_target_handles()
+        self.assertEqual(len(handles), 1)
+        execution_id = handles[0].execution_id
+
+        deadline = time.time() + 5
+        completed = None
+        while completed is None and time.time() < deadline:
+            completed = get_completed_execution_result(
+                execution_id,
+                workflow_id=uuid.UUID(TARGET_WF_ID),
+            )
+            if completed is None:
+                time.sleep(0.05)
+
+        self.assertIsNotNone(completed)
+        assert completed is not None
+        self.assertEqual(completed["type"], "execution_complete")
+        self.assertEqual(completed["status"], "success")
+        self.assertEqual(completed["workflow_id"], TARGET_WF_ID)
+
+    def test_wait_mode_also_reports_under_the_registered_id(self) -> None:
+        """The synchronous branch shares the fix: watcher id and executor id are one."""
+        seen: list[str] = []
+        original = WorkflowExecutor.execute
+
+        def _capture(self, workflow_id, initial_inputs):  # type: ignore[no-untyped-def]
+            if str(workflow_id) == TARGET_WF_ID:
+                seen.append(self.execution_id)
+            return original(self, workflow_id, initial_inputs)
+
+        with unittest.mock.patch.object(WorkflowExecutor, "execute", _capture):
+            executor = WorkflowExecutor(
+                nodes=_make_parent_nodes(do_not_wait=False),
+                edges=_PARENT_EDGES,
+                workflow_cache=dict(_WORKFLOW_CACHE),
+            )
+            executor.execute(workflow_id=uuid.uuid4(), initial_inputs=_INITIAL_INPUTS)
+
+        self.assertEqual(len(seen), 1)
+        completed = get_completed_execution_result(
+            uuid.UUID(seen[0]),
+            workflow_id=uuid.UUID(TARGET_WF_ID),
+        )
+        self.assertIsNotNone(completed)
+        assert completed is not None
+        self.assertEqual(completed["status"], "success")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_rag_node_metadata_expressions.py
+++ b/backend/tests/test_rag_node_metadata_expressions.py
@@ -2,7 +2,10 @@
 
 import unittest
 
-from app.services.node_execution.nodes.rag_node import _metadata_from_node_data
+from app.services.node_execution.nodes.rag_node import (
+    _metadata_from_node_data,
+    _resolve_filter_expressions,
+)
 from app.services.workflow_executor import WorkflowExecutor
 
 
@@ -72,6 +75,48 @@ class TestRagMetadataExpressions(unittest.TestCase):
     def test_empty_or_invalid_metadata_stays_empty(self) -> None:
         self.assertEqual(self._resolve(""), {})
         self.assertEqual(self._resolve("{"), {})
+
+
+class TestRagSearchFilterExpressions(unittest.TestCase):
+    """Search filters resolve by the same rules, so the dialog and the run agree."""
+
+    def setUp(self) -> None:
+        self.executor = WorkflowExecutor(nodes=[], edges=[])
+        self.inputs = {
+            "start": {
+                "url": "https://heym.run/docs",
+                "count": 7,
+                "title": 'He said "hello"',
+            }
+        }
+
+    def _resolve(self, parsed: object) -> dict | None:
+        return _resolve_filter_expressions(self.executor, parsed, self.inputs, "rag_1")
+
+    def test_resolves_a_plain_reference(self) -> None:
+        self.assertEqual(
+            self._resolve({"url": "$start.url"}),
+            {"url": "https://heym.run/docs"},
+        )
+
+    def test_keeps_the_resolved_type_so_a_number_filter_matches(self) -> None:
+        resolved = self._resolve({"count": "$start.count"})
+
+        assert resolved is not None
+        self.assertEqual(resolved["count"], 7)
+        self.assertIs(type(resolved["count"]), int)
+
+    def test_resolves_inside_a_text_template(self) -> None:
+        self.assertEqual(self._resolve({"label": "page $start.count"}), {"label": "page 7"})
+
+    def test_literal_filters_are_left_alone(self) -> None:
+        self.assertEqual(self._resolve({"category": "faq"}), {"category": "faq"})
+
+    def test_an_empty_filter_stays_empty(self) -> None:
+        self.assertEqual(self._resolve({}), {})
+
+    def test_a_non_object_filter_becomes_none(self) -> None:
+        self.assertIsNone(self._resolve(["faq"]))
 
 
 class TestRagMetadataWorkflowSource(unittest.TestCase):

--- a/frontend/src/components/Panels/propertiesPanel/nodes/RagNodeProperties.vue
+++ b/frontend/src/components/Panels/propertiesPanel/nodes/RagNodeProperties.vue
@@ -5,14 +5,10 @@ import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
 import SearchableSelect from "@/components/ui/SearchableSelect.vue";
 import Select from "@/components/ui/Select.vue";
-import Textarea from "@/components/ui/Textarea.vue";
 import { usePropertiesPanelContext } from "../usePropertiesPanelController";
 
 const {
   workflowStore,
-  ragQueryInputRef,
-  ragDocumentInputRef,
-  ragDocumentIdInputRef,
   selectedNode,
   selectedNodeEvaluateDialogLabel,
   vectorStoreOptions,
@@ -20,6 +16,11 @@ const {
   ragOperationOptions,
   cohereCredentialOptions,
   updateNodeData,
+  ragExpressionFieldCount,
+  ragExpressionFieldIndex,
+  setRagExpressionInputRef,
+  handleRagExpressionFieldNavigate,
+  onRagRegisterExpressionFieldIndex,
 } = usePropertiesPanelContext();
 </script>
 
@@ -102,7 +103,7 @@ const {
       <div class="space-y-2">
         <Label>Document ID <span class="text-destructive">*</span></Label>
         <ExpressionInput
-          ref="ragDocumentIdInputRef"
+          :ref="(el: unknown) => setRagExpressionInputRef('documentId', el)"
           :model-value="selectedNode.data.documentId || ''"
           placeholder="$input.id"
           :rows="1"
@@ -113,6 +114,11 @@ const {
           :dialog-node-label="selectedNodeEvaluateDialogLabel"
           dialog-key-label="Document ID"
           field-key="documentId"
+          :navigation-enabled="ragExpressionFieldCount > 1"
+          :navigation-index="ragExpressionFieldIndex('documentId')"
+          :navigation-total="ragExpressionFieldCount"
+          @navigate="handleRagExpressionFieldNavigate"
+          @register-field-index="onRagRegisterExpressionFieldIndex"
           @update:model-value="updateNodeData('documentId', $event)"
         />
         <p
@@ -141,7 +147,7 @@ const {
       <div class="space-y-2">
         <Label>Document Content <span class="text-destructive">*</span></Label>
         <ExpressionInput
-          ref="ragDocumentInputRef"
+          :ref="(el: unknown) => setRagExpressionInputRef('documentContent', el)"
           :model-value="selectedNode.data.documentContent || ''"
           placeholder="$input.text"
           :rows="3"
@@ -152,6 +158,11 @@ const {
           :dialog-node-label="selectedNodeEvaluateDialogLabel"
           dialog-key-label="Document content"
           field-key="documentContent"
+          :navigation-enabled="ragExpressionFieldCount > 1"
+          :navigation-index="ragExpressionFieldIndex('documentContent')"
+          :navigation-total="ragExpressionFieldCount"
+          @navigate="handleRagExpressionFieldNavigate"
+          @register-field-index="onRagRegisterExpressionFieldIndex"
           @update:model-value="updateNodeData('documentContent', $event)"
         />
         <p class="text-xs text-muted-foreground">
@@ -162,6 +173,7 @@ const {
       <div class="space-y-2">
         <Label>Document Metadata (JSON)</Label>
         <ExpressionInput
+          :ref="(el: unknown) => setRagExpressionInputRef('documentMetadata', el)"
           :model-value="selectedNode.data.documentMetadata || '{}'"
           placeholder="{&quot;source&quot;: &quot;manual&quot;, &quot;url&quot;: &quot;$start.url&quot;}"
           :rows="3"
@@ -172,6 +184,11 @@ const {
           :dialog-node-label="selectedNodeEvaluateDialogLabel"
           dialog-key-label="Document metadata"
           field-key="documentMetadata"
+          :navigation-enabled="ragExpressionFieldCount > 1"
+          :navigation-index="ragExpressionFieldIndex('documentMetadata')"
+          :navigation-total="ragExpressionFieldCount"
+          @navigate="handleRagExpressionFieldNavigate"
+          @register-field-index="onRagRegisterExpressionFieldIndex"
           @update:model-value="updateNodeData('documentMetadata', $event)"
         />
         <p class="text-xs text-muted-foreground">
@@ -185,7 +202,7 @@ const {
       <div class="space-y-2">
         <Label>Query Text <span class="text-destructive">*</span></Label>
         <ExpressionInput
-          ref="ragQueryInputRef"
+          :ref="(el: unknown) => setRagExpressionInputRef('queryText', el)"
           :model-value="selectedNode.data.queryText || ''"
           placeholder="$input.text"
           :rows="2"
@@ -196,6 +213,11 @@ const {
           :dialog-node-label="selectedNodeEvaluateDialogLabel"
           dialog-key-label="Query text"
           field-key="queryText"
+          :navigation-enabled="ragExpressionFieldCount > 1"
+          :navigation-index="ragExpressionFieldIndex('queryText')"
+          :navigation-total="ragExpressionFieldCount"
+          @navigate="handleRagExpressionFieldNavigate"
+          @register-field-index="onRagRegisterExpressionFieldIndex"
           @update:model-value="updateNodeData('queryText', $event)"
         />
         <p class="text-xs text-muted-foreground">
@@ -220,14 +242,28 @@ const {
 
       <div class="space-y-2">
         <Label>Metadata Filters (JSON)</Label>
-        <Textarea
+        <ExpressionInput
+          :ref="(el: unknown) => setRagExpressionInputRef('metadataFilters', el)"
           :model-value="selectedNode.data.metadataFilters || '{}'"
-          placeholder="{&quot;category&quot;: &quot;faq&quot;}"
+          placeholder="{&quot;category&quot;: &quot;faq&quot;, &quot;url&quot;: &quot;$start.url&quot;}"
           :rows="3"
+          :nodes="workflowStore.nodes"
+          :node-results="workflowStore.nodeResults"
+          :edges="workflowStore.edges"
+          :current-node-id="selectedNode.id"
+          :dialog-node-label="selectedNodeEvaluateDialogLabel"
+          dialog-key-label="Metadata filters"
+          field-key="metadataFilters"
+          :navigation-enabled="ragExpressionFieldCount > 1"
+          :navigation-index="ragExpressionFieldIndex('metadataFilters')"
+          :navigation-total="ragExpressionFieldCount"
+          @navigate="handleRagExpressionFieldNavigate"
+          @register-field-index="onRagRegisterExpressionFieldIndex"
           @update:model-value="updateNodeData('metadataFilters', $event)"
         />
         <p class="text-xs text-muted-foreground">
-          Filter results by metadata (exact match)
+          Filter results by metadata (exact match). Values support expressions, so
+          <code>{ "url": "$start.url" }</code> filters on the resolved value.
         </p>
       </div>
 

--- a/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
+++ b/frontend/src/components/Panels/propertiesPanel/usePropertiesPanelController.ts
@@ -600,9 +600,20 @@ export function usePropertiesPanelController() {
   >(new Map());
   const gristColumns = ref<{ id: string; name: string; type: string }[]>([]);
   const vectorStores = ref<{ id: string; name: string; backend: string }[]>([]);
-  const ragQueryInputRef = ref<ExpandableFieldRef | null>(null);
-  const ragDocumentInputRef = ref<ExpandableFieldRef | null>(null);
-  const ragDocumentIdInputRef = ref<ExpandableFieldRef | null>(null);
+  type RagExpressionFieldKey =
+    | "documentId"
+    | "documentContent"
+    | "documentMetadata"
+    | "queryText"
+    | "metadataFilters";
+
+  interface RagExpressionField {
+    key: RagExpressionFieldKey;
+    label: string;
+  }
+
+  const ragExpressionInputRefs = ref<Map<RagExpressionFieldKey, ExpandableFieldRef>>(new Map());
+  const currentRagExpressionFieldIndex = ref(0);
   const rabbitmqExchangeInputRef = ref<ExpandableFieldRef | null>(null);
   const rabbitmqRoutingKeyInputRef = ref<ExpandableFieldRef | null>(null);
   const rabbitmqQueueNameInputRef = ref<ExpandableFieldRef | null>(null);
@@ -2205,9 +2216,7 @@ export function usePropertiesPanelController() {
     redisKeyInputRef.value?.closeExpandDialog();
     variableValueInputRef.value?.closeExpandDialog();
     throwErrorMessageInputRef.value?.closeExpandDialog();
-    ragQueryInputRef.value?.closeExpandDialog();
-    ragDocumentInputRef.value?.closeExpandDialog();
-    ragDocumentIdInputRef.value?.closeExpandDialog();
+    closeRagExpressionDialogs();
     rabbitmqExchangeInputRef.value?.closeExpandDialog();
     rabbitmqRoutingKeyInputRef.value?.closeExpandDialog();
     rabbitmqQueueNameInputRef.value?.closeExpandDialog();
@@ -2646,24 +2655,16 @@ export function usePropertiesPanelController() {
         if (!n || n.type !== "rag") {
           return;
         }
-        const op = (n.data.ragOperation as string | undefined) || "";
-        const focusField = workflowStore.focusField;
-        if (focusField === "documentContent" && ragDocumentInputRef.value) {
-          nextTick(() => ragDocumentInputRef.value?.openExpandDialog());
-        } else if (focusField === "documentId" && ragDocumentIdInputRef.value) {
-          nextTick(() => ragDocumentIdInputRef.value?.openExpandDialog());
-        } else if (focusField === "queryText" && ragQueryInputRef.value) {
-          nextTick(() => ragQueryInputRef.value?.openExpandDialog());
-        } else if ((op === "insert" || op === "upsert") && ragDocumentInputRef.value) {
-          nextTick(() => ragDocumentInputRef.value?.openExpandDialog());
-        } else if (op === "delete" && ragDocumentIdInputRef.value) {
-          nextTick(() => ragDocumentIdInputRef.value?.openExpandDialog());
-        } else if (op === "search" && ragQueryInputRef.value) {
-          nextTick(() => ragQueryInputRef.value?.openExpandDialog());
-        } else if (ragQueryInputRef.value) {
-          nextTick(() => ragQueryInputRef.value?.openExpandDialog());
-        } else if (ragDocumentInputRef.value) {
-          nextTick(() => ragDocumentInputRef.value?.openExpandDialog());
+        const fields = ragExpressionFields.value;
+        if (fields.length === 0) {
+          return;
+        }
+        const focusField = workflowStore.focusField as RagExpressionFieldKey | null;
+        const startIndex = focusField ? ragExpressionFieldIndex(focusField) : 0;
+        const field = fields[startIndex];
+        if (field && ragExpressionInputRefs.value.get(field.key)) {
+          currentRagExpressionFieldIndex.value = startIndex;
+          nextTick(() => openRagExpressionFieldAtIndex(startIndex));
         } else {
           setTimeout(() => tryOpenDialog(attempts + 1), 100);
         }
@@ -5868,6 +5869,92 @@ export function usePropertiesPanelController() {
     nextTick(() => {
       openConverterExpressionFieldAtIndex(newIndex);
     });
+  }
+
+  /** Expression-capable rag fields, in the order the panel renders them. */
+  const ragExpressionFields = computed<RagExpressionField[]>(() => {
+    const n = workflowStore.selectedNode;
+    if (!n || n.type !== "rag") {
+      return [];
+    }
+    const operation = (n.data.ragOperation as string | undefined) || "";
+    if (operation === "search") {
+      return [
+        { key: "queryText", label: "Query text" },
+        { key: "metadataFilters", label: "Metadata filters" },
+      ];
+    }
+    if (operation === "delete") {
+      return [{ key: "documentId", label: "Document ID" }];
+    }
+    if (operation === "upsert") {
+      return [
+        { key: "documentId", label: "Document ID" },
+        { key: "documentContent", label: "Document content" },
+        { key: "documentMetadata", label: "Document metadata" },
+      ];
+    }
+    if (operation === "insert") {
+      return [
+        { key: "documentContent", label: "Document content" },
+        { key: "documentMetadata", label: "Document metadata" },
+      ];
+    }
+    return [];
+  });
+
+  const ragExpressionFieldCount = computed((): number => ragExpressionFields.value.length);
+
+  function ragExpressionFieldIndex(key: RagExpressionFieldKey): number {
+    const index = ragExpressionFields.value.findIndex((field) => field.key === key);
+    return index >= 0 ? index : 0;
+  }
+
+  function setRagExpressionInputRef(key: RagExpressionFieldKey, el: unknown): void {
+    if (el) {
+      ragExpressionInputRefs.value.set(key, el as ExpandableFieldRef);
+    } else {
+      ragExpressionInputRefs.value.delete(key);
+    }
+  }
+
+  function openRagExpressionFieldAtIndex(index: number): void {
+    const n = selectedNode.value;
+    if (!n || n.type !== "rag") {
+      return;
+    }
+    const field = ragExpressionFields.value[index];
+    if (!field) {
+      return;
+    }
+    currentRagExpressionFieldIndex.value = index;
+    ragExpressionInputRefs.value.get(field.key)?.openExpandDialog();
+  }
+
+  function closeRagExpressionDialogs(): void {
+    for (const input of ragExpressionInputRefs.value.values()) {
+      input.closeExpandDialog();
+    }
+  }
+
+  function handleRagExpressionFieldNavigate(direction: "prev" | "next"): void {
+    const total = ragExpressionFieldCount.value;
+    const newIndex =
+      direction === "prev"
+        ? currentRagExpressionFieldIndex.value - 1
+        : currentRagExpressionFieldIndex.value + 1;
+    if (newIndex < 0 || newIndex >= total) {
+      return;
+    }
+    closeRagExpressionDialogs();
+    currentRagExpressionFieldIndex.value = newIndex;
+    nextTick(() => {
+      openRagExpressionFieldAtIndex(newIndex);
+    });
+  }
+
+  function onRagRegisterExpressionFieldIndex(index: number): void {
+    currentRagExpressionFieldIndex.value = index;
   }
 
   const heymExpressionFields = computed<HeymExpressionField[]>(() => {
@@ -9132,9 +9219,12 @@ export function usePropertiesPanelController() {
     dataTableColumns,
     dataTableSelectiveValues,
     gristColumns,
-    ragQueryInputRef,
-    ragDocumentInputRef,
-    ragDocumentIdInputRef,
+    ragExpressionFields,
+    ragExpressionFieldCount,
+    ragExpressionFieldIndex,
+    setRagExpressionInputRef,
+    handleRagExpressionFieldNavigate,
+    onRagRegisterExpressionFieldIndex,
     rabbitmqExchangeInputRef,
     rabbitmqRoutingKeyInputRef,
     rabbitmqQueueNameInputRef,

--- a/frontend/src/docs/content/nodes/rag-node.md
+++ b/frontend/src/docs/content/nodes/rag-node.md
@@ -35,7 +35,7 @@ targets. See [Custom Embeddings](../reference/integrations.md#custom-embeddings-
 | `documentId` | expression | Value of the unique id (upsert, delete) |
 | `queryText` | expression | Search query (search only) |
 | `searchLimit` | number | Max results (default: 5) |
-| `metadataFilters` | JSON string | Metadata filters for search |
+| `metadataFilters` | JSON string | Metadata filters for search (values support expressions) |
 | `enableReranker` | boolean | Use Cohere to rerank search results |
 | `rerankerCredentialId` | UUID | Cohere credential for reranking |
 | `rerankerTopN` | number | Number of top results to keep after reranking |
@@ -67,8 +67,9 @@ whole expression keeps its resolved type — `{"count": "$start.count"}` stores 
 `"7"` — which matters because search `metadataFilters` match on exact type. Mixed text such as
 `"page $start.count"` resolves to a string, and nested objects and arrays are walked too.
 
-The same applies to `upsert`. Search's `metadataFilters` field is still a literal JSON object
-and does not resolve expressions.
+The same applies to `upsert`, and to search's `metadataFilters`: it is parsed first and its
+values resolved after, by the same rules. So a filter written as `{"count": "$start.count"}`
+matches the number an insert stored, rather than the string `"7"`.
 
 ### Which workflow stored a document
 
@@ -124,7 +125,7 @@ Semantic search for similar documents.
 |-------|----------|-------------|
 | `queryText` | yes | Search query |
 | `searchLimit` | no | Max results (default: 5) |
-| `metadataFilters` | no | Filter by metadata (exact match JSON object) |
+| `metadataFilters` | no | Filter by metadata (exact match JSON object, values support expressions) |
 | `enableReranker` | no | Enable Cohere reranking for better relevance |
 | `rerankerCredentialId` | when reranking | Cohere credential |
 | `rerankerTopN` | no | Final number of results after reranking |


### PR DESCRIPTION
Enhance RAG node and workflow execution handling

- Introduced support for resolving expressions in metadata filters for search operations, allowing dynamic filtering based on document metadata.
- Updated the execute workflow stream to ensure proper handling of sub-workflows, ensuring that parent workflows are marked as complete when sub-workflows finish.
- Added tests to validate the registration of active executions and the reporting of progress for dispatched sub-workflows.
- Refactored UI components to streamline the handling of RAG expression fields, improving user experience in the properties panel.
- Enhanced documentation to clarify the behavior of metadata filters and their support for expressions.