### PR TITLE
Fix execution history deletion authorization

### DIFF
--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1135,17 +1135,10 @@ async def clear_all_execution_history(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    accessible_workflows = select(Workflow.id).where(
-        or_(
-            Workflow.owner_id == current_user.id,
-            Workflow.id.in_(
-                select(WorkflowShare.workflow_id).where(WorkflowShare.user_id == current_user.id)
-            ),
-        )
-    )
+    owned_workflows = select(Workflow.id).where(Workflow.owner_id == current_user.id)
     await db.execute(
         ExecutionHistory.__table__.delete().where(
-            ExecutionHistory.workflow_id.in_(accessible_workflows)
+            ExecutionHistory.workflow_id.in_(owned_workflows)
         )
     )
     await db.execute(RunHistory.__table__.delete().where(RunHistory.user_id == current_user.id))
@@ -3608,6 +3601,12 @@ async def clear_execution_history(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Workflow not found",
+        )
+
+    if workflow.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only the owner can clear history",
         )
 
     audit(

--- a/backend/app/api/workflows.py
+++ b/backend/app/api/workflows.py
@@ -1137,9 +1137,7 @@ async def clear_all_execution_history(
 ) -> None:
     owned_workflows = select(Workflow.id).where(Workflow.owner_id == current_user.id)
     await db.execute(
-        ExecutionHistory.__table__.delete().where(
-            ExecutionHistory.workflow_id.in_(owned_workflows)
-        )
+        ExecutionHistory.__table__.delete().where(ExecutionHistory.workflow_id.in_(owned_workflows))
     )
     await db.execute(RunHistory.__table__.delete().where(RunHistory.user_id == current_user.id))
 

--- a/backend/tests/test_execution_history_api.py
+++ b/backend/tests/test_execution_history_api.py
@@ -1,10 +1,19 @@
 import unittest
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from fastapi import HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 
-from app.api.workflows import get_execution_history, list_all_execution_history
+from app.api.workflows import (
+    clear_all_execution_history,
+    clear_execution_history,
+    get_execution_history,
+    list_all_execution_history,
+)
+from app.db.models import ExecutionHistory, Workflow
 
 
 class _ExecuteResult:
@@ -73,6 +82,63 @@ class ExecutionHistoryApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("execution_history.trigger_source = 'quick drawer'", history_sql)
         self.assertNotIn("ilike", total_sql)
         self.assertNotIn("ilike", history_sql)
+
+    async def test_collaborator_bulk_clear_preserves_shared_workflow_history(self) -> None:
+        collaborator_id = uuid.uuid4()
+        self.db.execute = AsyncMock()
+
+        await clear_all_execution_history(
+            current_user=SimpleNamespace(id=collaborator_id),
+            db=self.db,
+        )
+
+        history_delete = self.db.execute.call_args_list[0].args[0]
+        expected_delete = ExecutionHistory.__table__.delete().where(
+            ExecutionHistory.workflow_id.in_(
+                select(Workflow.id).where(Workflow.owner_id == collaborator_id)
+            )
+        )
+
+        self.assertTrue(history_delete.compare(expected_delete))
+
+    async def test_collaborator_cannot_clear_shared_workflow_history(self) -> None:
+        workflow_id = uuid.uuid4()
+        collaborator_id = uuid.uuid4()
+        workflow = SimpleNamespace(id=workflow_id, owner_id=uuid.uuid4(), name="Shared workflow")
+        self.db.execute = AsyncMock()
+
+        with patch(
+            "app.api.workflows.get_workflow_for_user",
+            AsyncMock(return_value=workflow),
+        ):
+            with self.assertRaises(HTTPException) as ctx:
+                await clear_execution_history(
+                    workflow_id=workflow_id,
+                    current_user=SimpleNamespace(id=collaborator_id),
+                    db=self.db,
+                )
+
+        self.assertEqual(ctx.exception.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(ctx.exception.detail, "Only the owner can clear history")
+        self.db.execute.assert_not_called()
+
+    async def test_owner_can_clear_owned_workflow_history(self) -> None:
+        workflow_id = uuid.uuid4()
+        owner_id = uuid.uuid4()
+        workflow = SimpleNamespace(id=workflow_id, owner_id=owner_id, name="Owned workflow")
+        self.db.execute = AsyncMock()
+
+        with patch(
+            "app.api.workflows.get_workflow_for_user",
+            AsyncMock(return_value=workflow),
+        ):
+            await clear_execution_history(
+                workflow_id=workflow_id,
+                current_user=SimpleNamespace(id=owner_id),
+                db=self.db,
+            )
+
+        self.db.execute.assert_awaited_once()
 
     async def test_per_workflow_history_combines_search_and_trigger_source_filter(self) -> None:
         workflow_id = uuid.uuid4()

--- a/frontend/src/components/Panels/ExecutionHistoryAllDialog.vue
+++ b/frontend/src/components/Panels/ExecutionHistoryAllDialog.vue
@@ -457,7 +457,7 @@ async function refreshHistory(): Promise<void> {
 }
 
 async function clearAllHistory(): Promise<void> {
-  if (!confirm("Are you sure you want to clear all execution history?")) return;
+  if (!confirm("Are you sure you want to clear all execution history? (History for shared workflows will be retained.)")) return;
   cancelScheduledSearchReload();
   clearing.value = true;
   try {

--- a/frontend/src/components/Panels/ExecutionHistoryAllDialog.vue
+++ b/frontend/src/components/Panels/ExecutionHistoryAllDialog.vue
@@ -462,11 +462,7 @@ async function clearAllHistory(): Promise<void> {
   clearing.value = true;
   try {
     await workflowApi.clearAllHistory();
-    executionHistory.value = [];
-    totalCount.value = 0;
-    entryDetailsCache.value = new Map();
-    selectedId.value = null;
-    selectedTriggerSource.value = undefined;
+    await refreshHistory();
   } catch {
     error.value = "Failed to clear history";
   } finally {

--- a/frontend/src/components/Panels/ExecutionHistoryDialog.vue
+++ b/frontend/src/components/Panels/ExecutionHistoryDialog.vue
@@ -39,6 +39,7 @@ import {
 } from "@/lib/executionLog";
 import { cn } from "@/lib/utils";
 import { workflowApi } from "@/services/api";
+import { useAuthStore } from "@/stores/auth";
 import { useWorkflowStore } from "@/stores/workflow";
 import type { ActiveExecutionItem, ExecutionHistoryEntry, NodeResult } from "@/types/workflow";
 
@@ -51,7 +52,14 @@ const emit = defineEmits<{
   (e: "close"): void;
 }>();
 
+const authStore = useAuthStore();
 const workflowStore = useWorkflowStore();
+
+const isOwner = computed(() => {
+  const ownerId = workflowStore.currentWorkflow?.owner_id;
+  const userId = authStore.user?.id;
+  return Boolean(ownerId && userId && ownerId === userId);
+});
 const router = useRouter();
 const selectedId = ref<string | null>(null);
 const expandedNodes = ref<Set<string>>(new Set());
@@ -353,14 +361,18 @@ async function refreshHistory(): Promise<void> {
   }
 }
 
-function clearHistory(): void {
-  void workflowStore.clearExecutionHistory();
-  selectedId.value = null;
-  selectedTriggerSource.value = undefined;
-  selectedInstanceId.value = undefined;
-  searchActive.value = false;
-  searchQuery.value = "";
-  cancelScheduledSearchReload();
+async function clearHistory(): Promise<void> {
+  try {
+    await workflowStore.clearExecutionHistory();
+    selectedId.value = null;
+    selectedTriggerSource.value = undefined;
+    selectedInstanceId.value = undefined;
+    searchActive.value = false;
+    searchQuery.value = "";
+    cancelScheduledSearchReload();
+  } catch {
+    // Error is handled/toasted by store
+  }
 }
 
 function toggleSearch(): void {
@@ -736,6 +748,7 @@ function bringToCanvas(): void {
           <Search class="w-4 h-4" />
         </Button>
         <Button
+          v-if="isOwner"
           variant="ghost"
           size="sm"
           class="gap-2"

--- a/frontend/src/docs/content/reference/execution-history.md
+++ b/frontend/src/docs/content/reference/execution-history.md
@@ -30,7 +30,7 @@ Click the **History** button (clock icon) to open the dialog.
 ## Per-workflow vs All History
 
 - **Per-workflow** (Editor, Docs): Shows runs for the workflow you have open. Use **Clear history** to remove runs for that workflow only.
-- **All History** (Dashboard, Evals): Shows runs across all workflows and chat/assistant sessions. Use **Clear all history** to remove everything.
+- **All History** (Dashboard, Evals): Shows runs across all workflows and chat/assistant sessions. Use **Clear all history** to remove all records you own. History for shared workflows will be retained.
 
 ## Bring to Canvas
 
@@ -143,7 +143,7 @@ Use **Copy** next to Inputs or Outputs to copy the JSON to the clipboard.
 ## Clear History
 
 - **Per-workflow**: In the Editor history dialog, click **Clear history** to remove runs for the current workflow.
-- **All History**: In the Dashboard/Evals history dialog, click **Clear all history** to remove all execution records. This action cannot be undone.
+- **All History**: In the Dashboard/Evals history dialog, click **Clear all history** to remove all execution records you own. Runs from shared workflows are retained. This action cannot be undone.
 
 ## Execution timeline details
 

--- a/frontend/src/stores/workflow.test.ts
+++ b/frontend/src/stores/workflow.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/services/api", () => ({
     executeStream: vi.fn(),
     getWorkflowHistoryEntry: vi.fn(),
     streamActiveExecution: vi.fn(),
+    clearHistory: vi.fn(),
   },
 }));
 
@@ -314,5 +315,59 @@ describe("workflow execution state", () => {
     expect(store.executionResult?.outputs).toEqual({ completed: true });
     expect(store.executionResult?.highlight).toEqual({ records: [] });
     expect(store.isExecuting).toBe(false);
+  });
+
+  it("clears local execution history on successful deletion", async () => {
+    const workflow = makeWorkflow("workflow-a");
+    const getWorkflow = vi.mocked(workflowApi.get);
+    const clearHistory = vi.mocked(workflowApi.clearHistory);
+    getWorkflow.mockResolvedValue(workflow);
+    clearHistory.mockResolvedValue(undefined);
+
+    const store = useWorkflowStore();
+    await store.loadWorkflow(workflow.id);
+
+    // Seed some history
+    store.executionHistoryList = [
+      { id: "run-1", workflow_id: workflow.id, workflow_name: "A", status: "success", started_at: "2026-08-11T00:00:00Z", execution_time_ms: 10, run_type: "workflow", trigger_source: null }
+    ];
+    store.executionHistoryTotal = 1;
+    store.executionHistoryDetails.set("run-1", { id: "run-1", started_at: "", inputs: {}, status: "success", recovered: false, result: { workflow_id: workflow.id, status: "success", outputs: {}, execution_time_ms: 10, node_results: [], execution_history_id: "run-1", highlight: null } });
+
+    await store.clearExecutionHistory();
+
+    expect(clearHistory).toHaveBeenCalledWith(workflow.id);
+    expect(store.executionHistoryList).toEqual([]);
+    expect(store.executionHistoryTotal).toBe(0);
+    expect(store.executionHistoryDetails.size).toBe(0);
+  });
+
+  it("preserves local execution history on forbidden error from clearHistory", async () => {
+    const workflow = makeWorkflow("workflow-a");
+    const getWorkflow = vi.mocked(workflowApi.get);
+    const clearHistory = vi.mocked(workflowApi.clearHistory);
+    getWorkflow.mockResolvedValue(workflow);
+    const error403 = Object.assign(new Error("Forbidden"), {
+      isAxiosError: true,
+      response: { status: 403 }
+    });
+    clearHistory.mockRejectedValue(error403);
+
+    const store = useWorkflowStore();
+    await store.loadWorkflow(workflow.id);
+
+    // Seed some history
+    store.executionHistoryList = [
+      { id: "run-1", workflow_id: workflow.id, workflow_name: "A", status: "success", started_at: "2026-08-11T00:00:00Z", execution_time_ms: 10, run_type: "workflow", trigger_source: null }
+    ];
+    store.executionHistoryTotal = 1;
+    store.executionHistoryDetails.set("run-1", { id: "run-1", started_at: "", inputs: {}, status: "success", recovered: false, result: { workflow_id: workflow.id, status: "success", outputs: {}, execution_time_ms: 10, node_results: [], execution_history_id: "run-1", highlight: null } });
+
+    await expect(store.clearExecutionHistory()).rejects.toThrow("Forbidden");
+
+    expect(clearHistory).toHaveBeenCalledWith(workflow.id);
+    expect(store.executionHistoryTotal).toBe(1);
+    expect(store.executionHistoryList.length).toBe(1);
+    expect(store.executionHistoryDetails.size).toBe(1);
   });
 });

--- a/frontend/src/stores/workflow.ts
+++ b/frontend/src/stores/workflow.ts
@@ -2057,10 +2057,9 @@ export const useWorkflowStore = defineStore("workflow", () => {
       executionHistoryList.value = [];
       executionHistoryDetails.value = new Map();
       executionHistoryTotal.value = 0;
-    } catch {
-      executionHistoryList.value = [];
-      executionHistoryDetails.value = new Map();
-      executionHistoryTotal.value = 0;
+    } catch (error) {
+      showToast("Failed to clear execution history", "error", 3000);
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Problem

Workflow collaborators can currently delete execution history belonging
to the workflow owner.

## Fix

- Restrict bulk execution-history deletion to workflows owned by the current user.
- Return `403` when a collaborator attempts per-workflow history deletion.
- Add regression tests for collaborator and owner behavior.

## Validation

- 31 related backend tests passed
- Ruff passed
- git diff --check passed

This implements the behavior requested by the maintainers following
verification of the reported issue.