### PR TITLE
Improve command palette selection contrast in light mode

### DIFF
--- a/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
+++ b/frontend/src/components/Dialogs/WorkflowCommandPalette.vue
@@ -600,8 +600,8 @@ onUnmounted(() => {
                   :class="cn(
                     'command-palette-item flex items-center gap-3 px-4 py-3 cursor-pointer transition-colors duration-150',
                     selectedIndex === getFlatIndex(groupIdx, itemIdx)
-                      ? 'bg-accent/50 text-accent-foreground'
-                      : 'hover:bg-muted/50 text-foreground'
+                      ? 'command-palette-item--active text-accent-foreground'
+                      : 'command-palette-item--idle text-foreground'
                   )"
                   role="option"
                   :aria-selected="selectedIndex === getFlatIndex(groupIdx, itemIdx)"
@@ -816,6 +816,24 @@ onUnmounted(() => {
 
 .command-palette-item {
   outline: none;
+}
+
+.command-palette-item--active {
+  background: hsl(var(--primary) / 0.09);
+  box-shadow: inset 3px 0 0 hsl(var(--primary));
+}
+
+.command-palette-item--idle:hover {
+  background: hsl(var(--primary) / 0.045);
+}
+
+.dark .command-palette-item--active {
+  background: hsl(var(--accent) / 0.5);
+  box-shadow: inset 3px 0 0 hsl(var(--primary));
+}
+
+.dark .command-palette-item--idle:hover {
+  background: hsl(var(--muted) / 0.5);
 }
 
 .command-palette-item:focus-visible {


### PR DESCRIPTION
## Problem

In the Ctrl+K command palette, the selected row (keyboard navigation or hover) was nearly invisible in light mode. The selected state used `bg-accent/50`, and in light mode `--accent` is `210 40% 96.1%` — a near-white gray that, at 50% opacity over the white palette card, renders as roughly `#FAFBFC`. Dark mode was unaffected, since the same token sits well above the dark background.

## Change

`frontend/src/components/Dialogs/WorkflowCommandPalette.vue` (one shared component used by Editor, Dashboard, Docs, Chats and Evals):

- Selected and idle states moved from Tailwind utilities into two scoped classes, so each theme's tint lives in one place.
- **Light selected row:** `hsl(var(--primary) / 0.09)` plus a 3px primary left indicator (`inset box-shadow`, so it does not shift layout).
- **Light hover:** `hsl(var(--primary) / 0.045)`, deliberately weaker so hover does not compete with the active row.
- **Dark:** background tint left exactly as it was (`accent/0.5`); it only gains the same left indicator so both themes read the same.

The tint is intentionally kept light: at 14% the `muted-foreground` description text dropped to 4.55:1 contrast on the selected row. At 9% it is 4.93:1, close to the 5.67:1 it has on the plain white card and above the 4.5:1 AA threshold.

## Verification

- `bun run lint` and `bun run typecheck` pass.
- `./check.sh`: 3877 tests, 23 failures — all 23 reproduce identically on clean `main` (`test_cancellation_by_trigger`, `test_cron_scheduler`, `test_html_response_api`, `test_mcp_stdio_sandbox`, `test_workflow_execution_api`, `test_workflow_http_method`) and are unrelated to this CSS-only change.