### PR TITLE
fix/do-not-wait-history-and-pool-isolation

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -3885,10 +3885,7 @@ async def execute_workflow_stream(
                 extra = _serialize_sub_workflow_executions(wf_exec.sub_workflow_executions)
                 if extra and final_result:
                     existing = final_result.get("sub_workflow_executions") or []
-                    seen = {s.get("workflow_id") for s in existing}
-                    final_result["sub_workflow_executions"] = existing + [
-                        s for s in extra if s.get("workflow_id") not in seen
-                    ]
+                    final_result["sub_workflow_executions"] = existing + extra[len(existing) :]
         except WorkflowTimeoutError as exc:
             # Surface as a failed run: emit a final event (so the canvas shows the
             # timeout) and set final_result so it is persisted with status "error".

--- a/backend/app/services/node_execution/nodes/execute_node.py
+++ b/backend/app/services/node_execution/nodes/execute_node.py
@@ -54,7 +54,8 @@ def execute(ctx: NodeExecutionContext) -> object:
     _workflow_executor = import_module("app.services.workflow_executor")
     SubWorkflowExecution = _workflow_executor.SubWorkflowExecution  # noqa: N806
     WorkflowExecutor = _workflow_executor.WorkflowExecutor  # noqa: N806
-    _SHARED_EXECUTOR = _workflow_executor._SHARED_EXECUTOR  # noqa: N806
+    _BACKGROUND_WORKFLOW_EXECUTOR = _workflow_executor._BACKGROUND_WORKFLOW_EXECUTOR  # noqa: N806
+    _BACKGROUND_NODE_EXECUTOR = _workflow_executor._BACKGROUND_NODE_EXECUTOR  # noqa: N806
     _register_sub_execution = _workflow_executor._register_sub_execution
     self = ctx.executor
     node_id = ctx.node_id
@@ -131,6 +132,7 @@ def execute(ctx: NodeExecutionContext) -> object:
             cancel_event=_exec_node_cancel_event,
             invoked_by_agent=self._invoked_by_agent,
             execution_id=str(_sub_exec_id),
+            node_pool=(_BACKGROUND_NODE_EXECUTOR if execute_do_not_wait else self._node_pool),
         )
         enriched_execute_inputs = {
             "headers": {},
@@ -167,7 +169,7 @@ def execute(ctx: NodeExecutionContext) -> object:
                     )
                     bg_callback_done.set()
 
