### PR TITLE
update/hitl-background-multimode-worker

### DIFF
--- a/backend/app/api/discord.py
+++ b/backend/app/api/discord.py
@@ -30,6 +30,11 @@ from app.db.session import async_session_maker
 from app.services.cluster.dispatch import dispatch_workflow
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 
 logger = logging.getLogger("discord_webhook")
 
@@ -295,6 +300,32 @@ async def _execute_workflow_background(
                     workflow.id,
                     result.status,
                 )
+                return
+
+            if needs_local_pending_persist(result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=fresh_workflow,
+                    enriched_inputs=redact(inputs),
+                    execution_result=result,
+                    trigger_source="Discord",
+                    credentials_owner_id=fresh_workflow.owner_id,
+                    trace_user_id=fresh_workflow.owner_id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                    redact=redact,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=fresh_workflow.id,
+                    owner_id=fresh_workflow.owner_id,
+                    workflow_name_snapshot=fresh_workflow.name,
+                    status=result.status,
+                    execution_time_ms=result.execution_time_ms,
+                )
+                await db.commit()
+                logger.info("Workflow %s paused for human review via Discord", workflow.id)
+                await _send_discord_followup_message(interaction_body, result.outputs)
                 return
 
             history_entry = ExecutionHistory(

--- a/backend/app/api/mcp.py
+++ b/backend/app/api/mcp.py
@@ -60,9 +60,16 @@ from app.services.execution_cancellation import (
     register_execution,
 )
 from app.services.global_variables_service import get_global_variables_context
-from app.services.hitl_service import build_public_base_url
+from app.services.hitl_service import (
+    build_default_public_base_url,
+    build_public_base_url,
+)
 from app.services.mcp_session import mcp_session_store, mcp_sse_channels
 from app.services.oauth_tokens import hash_oauth_token
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 from app.services.secret_tokens import hash_secret
 
 router = APIRouter()
@@ -1071,10 +1078,39 @@ async def call_mcp_tool(
             cancel_event=cancel_event,
         )
 
+        if needs_local_pending_persist(execution_result):
+            await persist_pending_execution(
+                db=db,
+                workflow=target_workflow,
+                enriched_inputs=enriched_inputs,
+                execution_result=execution_result,
+                trigger_source="MCP",
+                credentials_owner_id=mcp_user.id,
+                trace_user_id=mcp_user.id,
+                public_base_url=build_default_public_base_url(),
+                history_entry_id=execution_id,
+            )
+            await upsert_workflow_analytics_snapshot(
+                db,
+                workflow_id=target_workflow.id,
+                owner_id=target_workflow.owner_id,
+                workflow_name_snapshot=target_workflow.name,
+                status=execution_result.status,
+                execution_time_ms=execution_result.execution_time_ms,
+            )
+            _add_mcp_workflow_trace(
+                db,
+                user_id=mcp_user.id,
+                workflow=target_workflow,
+                tool_name=tool_name,
+                arguments=arguments,
+                execution_result=execution_result,
+            )
+            await db.flush()
         # An offloaded run already wrote its history, traces and analytics on
         # the instance that executed it; writing them again would collide on
         # the execution id.
-        if not getattr(execution_result, "history_written", False):
+        elif not getattr(execution_result, "history_written", False):
             # Save execution history with MCP trigger source
             history_entry = ExecutionHistory(
                 id=execution_id,
@@ -1281,10 +1317,39 @@ async def _dispatch_mcp_jsonrpc(
                 cancel_event=cancel_event,
             )
 
+            if needs_local_pending_persist(execution_result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=target_workflow,
+                    enriched_inputs=enriched_inputs,
+                    execution_result=execution_result,
+                    trigger_source="MCP",
+                    credentials_owner_id=mcp_user.id,
+                    trace_user_id=mcp_user.id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=target_workflow.id,
+                    owner_id=target_workflow.owner_id,
+                    workflow_name_snapshot=target_workflow.name,
+                    status=execution_result.status,
+                    execution_time_ms=execution_result.execution_time_ms,
+                )
+                _add_mcp_workflow_trace(
+                    db,
+                    user_id=mcp_user.id,
+                    workflow=target_workflow,
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    execution_result=execution_result,
+                )
+                await db.flush()
             # An offloaded run already wrote its history, traces and analytics on
             # the instance that executed it; writing them again would collide on
             # the execution id.
-            if not getattr(execution_result, "history_written", False):
+            elif not getattr(execution_result, "history_written", False):
                 # Save execution history with MCP trigger source
                 history_entry = ExecutionHistory(
                     id=execution_id,

--- a/backend/app/api/mcp_servers.py
+++ b/backend/app/api/mcp_servers.py
@@ -57,8 +57,13 @@ from app.services.cluster.dispatch import dispatch_workflow
 from app.services.execution_cancellation import clear_execution as clear_active_execution
 from app.services.execution_cancellation import register_execution
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
 from app.services.mcp_session import mcp_session_store, mcp_sse_channels
 from app.services.oauth_tokens import hash_oauth_token
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 from app.services.secret_tokens import hash_secret
 
 router = APIRouter()
@@ -574,10 +579,31 @@ async def _dispatch_named_server_jsonrpc(
                 cancel_event=cancel_event,
             )
 
+            if needs_local_pending_persist(execution_result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=target_workflow,
+                    enriched_inputs=enriched_inputs,
+                    execution_result=execution_result,
+                    trigger_source="MCP",
+                    credentials_owner_id=user.id,
+                    trace_user_id=user.id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=target_workflow.id,
+                    owner_id=target_workflow.owner_id,
+                    workflow_name_snapshot=target_workflow.name,
+                    status=execution_result.status,
+                    execution_time_ms=execution_result.execution_time_ms,
+                )
+                await db.flush()
             # An offloaded run already wrote its history and analytics on the
             # instance that executed it; writing them again would collide on the
             # execution id.
-            if not getattr(execution_result, "history_written", False):
+            elif not getattr(execution_result, "history_written", False):
                 history_entry = ExecutionHistory(
                     id=execution_id,
                     workflow_id=target_workflow.id,

--- a/backend/app/api/slack.py
+++ b/backend/app/api/slack.py
@@ -27,6 +27,11 @@ from app.db.session import async_session_maker
 from app.services.cluster.dispatch import dispatch_workflow
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 
 logger = logging.getLogger("slack_webhook")
 
@@ -175,6 +180,30 @@ async def _execute_workflow_background(
                     workflow.id,
                     result.status,
                 )
+                return
+
+            if needs_local_pending_persist(result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=fresh_workflow,
+                    enriched_inputs=inputs,
+                    execution_result=result,
+                    trigger_source="Slack",
+                    credentials_owner_id=fresh_workflow.owner_id,
+                    trace_user_id=fresh_workflow.owner_id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=fresh_workflow.id,
+                    owner_id=fresh_workflow.owner_id,
+                    workflow_name_snapshot=fresh_workflow.name,
+                    status=result.status,
+                    execution_time_ms=result.execution_time_ms,
+                )
+                await db.commit()
+                logger.info("Workflow %s paused for human review via Slack", workflow.id)
                 return
 
             history_entry = ExecutionHistory(

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -23,6 +23,11 @@ from app.db.session import async_session_maker
 from app.services.cluster.dispatch import dispatch_workflow
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 
 logger = logging.getLogger("telegram_webhook")
 
@@ -176,6 +181,30 @@ async def _execute_workflow_background(
                     workflow.id,
                     result.status,
                 )
+                return
+
+            if needs_local_pending_persist(result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=fresh_workflow,
+                    enriched_inputs=inputs,
+                    execution_result=result,
+                    trigger_source="telegram",
+                    credentials_owner_id=fresh_workflow.owner_id,
+                    trace_user_id=fresh_workflow.owner_id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=fresh_workflow.id,
+                    owner_id=fresh_workflow.owner_id,
+                    workflow_name_snapshot=fresh_workflow.name,
+                    status=result.status,
+                    execution_time_ms=result.execution_time_ms,
+                )
+                await db.commit()
+                logger.info("Workflow %s paused for human review via Telegram", workflow.id)
                 return
 
             history_entry = ExecutionHistory(

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -113,6 +113,7 @@ from app.services.hitl_service import (
     persist_pending_hitl_execution,
 )
 from app.services.html_response import build_html_response, find_sole_html_terminal
+from app.services.pending_execution import needs_local_pending_persist
 from app.services.workflow_access import workflow_access_clause
 from app.services.workflow_executor import (
     ExecutionResult,
@@ -3136,7 +3137,7 @@ async def execute_workflow_endpoint(
     finally:
         clear_active_execution(execution_id)
 
-    if execution_result.status == "pending":
+    if needs_local_pending_persist(execution_result):
         if is_codex_pending_execution(execution_result):
             history_entry, _ = await persist_pending_codex_followup_execution(
                 db=db,
@@ -3202,6 +3203,7 @@ async def execute_workflow_endpoint(
     # An offloaded run wrote its history on the instance that executed it;
     # writing it again here would collide on the execution id.
     already_written = getattr(execution_result, "history_written", False)
+    remote_history_id = execution_id if already_written and not test_run else None
     if not test_run and not already_written:
         history_entry = ExecutionHistory(
             id=execution_id,
@@ -3349,7 +3351,7 @@ async def execute_workflow_endpoint(
         outputs=execution_result.outputs,
         node_results=execution_result.node_results,
         execution_time_ms=execution_result.execution_time_ms,
-        execution_history_id=history_entry.id if history_entry is not None else None,
+        execution_history_id=history_entry.id if history_entry is not None else remote_history_id,
         highlight=build_highlight_payload(
             execution_result.node_results, workflow.nodes or [], enriched_inputs
         ),

--- a/backend/app/services/cluster/dispatch.py
+++ b/backend/app/services/cluster/dispatch.py
@@ -23,6 +23,7 @@ from app.services.cluster.run_history import (
     OffloadedRun,
     from_summary,
     offloaded_error,
+    persist_pending_run_history,
     persist_run_history,
     summarize,
 )
@@ -299,26 +300,38 @@ class RunQueueWorker:
             )
             # History is written here, on the instance that ran it, stamped with
             # this instance's label. The caller only ever sees the summary.
-            await persist_run_history(
-                execution_id=row.execution_id,
-                workflow_id=row.workflow_id,
-                owner_id=owner_id,
-                workflow_name=workflow_name,
-                inputs=row.inputs,
-                trigger_source=row.trigger_source,
-                result=result,
-            )
-            if row.credentials_owner_id is not None:
-                async with async_session_maker() as db:
-                    await _persist_global_variables_from_execution(
-                        db,
-                        row.credentials_owner_id,
-                        nodes,
-                        workflow_cache,
-                        result.node_results,
-                        result.sub_workflow_executions,
-                    )
-                    await db.commit()
+            if result.status == "pending":
+                await persist_pending_run_history(
+                    execution_id=row.execution_id,
+                    workflow_id=row.workflow_id,
+                    owner_id=owner_id,
+                    workflow_name=workflow_name,
+                    inputs=row.inputs,
+                    trigger_source=row.trigger_source,
+                    credentials_owner_id=row.credentials_owner_id,
+                    result=result,
+                )
+            else:
+                await persist_run_history(
+                    execution_id=row.execution_id,
+                    workflow_id=row.workflow_id,
+                    owner_id=owner_id,
+                    workflow_name=workflow_name,
+                    inputs=row.inputs,
+                    trigger_source=row.trigger_source,
+                    result=result,
+                )
+                if row.credentials_owner_id is not None:
+                    async with async_session_maker() as db:
+                        await _persist_global_variables_from_execution(
+                            db,
+                            row.credentials_owner_id,
+                            nodes,
+                            workflow_cache,
+                            result.node_results,
+                            result.sub_workflow_executions,
+                        )
+                        await db.commit()
             await run_queue.complete(
                 row.execution_id, result=summarize(result, row.execution_id), error=None
             )

--- a/backend/app/services/cluster/run_history.py
+++ b/backend/app/services/cluster/run_history.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from app.api.analytics import upsert_workflow_analytics_snapshot
-from app.db.models import ExecutionHistory
+from app.db.models import ExecutionHistory, Workflow
 from app.db.session import async_session_maker
 from app.services.cluster.attribution import attribution_fields
 
@@ -28,6 +28,7 @@ def summarize(result: Any, execution_id: uuid.UUID) -> dict[str, Any]:
     """
     return {
         "execution_id": str(execution_id),
+        "workflow_id": str(getattr(result, "workflow_id", "") or ""),
         "status": result.status,
         "outputs": result.outputs,
         "execution_time_ms": result.execution_time_ms,
@@ -84,6 +85,54 @@ async def persist_run_history(
         await db.commit()
 
 
+async def persist_pending_run_history(
+    *,
+    execution_id: uuid.UUID,
+    workflow_id: uuid.UUID,
+    owner_id: uuid.UUID,
+    workflow_name: str,
+    inputs: dict,
+    trigger_source: str | None,
+    credentials_owner_id: uuid.UUID | None,
+    result: Any,
+) -> None:
+    """Mint a paused run's review request where the run actually paused.
+
+    A pause is not a finished run: without the request row there is no public
+    token, no link, no notification branch and no way to resume, and the run
+    sits at pending forever.
+    """
+    from app.services.hitl_service import build_default_public_base_url
+    from app.services.pending_execution import persist_pending_execution
+
+    async with async_session_maker() as db:
+        workflow = await db.get(Workflow, workflow_id)
+        if workflow is None:
+            return
+        history_entry, _ = await persist_pending_execution(
+            db=db,
+            workflow=workflow,
+            enriched_inputs=inputs,
+            execution_result=result,
+            trigger_source=trigger_source,
+            credentials_owner_id=credentials_owner_id or owner_id,
+            trace_user_id=owner_id,
+            public_base_url=build_default_public_base_url(),
+            history_entry_id=execution_id,
+        )
+        for name, value in attribution_fields().items():
+            setattr(history_entry, name, value)
+        await upsert_workflow_analytics_snapshot(
+            db,
+            workflow_id=workflow_id,
+            owner_id=owner_id,
+            workflow_name_snapshot=workflow_name,
+            status=result.status,
+            execution_time_ms=result.execution_time_ms,
+        )
+        await db.commit()
+
+
 @dataclass
 class OffloadedRun:
     """An offloaded run's result, shaped like ExecutionResult where it matters.
@@ -95,6 +144,7 @@ class OffloadedRun:
 
     status: str
     outputs: dict
+    workflow_id: str = ""
     execution_time_ms: float = 0.0
     error: str | None = None
     node_results: list = field(default_factory=list)
@@ -111,6 +161,7 @@ def from_summary(summary: dict[str, Any]) -> OffloadedRun:
     return OffloadedRun(
         status=str(summary.get("status") or "error"),
         outputs=summary.get("outputs") or {},
+        workflow_id=str(summary.get("workflow_id") or ""),
         execution_time_ms=float(summary.get("execution_time_ms") or 0.0),
         error=summary.get("error"),
     )

--- a/backend/app/services/dashboard_data.py
+++ b/backend/app/services/dashboard_data.py
@@ -45,8 +45,34 @@ async def _record_widget_execution(
     increases the history of both the widget and its underlying workflow.
     """
     from app.api.analytics import upsert_workflow_analytics_snapshot
+    from app.services.hitl_service import build_default_public_base_url
+    from app.services.pending_execution import (
+        needs_local_pending_persist,
+        persist_pending_execution,
+    )
 
     try:
+        if needs_local_pending_persist(result):
+            paused_entry, _ = await persist_pending_execution(
+                db=db,
+                workflow=workflow,
+                enriched_inputs={},
+                execution_result=result,
+                trigger_source="dashboard",
+                credentials_owner_id=workflow.owner_id,
+                trace_user_id=workflow.owner_id,
+                public_base_url=build_default_public_base_url(),
+            )
+            await upsert_workflow_analytics_snapshot(
+                db,
+                workflow_id=workflow.id,
+                owner_id=workflow.owner_id,
+                workflow_name_snapshot=workflow.name,
+                status=result.status,
+                execution_time_ms=result.execution_time_ms,
+            )
+            return paused_entry
+
         history_entry = ExecutionHistory(
             id=uuid.uuid4(),
             workflow_id=workflow.id,
@@ -286,7 +312,7 @@ async def compute_widget_data(
     )
 
     background_finalize = bool(getattr(result, "allow_downstream_pending", False))
-    if not background_finalize:
+    if not background_finalize and result.status != "pending":
         await _persist_widget_global_variables(db, user.id, nodes, workflow_cache, result)
 
     widget.cached_payload = payload

--- a/backend/app/services/heym_event_dispatcher.py
+++ b/backend/app/services/heym_event_dispatcher.py
@@ -215,6 +215,11 @@ class HeymEventDispatcher:
         from app.services.cluster.dispatch import dispatch_workflow
         from app.services.execution_cancellation import clear_execution, register_execution
         from app.services.global_variables_service import get_global_variables_context
+        from app.services.hitl_service import build_default_public_base_url
+        from app.services.pending_execution import (
+            needs_local_pending_persist,
+            persist_pending_execution,
+        )
 
         async with async_session_maker() as db:
             workflow_result = await db.execute(select(Workflow).where(Workflow.id == workflow.id))
@@ -264,6 +269,33 @@ class HeymEventDispatcher:
                     "Workflow %s executed via Heym event trigger on another instance, status: %s",
                     fresh_workflow.id,
                     result.status,
+                )
+                return
+
+            if needs_local_pending_persist(result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=fresh_workflow,
+                    enriched_inputs=inputs,
+                    execution_result=result,
+                    trigger_source="heym_event",
+                    credentials_owner_id=fresh_workflow.owner_id,
+                    trace_user_id=fresh_workflow.owner_id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=fresh_workflow.id,
+                    owner_id=fresh_workflow.owner_id,
+                    workflow_name_snapshot=fresh_workflow.name,
+                    status=result.status,
+                    execution_time_ms=result.execution_time_ms,
+                )
+                await db.commit()
+                logger.info(
+                    "Workflow %s paused for human review via Heym event",
+                    fresh_workflow.id,
                 )
                 return
 

--- a/backend/app/services/imap_trigger_service.py
+++ b/backend/app/services/imap_trigger_service.py
@@ -25,6 +25,11 @@ from app.services.cluster.dispatch import dispatch_workflow
 from app.services.distributed_lock import lock_service
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 
 logger = logging.getLogger("imap_trigger")
 
@@ -462,6 +467,30 @@ class ImapTriggerManager:
                     fresh_workflow.id,
                     result.status,
                 )
+                return
+
+            if needs_local_pending_persist(result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=fresh_workflow,
+                    enriched_inputs=inputs,
+                    execution_result=result,
+                    trigger_source="imap",
+                    credentials_owner_id=fresh_workflow.owner_id,
+                    trace_user_id=fresh_workflow.owner_id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=fresh_workflow.id,
+                    owner_id=fresh_workflow.owner_id,
+                    workflow_name_snapshot=fresh_workflow.name,
+                    status=result.status,
+                    execution_time_ms=result.execution_time_ms,
+                )
+                await db.commit()
+                logger.info("Workflow %s paused for human review via IMAP", fresh_workflow.id)
                 return
 
             history_entry = ExecutionHistory(

--- a/backend/app/services/node_execution/nodes/execute_node.py
+++ b/backend/app/services/node_execution/nodes/execute_node.py
@@ -54,6 +54,7 @@ def execute(ctx: NodeExecutionContext) -> object:
     _workflow_executor = import_module("app.services.workflow_executor")
     SubWorkflowExecution = _workflow_executor.SubWorkflowExecution  # noqa: N806
     WorkflowExecutor = _workflow_executor.WorkflowExecutor  # noqa: N806
+    SUB_WORKFLOW_HITL_UNSUPPORTED = _workflow_executor.SUB_WORKFLOW_HITL_UNSUPPORTED  # noqa: N806
     _BACKGROUND_WORKFLOW_EXECUTOR = _workflow_executor._BACKGROUND_WORKFLOW_EXECUTOR  # noqa: N806
     _BACKGROUND_NODE_EXECUTOR = _workflow_executor._BACKGROUND_NODE_EXECUTOR  # noqa: N806
     _register_sub_execution = _workflow_executor._register_sub_execution
@@ -213,7 +214,7 @@ def execute(ctx: NodeExecutionContext) -> object:
                     error=sub_error,
                 )
             if sub_result.status == "pending":
-                raise ValueError("HITL is not supported inside Execute node sub-workflows.")
+                raise ValueError(SUB_WORKFLOW_HITL_UNSUPPORTED)
 
             sub_exec = SubWorkflowExecution(
                 workflow_id=execute_workflow_id,

--- a/backend/app/services/pending_execution.py
+++ b/backend/app/services/pending_execution.py
@@ -1,0 +1,96 @@
+"""Turn a run that paused into the review request that lets a human resume it.
+
+Every trigger reaches the same fork: a paused run needs its HITL request or its
+Codex follow-up minted, its public token issued and its notification branch
+fired, while a finished run just needs a history row. This module owns that fork
+so no call site has to know which of the two persisters applies.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import ExecutionHistory, Workflow
+from app.services.workflow_executor import ExecutionResult
+
+Redactor = Callable[[Any], Any]
+
+
+def needs_local_pending_persist(result: Any) -> bool:
+    """Whether this caller still has to mint the review request for a paused run.
+
+    An offloaded pause was already minted on the instance that executed it, and
+    the summary that crossed the boundary carries none of the pause metadata, so
+    a second attempt here would only raise.
+    """
+    return result.status == "pending" and not getattr(result, "history_written", False)
+
+
+def _redact_pause(execution_result: ExecutionResult, redact: Redactor) -> None:
+    execution_result.outputs = redact(execution_result.outputs)
+    execution_result.node_results = redact(execution_result.node_results)
+    if execution_result.pending_review is not None:
+        execution_result.pending_review = redact(execution_result.pending_review)
+    if execution_result.resume_snapshot is not None:
+        execution_result.resume_snapshot = redact(execution_result.resume_snapshot)
+
+
+async def persist_pending_execution(
+    *,
+    db: AsyncSession,
+    workflow: Workflow,
+    enriched_inputs: dict,
+    execution_result: ExecutionResult,
+    trigger_source: str | None,
+    credentials_owner_id: uuid.UUID,
+    trace_user_id: uuid.UUID | None,
+    public_base_url: str,
+    history_entry: ExecutionHistory | None = None,
+    history_entry_id: uuid.UUID | None = None,
+    redact: Redactor | None = None,
+) -> tuple[ExecutionHistory, Any]:
+    """Mint the pause and write its history row, returning both.
+
+    `redact` is applied on both sides of the mint for triggers that carry a
+    request secret: once so the pause metadata never reaches the request row,
+    and once after so the notification branch's own results are covered too.
+    """
+    from app.services.codex_followup_service import (
+        is_codex_pending_execution,
+        persist_pending_codex_followup_execution,
+    )
+    from app.services.hitl_service import persist_pending_hitl_execution
+
+    if redact is not None:
+        _redact_pause(execution_result, redact)
+
+    mint = (
+        persist_pending_codex_followup_execution
+        if is_codex_pending_execution(execution_result)
+        else persist_pending_hitl_execution
+    )
+    entry, pending_request = await mint(
+        db=db,
+        workflow=workflow,
+        enriched_inputs=enriched_inputs,
+        execution_result=execution_result,
+        trigger_source=trigger_source,
+        credentials_owner_id=credentials_owner_id,
+        trace_user_id=trace_user_id,
+        public_base_url=public_base_url,
+        history_entry=history_entry,
+        history_entry_id=history_entry_id,
+    )
+
+    if redact is not None:
+        _redact_pause(execution_result, redact)
+        entry.inputs = redact(entry.inputs)
+        entry.outputs = redact(entry.outputs)
+        entry.node_results = redact(entry.node_results)
+        pending_request.execution_snapshot = redact(pending_request.execution_snapshot)
+
+    return entry, pending_request

--- a/backend/app/services/rabbitmq_consumer.py
+++ b/backend/app/services/rabbitmq_consumer.py
@@ -21,6 +21,11 @@ from app.services.cluster.dispatch import dispatch_workflow
 from app.services.distributed_lock import lock_service
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 
 logger = logging.getLogger("rabbitmq_consumer")
 
@@ -372,6 +377,31 @@ class RabbitMQConsumerManager:
                         workflow.id,
                         result.status,
                     )
+                    return
+
+                if needs_local_pending_persist(result):
+                    await persist_pending_execution(
+                        db=db,
+                        workflow=workflow,
+                        enriched_inputs=inputs,
+                        execution_result=result,
+                        trigger_source="rabbitmq",
+                        credentials_owner_id=workflow.owner_id,
+                        trace_user_id=workflow.owner_id,
+                        public_base_url=build_default_public_base_url(),
+                        history_entry_id=execution_id,
+                    )
+                    await upsert_workflow_analytics_snapshot(
+                        db,
+                        workflow_id=workflow.id,
+                        owner_id=workflow.owner_id,
+                        workflow_name_snapshot=workflow.name,
+                        status=result.status,
+                        execution_time_ms=result.execution_time_ms,
+                    )
+                    await db.commit()
+                    await message.ack()
+                    logger.info("Workflow %s paused for human review via RabbitMQ", workflow.id)
                     return
 
                 history_entry = ExecutionHistory(

--- a/backend/app/services/websocket_trigger_service.py
+++ b/backend/app/services/websocket_trigger_service.py
@@ -22,6 +22,11 @@ from app.db.session import async_session_maker
 from app.services.cluster.dispatch import dispatch_workflow
 from app.services.distributed_lock import lock_service
 from app.services.global_variables_service import get_global_variables_context
+from app.services.hitl_service import build_default_public_base_url
+from app.services.pending_execution import (
+    needs_local_pending_persist,
+    persist_pending_execution,
+)
 from app.services.ssrf_guard import (
     SsrfBlockedError,
     SsrfResolutionError,
@@ -450,6 +455,30 @@ class WebSocketTriggerManager:
                     workflow.id,
                     result.status,
                 )
+                return
+
+            if needs_local_pending_persist(result):
+                await persist_pending_execution(
+                    db=db,
+                    workflow=workflow,
+                    enriched_inputs=inputs,
+                    execution_result=result,
+                    trigger_source="websocket",
+                    credentials_owner_id=workflow.owner_id,
+                    trace_user_id=workflow.owner_id,
+                    public_base_url=build_default_public_base_url(),
+                    history_entry_id=execution_id,
+                )
+                await upsert_workflow_analytics_snapshot(
+                    db,
+                    workflow_id=workflow.id,
+                    owner_id=workflow.owner_id,
+                    workflow_name_snapshot=workflow.name,
+                    status=result.status,
+                    execution_time_ms=result.execution_time_ms,
+                )
+                await db.commit()
+                logger.info("Workflow %s paused for human review via WebSocket", workflow.id)
                 return
 
             history_entry = ExecutionHistory(

--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -1682,6 +1682,9 @@ def _extract_pending_metadata(result: "NodeResult") -> dict:
     return {}
 
 
+SUB_WORKFLOW_HITL_UNSUPPORTED = "HITL is not supported inside Execute node sub-workflows."
+
+
 @dataclass
 class SubWorkflowExecution:
     workflow_id: str
@@ -3054,6 +3057,21 @@ class WorkflowExecutor:
             return
         if sub_res.allow_downstream_pending:
             sub_res.join_allow_downstream()
+        if sub_res.status == "pending":
+            with parent.lock:
+                parent.sub_workflow_executions.append(
+                    SubWorkflowExecution(
+                        workflow_id=wf_id,
+                        inputs=inputs_snapshot,
+                        outputs={"error": SUB_WORKFLOW_HITL_UNSUPPORTED},
+                        status="error",
+                        execution_time_ms=sub_res.execution_time_ms,
+                        node_results=sub_res.node_results,
+                        workflow_name=wf_name,
+                        trigger_source=bg_trigger_source,
+                    )
+                )
+            return
         sub_exec = SubWorkflowExecution(
             workflow_id=wf_id,
             inputs=inputs_snapshot,

--- a/backend/tests/test_cluster_pending_runs.py
+++ b/backend/tests/test_cluster_pending_runs.py
@@ -1,0 +1,205 @@
+"""A run that pauses for human review must be minted where it executed.
+
+Without this the claiming instance writes a bare 'pending' history row and
+nothing else: no HITL request, no public token, no review URL, and no
+notification branch. The queue row is marked done, so nothing retries it and the
+run sits at pending forever. The waiting caller cannot repair it either - it only
+ever receives the summary, which carries none of the pause metadata.
+"""
+
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _workflow() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+        name="Review run",
+        nodes=[{"id": "agent", "type": "agent", "data": {"humanInTheLoop": True}}],
+        edges=[],
+    )
+
+
+def _row(workflow: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        execution_id=uuid.uuid4(),
+        workflow_id=workflow.id,
+        inputs={"triggered_by": "cron"},
+        trigger_source="schedule",
+        actor_user_id=workflow.owner_id,
+        credentials_owner_id=workflow.owner_id,
+        test_run=False,
+        timeout_seconds=None,
+        return_on_chart_output=False,
+    )
+
+
+def _pending_result(kind: str | None = None) -> SimpleNamespace:
+    pending: dict = {"summary": "Approve this", "draft_text": "draft"}
+    if kind:
+        pending["kind"] = kind
+    return SimpleNamespace(
+        status="pending",
+        outputs={"Agent": {"text": "draft"}},
+        node_results=[],
+        execution_time_ms=12.0,
+        sub_workflow_executions=[],
+        pending_review=pending,
+        resume_snapshot={"paused_node_id": "agent", "paused_node_label": "Agent"},
+    )
+
+
+class ClaimedPendingRunTests(unittest.IsolatedAsyncioTestCase):
+    async def _claim(self, result: SimpleNamespace) -> dict[str, object]:
+        from app.services.cluster.dispatch import RunQueueWorker
+
+        workflow = _workflow()
+        row = _row(workflow)
+
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: workflow))
+        db.get = AsyncMock(return_value=workflow)
+        db.commit = AsyncMock()
+        session_factory = MagicMock()
+        session_factory.return_value.__aenter__ = AsyncMock(return_value=db)
+        session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        history_entry = SimpleNamespace(id=row.execution_id)
+
+        def _mint(**kwargs: object) -> tuple[SimpleNamespace, SimpleNamespace]:
+            # The real helper rewrites outputs with the review URL in place.
+            result.outputs = {"Agent": {"reviewUrl": "https://heym.test/review/tok"}}
+            return history_entry, SimpleNamespace(id=uuid.uuid4())
+
+        hitl = AsyncMock(side_effect=_mint)
+        codex = AsyncMock(side_effect=_mint)
+        terminal = AsyncMock()
+        complete = AsyncMock()
+
+        with (
+            patch("app.db.session.async_session_maker", session_factory),
+            patch("app.services.cluster.run_history.async_session_maker", session_factory),
+            patch("app.api.workflows.get_credentials_context", new=AsyncMock(return_value={})),
+            patch("app.api.workflows.collect_referenced_workflows", new=AsyncMock(return_value={})),
+            patch(
+                "app.api.workflows._persist_global_variables_from_execution", new=AsyncMock()
+            ) as globals_writer,
+            patch(
+                "app.services.global_variables_service.get_global_variables_context",
+                new=AsyncMock(return_value={}),
+            ),
+            patch("app.services.cluster.dispatch.register_execution"),
+            patch(
+                "app.services.cluster.dispatch.asyncio.to_thread",
+                new=AsyncMock(return_value=result),
+            ),
+            patch("app.services.cluster.dispatch.persist_run_history", terminal),
+            patch("app.services.hitl_service.persist_pending_hitl_execution", hitl),
+            patch(
+                "app.services.codex_followup_service.persist_pending_codex_followup_execution",
+                codex,
+            ),
+            patch(
+                "app.services.hitl_service.build_default_public_base_url",
+                MagicMock(return_value="https://heym.test"),
+            ),
+            patch(
+                "app.services.cluster.run_history.upsert_workflow_analytics_snapshot",
+                new=AsyncMock(),
+            ),
+            patch("app.services.cluster.dispatch.run_queue.complete", complete),
+            patch("app.services.cluster.dispatch.run_queue.notify_done", new=AsyncMock()),
+        ):
+            await RunQueueWorker()._execute_claimed(row)  # type: ignore[arg-type]
+
+        return {
+            "hitl": hitl,
+            "codex": codex,
+            "terminal": terminal,
+            "complete": complete,
+            "workflow": workflow,
+            "row": row,
+            "globals_writer": globals_writer,
+            "history_entry": history_entry,
+        }
+
+    async def test_a_paused_run_mints_its_review_request(self) -> None:
+        claimed = self._claim(_pending_result())
+        captured = await claimed
+        captured["hitl"].assert_awaited_once()
+        kwargs = captured["hitl"].await_args.kwargs
+        self.assertEqual(kwargs["history_entry_id"], captured["row"].execution_id)
+        self.assertEqual(kwargs["public_base_url"], "https://heym.test")
+        self.assertEqual(kwargs["trigger_source"], "schedule")
+        self.assertEqual(kwargs["credentials_owner_id"], captured["workflow"].owner_id)
+
+    async def test_a_paused_run_does_not_also_write_a_terminal_history_row(self) -> None:
+        captured = await self._claim(_pending_result())
+        captured["terminal"].assert_not_awaited()
+
+    async def test_the_review_url_reaches_the_waiting_caller(self) -> None:
+        captured = await self._claim(_pending_result())
+        summary = captured["complete"].await_args.kwargs["result"]
+        self.assertEqual(summary["status"], "pending")
+        self.assertEqual(summary["outputs"]["Agent"]["reviewUrl"], "https://heym.test/review/tok")
+
+    async def test_a_paused_codex_run_mints_a_follow_up_instead(self) -> None:
+        captured = await self._claim(_pending_result(kind="codex"))
+        captured["codex"].assert_awaited_once()
+        captured["hitl"].assert_not_awaited()
+
+    async def test_a_paused_run_defers_global_variable_writes_to_the_resume(self) -> None:
+        captured = await self._claim(_pending_result())
+        captured["globals_writer"].assert_not_awaited()
+
+    async def test_a_finished_run_still_takes_the_terminal_path(self) -> None:
+        finished = SimpleNamespace(
+            status="success",
+            outputs={"Agent": {"text": "done"}},
+            node_results=[],
+            execution_time_ms=3.0,
+            sub_workflow_executions=[],
+            pending_review=None,
+            resume_snapshot=None,
+        )
+        captured = await self._claim(finished)
+        captured["terminal"].assert_awaited_once()
+        captured["hitl"].assert_not_awaited()
+        captured["codex"].assert_not_awaited()
+
+
+class OffloadedRunShapeTests(unittest.TestCase):
+    """The execute endpoint reads these off whatever dispatch returns."""
+
+    def test_an_offloaded_run_carries_the_workflow_id(self) -> None:
+        from app.services.cluster.run_history import from_summary
+
+        run = from_summary(
+            {
+                "execution_id": str(uuid.uuid4()),
+                "workflow_id": "wf-1",
+                "status": "pending",
+                "outputs": {},
+                "execution_time_ms": 1.0,
+            }
+        )
+        self.assertEqual(run.workflow_id, "wf-1")
+
+    def test_a_run_summary_carries_the_workflow_id(self) -> None:
+        from app.services.cluster.run_history import summarize
+
+        workflow_id = uuid.uuid4()
+        summary = summarize(
+            SimpleNamespace(
+                workflow_id=workflow_id, status="success", outputs={}, execution_time_ms=1.0
+            ),
+            uuid.uuid4(),
+        )
+        self.assertEqual(summary["workflow_id"], str(workflow_id))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_slack_trigger.py
+++ b/backend/tests/test_slack_trigger.py
@@ -164,6 +164,70 @@ class TestSlackValidSignature(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(history.inputs["trigger_node_id"], "slack-node")
         self.assertEqual(history.inputs["event"]["event"]["text"], "hello")
 
+    async def test_a_paused_run_mints_its_review_request(self) -> None:
+        """A Slack-started run that pauses must get a review link, not a dead row."""
+        from app.api.slack import _execute_workflow_background
+
+        owner_id = uuid.uuid4()
+        workflow_id = uuid.uuid4()
+        workflow = SimpleNamespace(
+            id=workflow_id,
+            owner_id=owner_id,
+            name="Slack workflow",
+            nodes=[],
+            edges=[],
+        )
+        added_rows: list[object] = []
+        db = SimpleNamespace(
+            execute=AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: workflow)),
+            add=added_rows.append,
+            commit=AsyncMock(),
+        )
+        execution_result = ExecutionResult(
+            workflow_id=workflow_id,
+            status="pending",
+            outputs={"Agent": {"text": "draft"}},
+            execution_time_ms=12.3,
+            node_results=[],
+            sub_workflow_executions=[],
+            pending_review={"summary": "Approve", "draft_text": "draft"},
+            resume_snapshot={"paused_node_id": "agent", "paused_node_label": "Agent"},
+        )
+        mint = AsyncMock(return_value=(SimpleNamespace(id=uuid.uuid4()), SimpleNamespace()))
+        globals_writer = AsyncMock()
+
+        with (
+            patch("app.api.slack.async_session_maker") as mock_session_maker,
+            patch("app.api.slack.collect_referenced_workflows", AsyncMock(return_value={})),
+            patch("app.api.slack.get_credentials_context", AsyncMock(return_value={})),
+            patch("app.api.slack.get_global_variables_context", AsyncMock(return_value={})),
+            patch("app.api.slack.dispatch_workflow", AsyncMock(return_value=execution_result)),
+            patch("app.api.slack.upsert_workflow_analytics_snapshot", AsyncMock()),
+            patch("app.api.slack._persist_global_variables_from_execution", globals_writer),
+            patch("app.api.slack.persist_pending_execution", mint),
+        ):
+            mock_session = AsyncMock()
+            mock_session.__aenter__.return_value = db
+            mock_session.__aexit__.return_value = None
+            mock_session_maker.return_value = mock_session
+
+            await _execute_workflow_background(
+                workflow,
+                "slack-node",
+                {"event": {"type": "message", "text": "hello"}},
+                {"x-slack-request-timestamp": "123"},
+            )
+
+        mint.assert_awaited_once()
+        kwargs = mint.await_args.kwargs
+        self.assertEqual(kwargs["trigger_source"], "Slack")
+        self.assertEqual(kwargs["credentials_owner_id"], owner_id)
+        self.assertEqual(kwargs["execution_result"], execution_result)
+        # The pause writes its own row through the persister, never a bare one here.
+        self.assertEqual([row for row in added_rows if isinstance(row, ExecutionHistory)], [])
+        globals_writer.assert_not_awaited()
+        db.commit.assert_awaited()
+
 
 class TestSlackInvalidSignature(unittest.IsolatedAsyncioTestCase):
     """Wrong HMAC → 403, workflow not executed."""

--- a/backend/tests/test_sub_workflow_pending_guard.py
+++ b/backend/tests/test_sub_workflow_pending_guard.py
@@ -1,0 +1,74 @@
+"""A sub-workflow that pauses must say so, never sit at pending unnoticed.
+
+HITL is deliberately unsupported inside a sub-workflow: the Execute node, the
+agent's sub-workflow tool and the sub-agent tool all refuse it with a message.
+The fire-and-forget branch had no such guard, so a paused executeDoNotWait run
+was recorded as `pending` and stranded - no review request, no link, no error,
+and the pause metadata dropped at the callback boundary.
+"""
+
+import unittest
+import uuid
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.services.workflow_executor import ExecutionResult, WorkflowExecutor
+
+
+def _parent() -> SimpleNamespace:
+    return SimpleNamespace(
+        lock=MagicMock(__enter__=MagicMock(), __exit__=MagicMock(return_value=False)),
+        sub_workflow_executions=[],
+        _invoked_by_agent=False,
+    )
+
+
+def _future(result: ExecutionResult) -> Future:
+    future: Future = Future()
+    future.set_result(result)
+    return future
+
+
+class BackgroundSubWorkflowPauseTests(unittest.TestCase):
+    def _record(self, status: str) -> SimpleNamespace:
+        workflow_id = uuid.uuid4()
+        result = ExecutionResult(
+            workflow_id=workflow_id,
+            status=status,
+            outputs={"Agent": {"text": "draft"}},
+            execution_time_ms=4.0,
+            node_results=[],
+            pending_review=(
+                {"summary": "Approve", "draft_text": "draft"} if status == "pending" else None
+            ),
+            resume_snapshot=(
+                {"paused_node_id": "a", "paused_node_label": "Agent"}
+                if status == "pending"
+                else None
+            ),
+        )
+        parent = _parent()
+        WorkflowExecutor._record_bg_sub_workflow_done(
+            _future(result), parent, str(workflow_id), "Sub B", {"x": 1}
+        )
+        return parent
+
+    def test_a_paused_background_sub_workflow_is_recorded_as_an_error(self) -> None:
+        parent = self._record("pending")
+        recorded = parent.sub_workflow_executions[0]
+        self.assertEqual(recorded.status, "error")
+
+    def test_the_recorded_error_names_the_unsupported_case(self) -> None:
+        parent = self._record("pending")
+        self.assertIn("HITL is not supported", str(parent.sub_workflow_executions[0].outputs))
+
+    def test_a_finished_background_sub_workflow_is_untouched(self) -> None:
+        parent = self._record("success")
+        recorded = parent.sub_workflow_executions[0]
+        self.assertEqual(recorded.status, "success")
+        self.assertEqual(recorded.outputs, {"Agent": {"text": "draft"}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_trigger_pending_hitl.py
+++ b/backend/tests/test_trigger_pending_hitl.py
@@ -1,0 +1,151 @@
+"""Every background trigger must mint the pause, not just write a pending row.
+
+A workflow that pauses for human review is stranded unless its HITL request is
+created: no public token, no review link, no notification branch, and no
+snapshot to resume from. Cron already did this; these triggers did not, so a run
+started from Slack, Telegram, a queue or the cluster's run queue sat at pending
+forever whether or not a cluster was involved.
+"""
+
+import unittest
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _result(status: str = "pending", *, kind: str | None = None) -> SimpleNamespace:
+    pending: dict | None = None
+    if status == "pending":
+        pending = {"summary": "Approve", "draft_text": "draft"}
+        if kind:
+            pending["kind"] = kind
+    return SimpleNamespace(
+        status=status,
+        outputs={"Agent": {"text": "draft"}},
+        node_results=[],
+        execution_time_ms=5.0,
+        sub_workflow_executions=[],
+        pending_review=pending,
+        resume_snapshot={"paused_node_id": "a", "paused_node_label": "Agent"} if pending else None,
+    )
+
+
+class PendingPersistGuardTests(unittest.TestCase):
+    def test_a_local_pause_must_be_persisted_by_the_caller(self) -> None:
+        from app.services.pending_execution import needs_local_pending_persist
+
+        self.assertTrue(needs_local_pending_persist(_result()))
+
+    def test_an_offloaded_pause_was_already_persisted(self) -> None:
+        from app.services.pending_execution import needs_local_pending_persist
+
+        offloaded = _result()
+        offloaded.history_written = True
+        self.assertFalse(needs_local_pending_persist(offloaded))
+
+    def test_a_finished_run_is_never_a_pending_persist(self) -> None:
+        from app.services.pending_execution import needs_local_pending_persist
+
+        self.assertFalse(needs_local_pending_persist(_result("success")))
+
+
+class PendingMintRoutingTests(unittest.IsolatedAsyncioTestCase):
+    async def _mint(self, result: SimpleNamespace, **kwargs: object) -> dict[str, object]:
+        from app.services.pending_execution import persist_pending_execution
+
+        entry = SimpleNamespace(inputs={}, outputs={}, node_results=[])
+        request = SimpleNamespace(execution_snapshot={})
+        hitl = AsyncMock(return_value=(entry, request))
+        codex = AsyncMock(return_value=(entry, request))
+        with (
+            patch("app.services.hitl_service.persist_pending_hitl_execution", hitl),
+            patch(
+                "app.services.codex_followup_service.persist_pending_codex_followup_execution",
+                codex,
+            ),
+        ):
+            await persist_pending_execution(
+                db=MagicMock(),
+                workflow=SimpleNamespace(id=uuid.uuid4(), owner_id=uuid.uuid4(), name="W"),
+                enriched_inputs={},
+                execution_result=result,
+                trigger_source="Slack",
+                credentials_owner_id=uuid.uuid4(),
+                trace_user_id=None,
+                public_base_url="https://heym.test",
+                **kwargs,  # type: ignore[arg-type]
+            )
+        return {"hitl": hitl, "codex": codex, "entry": entry, "request": request}
+
+    async def test_a_human_review_pause_goes_to_the_hitl_persister(self) -> None:
+        minted = await self._mint(_result())
+        minted["hitl"].assert_awaited_once()
+        minted["codex"].assert_not_awaited()
+
+    async def test_a_codex_pause_goes_to_the_follow_up_persister(self) -> None:
+        minted = await self._mint(_result(kind="codex"))
+        minted["codex"].assert_awaited_once()
+        minted["hitl"].assert_not_awaited()
+
+    async def test_a_request_secret_is_redacted_before_it_reaches_the_pause(self) -> None:
+        """Discord carries an interaction token; it must not land in the request row."""
+        result = _result()
+        result.outputs = {"Agent": {"text": "tok-abc"}}
+        result.pending_review = {"summary": "tok-abc", "draft_text": "tok-abc"}
+        result.resume_snapshot = {
+            "paused_node_id": "a",
+            "paused_node_label": "Agent",
+            "t": "tok-abc",
+        }
+
+        def redact(value: object) -> object:
+            if isinstance(value, str):
+                return value.replace("tok-abc", "[redacted]")
+            if isinstance(value, dict):
+                return {k: redact(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [redact(v) for v in value]
+            return value
+
+        minted = await self._mint(result, redact=redact)
+        passed = minted["hitl"].await_args.kwargs["execution_result"]
+        self.assertNotIn("tok-abc", str(passed.pending_review))
+        self.assertNotIn("tok-abc", str(passed.resume_snapshot))
+        self.assertNotIn("tok-abc", str(passed.outputs))
+
+
+class TriggerCallSiteCoverageTests(unittest.TestCase):
+    """A trigger that can reach a paused run must know how to mint it.
+
+    This is the guard that caught the original bug: every one of these modules
+    dispatched a run and then wrote its status straight into history.
+    """
+
+    TRIGGERS = (
+        "app/api/telegram.py",
+        "app/api/slack.py",
+        "app/api/discord.py",
+        "app/api/mcp.py",
+        "app/api/mcp_servers.py",
+        "app/services/imap_trigger_service.py",
+        "app/services/rabbitmq_consumer.py",
+        "app/services/websocket_trigger_service.py",
+        "app/services/heym_event_dispatcher.py",
+        "app/services/dashboard_data.py",
+        "app/services/cluster/dispatch.py",
+    )
+
+    def test_every_dispatching_trigger_handles_a_pause(self) -> None:
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parent.parent
+        missing = []
+        for rel in self.TRIGGERS:
+            source = (root / rel).read_text()
+            if "persist_pending" not in source:
+                missing.append(rel)
+        self.assertEqual(missing, [], f"trigger(s) with no pause branch: {missing}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/docs/content/getting-started/running-and-deployment.md
+++ b/frontend/src/docs/content/getting-started/running-and-deployment.md
@@ -37,7 +37,7 @@ For every supported variable, default, and production note, see [Environment Var
 | `DATABASE_URL` | Optional database connection string override. If empty, Heym builds it from `POSTGRES_*` settings. |
 | `BACKEND_PORT` | Backend API port — defaults to `10105` |
 | `FRONTEND_PORT` | Frontend port — defaults to `4017` |
-| `FRONTEND_URL` | **Required in production.** Public URL of the app (scheme + host, e.g. `https://heym.example.com`). Used for OAuth redirect URIs (Google Sheets, BigQuery, Notion, and similar); must match the URL users use in the browser. |
+| `FRONTEND_URL` | **Required in production.** Public URL of the app (scheme + host, e.g. `https://heym.example.com`). Used for OAuth redirect URIs (Google Sheets, BigQuery, Notion, and similar), and for the review, Codex follow-up and file links that background runs mint; must match the URL users use in the browser. In a cluster, set the same value on every instance. |
 | `ALLOW_REGISTER` | Open user registration (`false` in prod, `true` in dev). Flip it to `false` only after your admin account exists — there is no first-user bootstrap, so an empty database plus disabled registration leaves no way to create one. |
 | `DOCKER_LOGS_ENABLED` | Enables Docker-backed Logs tab access when set to `true`; also requires Docker socket access |
 | `DOCKER_LOGS_ALLOWED_EMAILS` | Comma-separated list of trusted user emails allowed to access Docker logs when `DOCKER_LOGS_ENABLED=true` |

--- a/frontend/src/docs/content/reference/cluster.md
+++ b/frontend/src/docs/content/reference/cluster.md
@@ -89,6 +89,8 @@ That also defines the upgrade order. Upgrading main first marks every worker inc
 
 **Point ingress at the main instance only.** Round-robining user traffic across instances would send a file upload to one machine and its download to another. Nothing in the code prevents this, because a worker runs the same image and will answer any request it receives.
 
+**Every instance needs `FRONTEND_URL`, set to the same public address.** A run that pauses for human review mints its review link on the instance that executed it, not on main, and the same holds for Codex follow-up links and for the download URLs of generated files. A worker left without it builds those links against its own local address, and whoever receives one cannot open it.
+
 **Worker instances have a different outbound IP.** Any API that allowlists source addresses sees the new one. Send Email runs on main for exactly this reason; for the HTTP node, either give the cluster a single NAT egress address or allowlist every instance.
 
 ## Adding a worker on another machine


### PR DESCRIPTION
Implement pending execution handling across various triggers

- Added functionality to persist pending executions for workflows triggered via Discord, Slack, Telegram, IMAP, RabbitMQ, WebSocket, and Heym events.
- Introduced a new method `persist_pending_run_history` to handle paused runs and mint review requests.
- Updated the execution flow to ensure that workflows that require human review are properly logged and tracked.
- Enhanced documentation to clarify the importance of the `FRONTEND_URL` environment variable for generating review links in a clustered environment.