### PR TITLE
fix: align variable delete with edit permissions and add auth to reserved-variable-names

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -10,7 +10,9 @@ router = APIRouter()
 
 
 @router.get("/reserved-variable-names")
-async def get_reserved_variable_names() -> list[str]:
+async def get_reserved_variable_names(
+    _current_user: User = Depends(get_current_user),
+) -> list[str]:
     return RESERVED_VARIABLE_NAMES
 
 

--- a/backend/app/api/global_variables.py
+++ b/backend/app/api/global_variables.py
@@ -386,13 +386,7 @@ async def delete_global_variable(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    result = await db.execute(
-        select(GlobalVariable).where(
-            GlobalVariable.id == variable_id,
-            GlobalVariable.owner_id == current_user.id,
-        )
-    )
-    variable = result.scalar_one_or_none()
+    variable = await _get_editable_variable(db, variable_id, current_user.id)
     if variable is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -415,13 +409,11 @@ async def bulk_delete_global_variables(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    result = await db.execute(
-        select(GlobalVariable).where(
-            GlobalVariable.id.in_(body.ids),
-            GlobalVariable.owner_id == current_user.id,
-        )
-    )
-    variables = result.scalars().all()
+    variables = []
+    for vid in body.ids:
+        v = await _get_editable_variable(db, vid, current_user.id)
+        if v is not None:
+            variables.append(v)
     audit(
         action="variable.bulk_delete",
         actor=current_user,


### PR DESCRIPTION
## Summary

- **`delete_global_variable`** now uses `_get_editable_variable()` instead of an owner-only query, aligning it with `update_global_variable`. Shared users (user-share or team-share) who can edit a variable can now also delete it.
- **`bulk_delete_global_variables`** similarly updated for consistency.
- **`GET /reserved-variable-names`** now requires authentication via `get_current_user`.

## Motivation

The existing code had an authorization inconsistency: `update_global_variable` granted edit access to owners, user-shares, and team-shares via `_get_editable_variable`, but `delete_global_variable` and `bulk_delete_global_variables` only checked `owner_id`. This meant shared users could edit variables but not delete them.

The `/reserved-variable-names` endpoint exposed internal platform constants to unauthenticated callers, violating the project's auth convention where all non-webhook routes use `Depends(get_current_user)`.

## Testing

- Both files pass `ruff check` and `ruff format`
- No existing tests broken (verified no test files reference these specific endpoints)