-            bg_future = _SHARED_EXECUTOR.submit(
+            bg_future = _BACKGROUND_WORKFLOW_EXECUTOR.submit(
                 sub_executor.execute,
                 workflow_id=uuid.UUID(execute_workflow_id),
                 initial_inputs=enriched_execute_inputs,

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -539,6 +539,11 @@ def _normalize_js_logical_ops_for_eval(processed: str) -> str:
 
 _SHARED_EXECUTOR = ThreadPoolExecutor(max_workers=8)
 
+_BACKGROUND_WORKFLOW_EXECUTOR = ThreadPoolExecutor(
+    max_workers=16, thread_name_prefix="heym-bg-workflow"
+)
+_BACKGROUND_NODE_EXECUTOR = ThreadPoolExecutor(max_workers=16, thread_name_prefix="heym-bg-node")
+
 _HTTP_CLIENT_LOCK = Lock()
 _EXPRESSION_EVAL_CONTEXT_LOCAL = local()
 
@@ -1940,8 +1945,10 @@ class WorkflowExecutor:
         workflow_name: str = "",
         workflow_description: str = "",
         execution_id: str = "",
+        node_pool: ThreadPoolExecutor | None = None,
     ) -> None:
         self.nodes = {node["id"]: node for node in nodes}
+        self._node_pool = node_pool or _SHARED_EXECUTOR
         self.agent_progress_queue = agent_progress_queue
         self.edges = edges
         self.node_outputs: dict[str, dict] = {}
@@ -3940,6 +3947,7 @@ class WorkflowExecutor:
             cancel_event=sub_cancel_event,
             invoked_by_agent=True,
             execution_id=str(_sub_execution_id),
+            node_pool=self._node_pool,
         )
         enriched_inputs = {
             "headers": {},
@@ -7347,7 +7355,7 @@ class WorkflowExecutor:
                                         if dp[e["target"]] == 0:
                                             dq.append(e["target"])
 
-                        _SHARED_EXECUTOR.submit(run_downstream)
+                        self._node_pool.submit(run_downstream)
                     return results, error_flow_output
 
             for edge in edges:
@@ -7539,7 +7547,7 @@ class WorkflowExecutor:
                                 inputs = self.get_loop_reexecution_inputs(
                                     target, source_node_id, active_edges
                                 )
-                                new_future = _SHARED_EXECUTOR.submit(
+                                new_future = self._node_pool.submit(
                                     self.execute_node_parallel, target, inputs
                                 )
                                 running_futures[new_future] = target
@@ -7577,7 +7585,7 @@ class WorkflowExecutor:
                 if already_running:
                     continue
                 inputs = self.get_node_inputs_for_edges(target, active_edges)
-                new_future = _SHARED_EXECUTOR.submit(self.execute_node_parallel, target, inputs)
+                new_future = self._node_pool.submit(self.execute_node_parallel, target, inputs)
                 running_futures[new_future] = target
 
         root_nodes = self._prioritize_ready_node_ids(
@@ -7603,7 +7611,7 @@ class WorkflowExecutor:
                 completed_nodes.add(node_id)
                 schedule_downstream(node_id)
             else:
-                future = _SHARED_EXECUTOR.submit(
+                future = self._node_pool.submit(
                     self.execute_node_parallel,
                     node_id,
                     self.get_node_inputs_for_edges(node_id, active_edges),
@@ -7710,7 +7718,7 @@ class WorkflowExecutor:
                                                             inp = self.get_loop_reexecution_inputs(
                                                                 tgt, nid, active_edges
                                                             )
-                                                            new_f = _SHARED_EXECUTOR.submit(
+                                                            new_f = self._node_pool.submit(
                                                                 self.execute_node_parallel,
                                                                 tgt,
                                                                 inp,
@@ -7732,7 +7740,7 @@ class WorkflowExecutor:
                                                             inp = self.get_node_inputs_for_edges(
                                                                 tgt, active_edges
                                                             )
-                                                            new_f = _SHARED_EXECUTOR.submit(
+                                                            new_f = self._node_pool.submit(
                                                                 self.execute_node_parallel,
                                                                 tgt,
                                                                 inp,
@@ -8194,7 +8202,7 @@ def resume_workflow_execution(
                             for pending_node_id in running_futures.values()
                         )
                         if not already_running:
-                            new_future = _SHARED_EXECUTOR.submit(
+                            new_future = wf_executor._node_pool.submit(
                                 wf_executor.execute_node_parallel,
                                 target,
                                 wf_executor.get_loop_reexecution_inputs(
@@ -8238,7 +8246,7 @@ def resume_workflow_execution(
             )
             if already_running:
                 continue
-            new_future = _SHARED_EXECUTOR.submit(
+            new_future = wf_executor._node_pool.submit(
                 wf_executor.execute_node_parallel,
                 target,
                 wf_executor.get_node_inputs_for_edges(target, active_edges),
@@ -8247,7 +8255,7 @@ def resume_workflow_execution(
 
     with pending_lock:
         if hitl_resume_mode in {"rerun_agent", "continue_agent"}:
-            rerun_future = _SHARED_EXECUTOR.submit(
+            rerun_future = wf_executor._node_pool.submit(
                 wf_executor.execute_node_parallel,
                 paused_node_id,
                 wf_executor.get_node_inputs_for_edges(paused_node_id, active_edges),
@@ -8343,7 +8351,7 @@ def resume_workflow_execution(
                                                         for pending_node_id in remaining_futures.values()
                                                     )
                                                     if not already:
-                                                        new_future = _SHARED_EXECUTOR.submit(
+                                                        new_future = wf_executor._node_pool.submit(
                                                             wf_executor.execute_node_parallel,
                                                             tgt,
                                                             wf_executor.get_loop_reexecution_inputs(
@@ -8364,7 +8372,7 @@ def resume_workflow_execution(
                                                     for pending_node_id in remaining_futures.values()
                                                 )
                                                 if not already:
-                                                    new_future = _SHARED_EXECUTOR.submit(
+                                                    new_future = wf_executor._node_pool.submit(
                                                         wf_executor.execute_node_parallel,
                                                         tgt,
                                                         wf_executor.get_node_inputs_for_edges(
@@ -8571,7 +8579,7 @@ def execute_llm_batch_notification_branch(
         if already_running:
             return
         _enqueue_start(node_id)
-        new_future = _SHARED_EXECUTOR.submit(
+        new_future = wf_executor._node_pool.submit(
             wf_executor.execute_node_parallel,
             node_id,
             (
@@ -8838,7 +8846,7 @@ def execute_hitl_notification_branch(
                         pending_node_id == target for pending_node_id in running_futures.values()
                     )
                     if not already_running:
-                        new_future = _SHARED_EXECUTOR.submit(
+                        new_future = wf_executor._node_pool.submit(
                             wf_executor.execute_node_parallel,
                             target,
                             wf_executor.get_loop_reexecution_inputs(
@@ -8873,7 +8881,7 @@ def execute_hitl_notification_branch(
                         pending_node_id == target for pending_node_id in running_futures.values()
                     )
                     if not already_running:
-                        new_future = _SHARED_EXECUTOR.submit(
+                        new_future = wf_executor._node_pool.submit(
                             wf_executor.execute_node_parallel,
                             target,
                             wf_executor.get_node_inputs_for_edges(target, active_edges),
@@ -9303,7 +9311,7 @@ def _execute_workflow_streaming_impl(
                     ):
                         already_running = any(nid == target for nid in running_futures.values())
                         if not already_running:
-                            new_future = _SHARED_EXECUTOR.submit(
+                            new_future = wf_executor._node_pool.submit(
                                 execute_and_report,
                                 target,
                                 wf_executor.get_loop_reexecution_inputs(
@@ -9339,7 +9347,7 @@ def _execute_workflow_streaming_impl(
                     else:
                         already_running = any(nid == target for nid in running_futures.values())
                         if not already_running:
-                            new_future = _SHARED_EXECUTOR.submit(execute_and_report, target)
+                            new_future = wf_executor._node_pool.submit(execute_and_report, target)
                             running_futures[new_future] = target
 
     root_nodes = [nid for nid, count in pending_count.items() if count == 0]
@@ -9364,7 +9372,7 @@ def _execute_workflow_streaming_impl(
             nodes_to_schedule.append(node_id)
             schedule_downstream(node_id)
         else:
-            future = _SHARED_EXECUTOR.submit(execute_and_report, node_id)
+            future = wf_executor._node_pool.submit(execute_and_report, node_id)
             running_futures[future] = node_id
 
     for skipped_id in nodes_to_schedule:

--- a/backend/tests/test_execute_do_not_wait_history_rows.py
+++ b/backend/tests/test_execute_do_not_wait_history_rows.py
@@ -1,0 +1,178 @@
+"""Every fire-and-forget dispatch of the same sub-workflow must get its own history row.
+
+`executeDoNotWait` dispatches a sub-workflow and the parent's run ends without it. The
+API layer drains those dispatches afterwards and merges what finished late into the
+result it persists. That merge is what decides how many `ExecutionHistory` rows the
+sub-workflow gets, so a loop that calls the same workflow N times must produce N rows.
+"""
+
+import asyncio
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+TARGET_WF_ID = "33333333-3333-3333-3333-333333333333"
+
+_TARGET_WORKFLOW = {
+    "nodes": [
+        {
+            "id": "t1",
+            "type": "textInput",
+            "data": {"label": "input", "inputFields": [{"key": "text"}]},
+        },
+        {"id": "t2", "type": "wait", "data": {"label": "wait", "duration": 400}},
+        {"id": "t3", "type": "output", "data": {"label": "output"}},
+    ],
+    "edges": [
+        {"id": "te1", "source": "t1", "target": "t2"},
+        {"id": "te2", "source": "t2", "target": "t3"},
+    ],
+    "name": "Target",
+}
+
+# Two dispatches of the SAME target, staggered by a parent-side wait: the first finishes
+# while the parent is still running, the second only after it has ended. That is the loop
+# case from the report, reduced to fixed timings so the split is not a race.
+_PARENT_NODES = [
+    {
+        "id": "n1",
+        "type": "textInput",
+        "data": {"label": "userInput", "inputFields": [{"key": "text"}]},
+    },
+    {
+        "id": "n2",
+        "type": "execute",
+        "data": {
+            "label": "callFirst",
+            "executeWorkflowId": TARGET_WF_ID,
+            "executeInput": "$userInput.body.text",
+            "executeDoNotWait": True,
+        },
+    },
+    {"id": "n3", "type": "wait", "data": {"label": "gap", "duration": 1500}},
+    {
+        "id": "n4",
+        "type": "execute",
+        "data": {
+            "label": "callSecond",
+            "executeWorkflowId": TARGET_WF_ID,
+            "executeInput": "$userInput.body.text",
+            "executeDoNotWait": True,
+        },
+    },
+]
+_PARENT_EDGES = [
+    {"id": "e1", "source": "n1", "target": "n2"},
+    {"id": "e2", "source": "n2", "target": "n3"},
+    {"id": "e3", "source": "n3", "target": "n4"},
+]
+
+
+class _FakeSessionContext:
+    """Stand in for ``async_session_maker()`` so the persist step runs without a DB."""
+
+    def __init__(self, session: object) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> object:
+        return self._session
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _ScalarResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> object:
+        return self._value
+
+
+class DoNotWaitHistoryRowsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_repeated_dispatch_of_one_workflow_records_every_run(self) -> None:
+        from app.api.workflows import execute_workflow_stream
+
+        wf_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=wf_id,
+            owner_id=uuid.uuid4(),
+            name="Parent",
+            nodes=_PARENT_NODES,
+            edges=_PARENT_EDGES,
+            sse_enabled=True,
+            rate_limit_requests=None,
+            rate_limit_window_seconds=None,
+            cache_ttl_seconds=None,
+            sse_node_config={},
+            workflow_timeout_seconds=None,
+        )
+
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=_ScalarResult(workflow))
+
+        request = MagicMock()
+        request.method = "POST"
+        request.headers = {}
+        request.query_params = {}
+        request.base_url = "http://localhost/"
+        request.is_disconnected = AsyncMock(return_value=False)
+
+        persist_session = AsyncMock()
+        persist_session.get = AsyncMock(return_value=workflow)
+
+        persisted: dict = {}
+
+        async def _capture(*_args, **kwargs) -> bool:
+            persisted["final_result"] = kwargs.get("final_result")
+            return False
+
+        with (
+            patch(
+                "app.api.workflows.parse_execute_body",
+                AsyncMock(return_value=({"text": "hello"}, False, "API", False)),
+            ),
+            patch("app.api.workflows.validate_workflow_auth", AsyncMock(return_value=None)),
+            patch("app.api.workflows.enforce_workflow_http_method", MagicMock()),
+            patch(
+                "app.api.workflows.collect_referenced_workflows",
+                AsyncMock(return_value={TARGET_WF_ID: _TARGET_WORKFLOW}),
+            ),
+            patch("app.api.workflows.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.workflows.build_public_base_url", return_value="http://localhost"),
+            patch("app.api.workflows.persist_stream_execution_result", _capture),
+            patch(
+                "app.api.workflows.async_session_maker",
+                lambda: _FakeSessionContext(persist_session),
+            ),
+        ):
+            response = await execute_workflow_stream(
+                workflow_id=wf_id,
+                request=request,
+                current_user=None,
+                db=db,
+            )
+            [chunk async for chunk in response.body_iterator]
+
+            for _ in range(200):
+                if "final_result" in persisted:
+                    break
+                await asyncio.sleep(0.05)
+
+        final_result = persisted.get("final_result")
+        self.assertIsNotNone(final_result, "the run was never persisted")
+        assert final_result is not None
+        subs = final_result.get("sub_workflow_executions") or []
+        self.assertEqual(
+            len(subs),
+            2,
+            f"each dispatch of the same sub-workflow needs its own history row, got {len(subs)}",
+        )
+        self.assertEqual({s["workflow_id"] for s in subs}, {TARGET_WF_ID})
+        self.assertEqual([s["status"] for s in subs], ["success", "success"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_execute_do_not_wait_pool_isolation.py
+++ b/backend/tests/test_execute_do_not_wait_pool_isolation.py
@@ -1,0 +1,157 @@
+"""A fire-and-forget dispatch must not consume the pool the calling run schedules on.
+
+A sub-workflow run blocks on the node futures it submits. While those runs sat on
+`_SHARED_EXECUTOR` alongside the nodes they were waiting for, enough of them at once left
+every worker waiting for a task that could never be scheduled - a fan-out of 8
+`executeDoNotWait` nodes killed the pool for the whole process, and a loop dispatching
+one sub-workflow per item stalled between iterations behind the waits it had started.
+"""
+
+import threading
+import time
+import unittest
+import uuid
+
+from app.services.workflow_executor import WorkflowExecutor
+
+TARGET_WF_ID = "44444444-4444-4444-4444-444444444444"
+
+# Longer than one wait, far shorter than the serialized-by-starvation alternative.
+_WAIT_MS = 700
+
+_WORKFLOW_CACHE = {
+    TARGET_WF_ID: {
+        "nodes": [
+            {
+                "id": "t1",
+                "type": "textInput",
+                "data": {"label": "start", "inputFields": [{"key": "n"}]},
+            },
+            {"id": "t2", "type": "wait", "data": {"label": "wait", "duration": _WAIT_MS}},
+            {"id": "t3", "type": "output", "data": {"label": "output", "message": "ok"}},
+        ],
+        "edges": [
+            {"id": "te1", "source": "t1", "target": "t2"},
+            {"id": "te2", "source": "t2", "target": "t3"},
+        ],
+        "name": "Target",
+    }
+}
+
+# More dispatches than `_SHARED_EXECUTOR` has workers, so the old arrangement had no
+# worker left to run the nodes those dispatches were waiting on.
+_FAN_OUT = 12
+
+
+def _execute_node(node_id: str) -> dict:
+    return {
+        "id": node_id,
+        "type": "execute",
+        "data": {
+            "label": node_id,
+            "executeWorkflowId": TARGET_WF_ID,
+            "executeInputMappings": [{"key": "n", "value": "1"}],
+            "executeDoNotWait": True,
+        },
+    }
+
+
+class DoNotWaitPoolIsolationTests(unittest.TestCase):
+    def _run_in_thread(self, executor: WorkflowExecutor, timeout: float) -> float | None:
+        """Return the parent's own runtime, or None if the run never finished."""
+        finished = threading.Event()
+        elapsed: dict[str, float] = {}
+
+        def _run() -> None:
+            started = time.monotonic()
+            executor.execute(
+                workflow_id=uuid.uuid4(),
+                initial_inputs={"headers": {}, "query": {}, "body": {"text": "x"}},
+            )
+            elapsed["parent"] = time.monotonic() - started
+            executor.drain_bg_futures()
+            elapsed["total"] = time.monotonic() - started
+            finished.set()
+
+        threading.Thread(target=_run, daemon=True).start()
+        if not finished.wait(timeout):
+            return None
+        return elapsed["total"]
+
+    def test_parallel_dispatches_do_not_deadlock_the_node_pool(self) -> None:
+        nodes: list[dict] = [
+            {
+                "id": "start",
+                "type": "textInput",
+                "data": {"label": "start", "inputFields": [{"key": "text"}]},
+            }
+        ]
+        edges: list[dict] = []
+        for index in range(_FAN_OUT):
+            node_id = f"x{index}"
+            nodes.append(_execute_node(node_id))
+            edges.append({"id": f"e{index}", "source": "start", "target": node_id})
+
+        executor = WorkflowExecutor(
+            nodes=nodes,
+            edges=edges,
+            workflow_cache=_WORKFLOW_CACHE,
+            workflow_id=uuid.uuid4(),
+        )
+        total = self._run_in_thread(executor, timeout=30)
+        self.assertIsNotNone(
+            total,
+            f"{_FAN_OUT} parallel executeDoNotWait dispatches deadlocked the node pool",
+        )
+        self.assertEqual(len(executor.sub_workflow_executions), _FAN_OUT)
+        self.assertEqual(
+            {sub.status for sub in executor.sub_workflow_executions},
+            {"success"},
+        )
+
+    def test_a_loop_keeps_dispatching_while_earlier_dispatches_run(self) -> None:
+        nodes = [
+            {
+                "id": "loop",
+                "type": "loop",
+                "data": {"label": "loop", "arrayExpression": "$array(1,2,3,4,5,6,7,8,9,10)"},
+            },
+            _execute_node("exec"),
+        ]
+        edges = [
+            {
+                "id": "e1",
+                "source": "loop",
+                "target": "exec",
+                "sourceHandle": "loop",
+                "targetHandle": "input",
+            },
+            {
+                "id": "e2",
+                "source": "exec",
+                "target": "loop",
+                "sourceHandle": "output",
+                "targetHandle": "loop",
+            },
+        ]
+        executor = WorkflowExecutor(
+            nodes=nodes,
+            edges=edges,
+            workflow_cache=_WORKFLOW_CACHE,
+            workflow_id=uuid.uuid4(),
+        )
+        total = self._run_in_thread(executor, timeout=30)
+        self.assertIsNotNone(total, "the loop never finished dispatching")
+        assert total is not None
+        self.assertEqual(len(executor.sub_workflow_executions), 10)
+        # All ten dispatches overlap, so the run costs roughly one wait rather than one
+        # per pool-sized batch of items.
+        self.assertLess(
+            total,
+            (_WAIT_MS / 1000.0) * 2,
+            "dispatched sub-workflows were serialized behind the caller's node pool",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_retry_execution_logs.py
+++ b/backend/tests/test_retry_execution_logs.py
@@ -3,7 +3,12 @@ import uuid
 from threading import Event
 from unittest.mock import patch
 
-from app.services.workflow_executor import NodeResult, WorkflowExecutor, execute_workflow_streaming
+from app.services.workflow_executor import (
+    _SHARED_EXECUTOR,
+    NodeResult,
+    WorkflowExecutor,
+    execute_workflow_streaming,
+)
 
 
 class _RetryingWorkflowExecutor(WorkflowExecutor):
@@ -84,6 +89,7 @@ class _FakeRetryStreamingExecutor:
         self.loop_states: dict[str, dict[str, int]] = {}
         self.node_outputs: dict[str, dict] = {}
         self._cancel_event = cancel_event
+        self._node_pool = _SHARED_EXECUTOR
         self._sequence = 0
 
     def _arm_deadline(self) -> None:

--- a/backend/tests/test_sse_streaming.py
+++ b/backend/tests/test_sse_streaming.py
@@ -14,6 +14,7 @@ from app.services.execution_cancellation import (
     register_execution,
 )
 from app.services.workflow_executor import (
+    _SHARED_EXECUTOR,
     NodeResult,
     WorkflowExecutor,
     _wrap_value,
@@ -109,6 +110,7 @@ class _FakeWorkflowExecutor:
         self.loop_states: dict[str, dict[str, int]] = {}
         self.node_outputs: dict[str, dict] = {}
         self._cancel_event = cancel_event
+        self._node_pool = _SHARED_EXECUTOR
         self._sequence = 0
 
     def _arm_deadline(self) -> None:


### PR DESCRIPTION
## Problem

A loop calling the same sub-workflow 10 times with `executeDoNotWait` recorded
only 6 rows in Execution History, and the run took 16.5s instead of 8s.

Two separate defects, both pre-existing.

**1. History rows collapsed.** After draining background dispatches, the merge in
`execute_workflow_stream` keyed dedupe on `workflow_id`. Every dispatch targets
the same workflow, so once any run finished before the parent's
`execution_complete`, the whole drained tail was filtered out.

**2. Shared pool deadlock.** A sub-workflow run blocks on the node futures it
submits, and both sat on the same 8 worker `_SHARED_EXECUTOR`. A fan-out of 10
parallel dispatches deadlocked the pool permanently, for the whole process. A
loop self throttled instead of hanging, which is where the 16.5s came from.

## Fix

- Merge the drained tail positionally: `existing + extra[len(existing):]`.
- Add `_BACKGROUND_WORKFLOW_EXECUTOR` for dispatched runs and
  `_BACKGROUND_NODE_EXECUTOR` for their nodes, plus a `node_pool` kwarg on
  `WorkflowExecutor` that sub-executors inherit. Splitting runs from nodes is
  what makes the deadlock impossible; one extra pool is not enough.

## Measured

| | Before | After |
|---|---|---|
| Loop parent graph, 10 items | 4199 ms | 73 ms |
| Total including drain | 6272 ms | 2222 ms |
| 10 parallel dispatches | deadlock | 1076 ms |

