### PR TITLE
security/credential-hardening-followups

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -98,11 +98,10 @@ vulnerabilities in Heym:
   egress guard, and contributing that fix (GHSA-6rph-qqcv-jqh4), and a cluster
   of capability secrets stored or returned in plaintext across webhook auth,
   MCP keys, portal sessions, and Discord interactions (GHSA-6x65-w7q7-wg93).
-- [@fatihkaratash](https://github.com/fatihkaratash) for the Redis node reading
-  an inaccessible or missing credential as an empty configuration, so an
-  authorization result fell through to the `localhost:6379` connection defaults
-  instead of failing closed (GHSA-fmpw-hj3m-xvj6), and for contributing the
-  remediation.
-- [@fatihkaratash](https://github.com/fatihkaratash) for reporting
-  credential-controlled base URL SSRF across Jira, Sentry, GitHub, Grist,
-  Supabase, and custom OpenAI-compatible integrations (GHSA-xchj-mw74-2232).
+- [@fatihkaratash](https://github.com/fatihkaratash) for two reports: the Redis
+  node reading an inaccessible or missing credential as an empty configuration,
+  so an authorization result fell through to the `localhost:6379` connection
+  defaults instead of failing closed, and contributing that remediation
+  (GHSA-fmpw-hj3m-xvj6), and credential-controlled base URL SSRF across Jira,
+  Sentry, GitHub, Grist, Supabase, and custom OpenAI-compatible integrations
+  (GHSA-xchj-mw74-2232).

--- a/backend/app/services/github_service.py
+++ b/backend/app/services/github_service.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 import httpx
 
 from app.http_identity import merge_outbound_headers
+from app.services.http_paths import encode_path_segment
 from app.services.ssrf_guard import build_guarded_http_client, guard_http_url
 
 GITHUB_API_BASE_URL = "https://api.github.com"
@@ -41,13 +42,29 @@ class GitHubService:
         if self._owns_client and not self._client.is_closed:
             self._client.close()
 
+    @staticmethod
+    def _encode_content_path(path: str) -> str:
+        """Encode a repository file path one segment at a time.
+
+        The slashes are structural here, so they stay, but every segment is
+        encoded and dot segments are escaped: httpx removes them, so a raw
+        ``../..`` in the path would climb out of the contents endpoint.
+        """
+        return "/".join(
+            encode_path_segment(segment) for segment in path.lstrip("/").split("/") if segment
+        )
+
     def get_repository(self, owner: str, repo: str) -> dict[str, Any]:
         """Fetch repository metadata."""
-        return self._request_json("GET", f"/repos/{owner}/{repo}")
+        return self._request_json(
+            "GET", f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}"
+        )
 
     def get_repository_license(self, owner: str, repo: str) -> dict[str, Any]:
         """Fetch the detected repository license and decoded file content."""
-        response = self._request_json("GET", f"/repos/{owner}/{repo}/license")
+        response = self._request_json(
+            "GET", f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/license"
+        )
         if not isinstance(response, dict):
             raise ValueError("GitHub getRepositoryLicense returned an unexpected response")
         decoded_content: str | None = None
@@ -62,24 +79,36 @@ class GitHubService:
 
     def get_repository_profile(self, owner: str, repo: str) -> dict[str, Any]:
         """Fetch repository community profile metrics."""
-        response = self._request_json("GET", f"/repos/{owner}/{repo}/community/profile")
+        response = self._request_json(
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/community/profile",
+        )
         if not isinstance(response, dict):
             raise ValueError("GitHub getRepositoryProfile returned an unexpected response")
         return response
 
     def list_popular_paths(self, owner: str, repo: str) -> list[dict[str, Any]]:
         """List the repository's popular content paths."""
-        response = self._request_json("GET", f"/repos/{owner}/{repo}/traffic/popular/paths")
+        response = self._request_json(
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/traffic/popular/paths",
+        )
         return response if isinstance(response, list) else []
 
     def list_referrers(self, owner: str, repo: str) -> list[dict[str, Any]]:
         """List the repository's top referring domains."""
-        response = self._request_json("GET", f"/repos/{owner}/{repo}/traffic/popular/referrers")
+        response = self._request_json(
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/traffic/popular/referrers",
+        )
         return response if isinstance(response, list) else []
 
     def get_issue(self, owner: str, repo: str, issue_number: int) -> dict[str, Any]:
         """Fetch one issue by number."""
-        return self._request_json("GET", f"/repos/{owner}/{repo}/issues/{issue_number}")
+        return self._request_json(
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/issues/{issue_number}",
+        )
 
     def list_issues(
         self,
@@ -113,7 +142,7 @@ class GitHubService:
                 params[key] = value
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/issues",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/issues",
             params=params,
         )
         if not isinstance(response, list):
@@ -134,7 +163,7 @@ class GitHubService:
         """Create an issue comment."""
         return self._request_json(
             "POST",
-            f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/issues/{issue_number}/comments",
             json={"body": body},
         )
 
@@ -149,7 +178,7 @@ class GitHubService:
         payload = {"lock_reason": lock_reason} if lock_reason else None
         self._request_no_content(
             "PUT",
-            f"/repos/{owner}/{repo}/issues/{issue_number}/lock",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/issues/{issue_number}/lock",
             json=payload,
             success_codes=(204,),
         )
@@ -172,7 +201,11 @@ class GitHubService:
             payload["labels"] = labels
         if assignees:
             payload["assignees"] = assignees
-        return self._request_json("POST", f"/repos/{owner}/{repo}/issues", json=payload)
+        return self._request_json(
+            "POST",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/issues",
+            json=payload,
+        )
 
     def update_issue(
         self,
@@ -204,7 +237,7 @@ class GitHubService:
             raise ValueError("GitHub updateIssue requires at least one field to update")
         return self._request_json(
             "PATCH",
-            f"/repos/{owner}/{repo}/issues/{issue_number}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/issues/{issue_number}",
             json=payload,
         )
 
@@ -228,7 +261,7 @@ class GitHubService:
             params["direction"] = direction
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/pulls",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/pulls",
             params=params,
         )
         return response if isinstance(response, list) else []
@@ -270,7 +303,11 @@ class GitHubService:
         }
         if body:
             payload["body"] = body
-        return self._request_json("POST", f"/repos/{owner}/{repo}/pulls", json=payload)
+        return self._request_json(
+            "POST",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/pulls",
+            json=payload,
+        )
 
     def get_review(
         self,
@@ -282,7 +319,7 @@ class GitHubService:
         """Fetch one pull request review."""
         return self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/pulls/{pull_request_number}/reviews/{review_id}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/pulls/{pull_request_number}/reviews/{review_id}",
         )
 
     def list_reviews(
@@ -295,7 +332,7 @@ class GitHubService:
         """List reviews for a pull request."""
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/pulls/{pull_request_number}/reviews",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/pulls/{pull_request_number}/reviews",
             params={"per_page": max(1, min(per_page, 100))},
         )
         return response if isinstance(response, list) else []
@@ -317,7 +354,7 @@ class GitHubService:
             payload["commit_id"] = commit_id
         return self._request_json(
             "POST",
-            f"/repos/{owner}/{repo}/pulls/{pull_request_number}/reviews",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/pulls/{pull_request_number}/reviews",
             json=payload,
         )
 
@@ -332,7 +369,7 @@ class GitHubService:
         """Update a pull request review body."""
         return self._request_json(
             "PUT",
-            f"/repos/{owner}/{repo}/pulls/{pull_request_number}/reviews/{review_id}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/pulls/{pull_request_number}/reviews/{review_id}",
             json={"body": body},
         )
 
@@ -345,14 +382,17 @@ class GitHubService:
         """List repository releases."""
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/releases",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases",
             params={"per_page": max(1, min(per_page, 100))},
         )
         return response if isinstance(response, list) else []
 
     def get_release(self, owner: str, repo: str, release_id: int) -> dict[str, Any]:
         """Fetch a release by id."""
-        return self._request_json("GET", f"/repos/{owner}/{repo}/releases/{release_id}")
+        return self._request_json(
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases/{release_id}",
+        )
 
     def create_release(
         self,
@@ -377,19 +417,25 @@ class GitHubService:
             payload["body"] = body
         if target_commitish:
             payload["target_commitish"] = target_commitish
-        return self._request_json("POST", f"/repos/{owner}/{repo}/releases", json=payload)
+        return self._request_json(
+            "POST",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases",
+            json=payload,
+        )
 
     def get_release_by_tag(self, owner: str, repo: str, tag: str) -> dict[str, Any]:
         """Fetch a release by git tag name."""
         return self._request_json(
-            "GET", f"/repos/{owner}/{repo}/releases/tags/{quote(tag, safe='')}"
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases/tags/"
+            f"{encode_path_segment(tag)}",
         )
 
     def delete_release_asset(self, owner: str, repo: str, asset_id: int) -> dict[str, Any]:
         """Delete a release asset by id."""
         self._request_no_content(
             "DELETE",
-            f"/repos/{owner}/{repo}/releases/assets/{asset_id}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases/assets/{asset_id}",
             success_codes=(204,),
         )
         return {"asset_id": asset_id, "deleted": True}
@@ -416,7 +462,7 @@ class GitHubService:
             base = template.split("{", 1)[0]
         else:
             upload_base = self._uploads_base_url()
-            base = f"{upload_base}/repos/{owner}/{repo}/releases/{release_id}/assets"
+            base = f"{upload_base}/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases/{release_id}/assets"
         params = [f"name={quote(asset_name)}"]
         if label:
             params.append(f"label={quote(label)}")
@@ -473,14 +519,16 @@ class GitHubService:
         if not payload:
             raise ValueError("GitHub updateRelease requires at least one field to update")
         return self._request_json(
-            "PATCH", f"/repos/{owner}/{repo}/releases/{release_id}", json=payload
+            "PATCH",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases/{release_id}",
+            json=payload,
         )
 
     def delete_release(self, owner: str, repo: str, release_id: int) -> dict[str, Any]:
         """Delete a release by id."""
         self._request_no_content(
             "DELETE",
-            f"/repos/{owner}/{repo}/releases/{release_id}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/releases/{release_id}",
             success_codes=(204,),
         )
         return {"release_id": release_id, "deleted": True}
@@ -494,7 +542,7 @@ class GitHubService:
         """List GitHub Actions workflows for a repository."""
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/actions/workflows",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows",
             params={"per_page": max(1, min(per_page, 100))},
         )
         if isinstance(response, dict):
@@ -504,13 +552,16 @@ class GitHubService:
 
     def get_workflow(self, owner: str, repo: str, workflow_id: str) -> dict[str, Any]:
         """Fetch a workflow by numeric id or file name."""
-        return self._request_json("GET", f"/repos/{owner}/{repo}/actions/workflows/{workflow_id}")
+        return self._request_json(
+            "GET",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows/{encode_path_segment(workflow_id)}",
+        )
 
     def enable_workflow(self, owner: str, repo: str, workflow_id: str) -> dict[str, Any]:
         """Enable a GitHub Actions workflow."""
         self._request_no_content(
             "PUT",
-            f"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows/{encode_path_segment(workflow_id)}/enable",
             success_codes=(204,),
         )
         return {"workflow_id": workflow_id, "enabled": True}
@@ -519,7 +570,7 @@ class GitHubService:
         """Disable a GitHub Actions workflow."""
         self._request_no_content(
             "PUT",
-            f"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows/{encode_path_segment(workflow_id)}/disable",
             success_codes=(204,),
         )
         return {"workflow_id": workflow_id, "disabled": True}
@@ -533,7 +584,7 @@ class GitHubService:
         """Fetch billable GitHub Actions usage for one workflow."""
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows/{encode_path_segment(workflow_id)}/timing",
         )
         if not isinstance(response, dict):
             raise ValueError("GitHub getWorkflowUsage returned an unexpected response")
@@ -551,7 +602,7 @@ class GitHubService:
         payload: dict[str, Any] = {"ref": ref}
         if inputs:
             payload["inputs"] = inputs
-        url = f"{self._base_url()}/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"
+        url = f"{self._base_url()}/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows/{encode_path_segment(workflow_id)}/dispatches"
         response = self._client.request(
             "POST",
             url,
@@ -584,7 +635,7 @@ class GitHubService:
         """Fetch one GitHub Actions workflow run."""
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/actions/runs/{run_id}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/runs/{run_id}",
         )
         if not isinstance(response, dict):
             raise ValueError("GitHub getWorkflowRun returned an unexpected response")
@@ -600,7 +651,7 @@ class GitHubService:
         """List recent workflow-dispatch runs for one workflow."""
         response = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/actions/workflows/{encode_path_segment(workflow_id)}/runs",
             params={
                 "event": "workflow_dispatch",
                 "per_page": max(1, min(per_page, 100)),
@@ -714,7 +765,7 @@ class GitHubService:
             params["ref"] = ref
         data = self._request_json(
             "GET",
-            f"/repos/{owner}/{repo}/contents/{quote(path.lstrip('/'), safe='/')}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/contents/{self._encode_content_path(path)}",
             params=params or None,
         )
         if not isinstance(data, dict):
@@ -748,8 +799,8 @@ class GitHubService:
         ref: str | None = None,
     ) -> dict[str, Any]:
         """List files inside a repository directory via the contents API."""
-        normalized_path = quote(path.lstrip("/"), safe="/")
-        endpoint = f"/repos/{owner}/{repo}/contents"
+        normalized_path = self._encode_content_path(path)
+        endpoint = f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/contents"
         if normalized_path:
             endpoint = f"{endpoint}/{normalized_path}"
         params: dict[str, Any] = {}
@@ -785,13 +836,13 @@ class GitHubService:
         sha: str | None = None,
     ) -> dict[str, Any]:
         """Create or update a repository file."""
-        normalized_path = quote(path.lstrip("/"), safe="/")
+        normalized_path = self._encode_content_path(path)
         target_sha = sha.strip() if sha else ""
         if not target_sha:
             try:
                 existing = self._request_json(
                     "GET",
-                    f"/repos/{owner}/{repo}/contents/{normalized_path}",
+                    f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/contents/{normalized_path}",
                     params={"ref": branch} if branch else None,
                 )
                 if isinstance(existing, dict):
@@ -811,7 +862,7 @@ class GitHubService:
 
         data = self._request_json(
             "PUT",
-            f"/repos/{owner}/{repo}/contents/{normalized_path}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/contents/{normalized_path}",
             json=payload,
         )
         if not isinstance(data, dict):
@@ -837,12 +888,12 @@ class GitHubService:
         sha: str | None = None,
     ) -> dict[str, Any]:
         """Delete a repository file."""
-        normalized_path = quote(path.lstrip("/"), safe="/")
+        normalized_path = self._encode_content_path(path)
         target_sha = sha.strip() if sha else ""
         if not target_sha:
             existing = self._request_json(
                 "GET",
-                f"/repos/{owner}/{repo}/contents/{normalized_path}",
+                f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/contents/{normalized_path}",
                 params={"ref": branch} if branch else None,
             )
             if not isinstance(existing, dict):
@@ -856,7 +907,7 @@ class GitHubService:
             payload["branch"] = branch
         data = self._request_json(
             "DELETE",
-            f"/repos/{owner}/{repo}/contents/{normalized_path}",
+            f"/repos/{encode_path_segment(owner)}/{encode_path_segment(repo)}/contents/{normalized_path}",
             json=payload,
         )
         if not isinstance(data, dict):
@@ -878,7 +929,7 @@ class GitHubService:
         """List repositories for an organization."""
         response = self._request_json(
             "GET",
-            f"/orgs/{organization}/repos",
+            f"/orgs/{encode_path_segment(organization)}/repos",
             params={"per_page": max(1, min(per_page, 100))},
         )
         return response if isinstance(response, list) else []
@@ -891,7 +942,7 @@ class GitHubService:
         """List repositories for a user."""
         response = self._request_json(
             "GET",
-            f"/users/{username}/repos",
+            f"/users/{encode_path_segment(username)}/repos",
             params={"per_page": max(1, min(per_page, 100))},
         )
         return response if isinstance(response, list) else []
@@ -944,7 +995,7 @@ class GitHubService:
         """Invite a user to an organization by email."""
         response = self._request_json(
             "POST",
-            f"/orgs/{organization}/invitations",
+            f"/orgs/{encode_path_segment(organization)}/invitations",
             json={"email": email},
         )
         if not isinstance(response, dict):

--- a/backend/app/services/http_paths.py
+++ b/backend/app/services/http_paths.py
@@ -1,0 +1,32 @@
+"""Percent-encoding for user-controlled URL path segments.
+
+Integration clients build REST paths by interpolating values a workflow author
+or an upstream API supplies (issue keys, repository owners, Grist document IDs).
+Interpolating them raw lets a value carrying ``/`` or ``..`` rewrite the request
+path: httpx and :func:`urllib.parse.urljoin` both apply RFC 3986 dot-segment
+removal, so ``../../`` in an issue key reaches a different endpoint than the
+operation intended.
+
+:func:`encode_path_segment` is the one helper for this; do not add a second.
+``quote(value, safe="")`` alone is not enough because ``.`` is in the always-safe
+set, so a bare ``.`` or ``..`` value survives encoding and is still resolved as a
+dot segment.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import quote
+
+__all__ = ["encode_path_segment"]
+
+
+def encode_path_segment(value: object) -> str:
+    """Encode one value for safe interpolation into a URL path.
+
+    Every reserved character, ``/`` included, is percent-encoded, and the two
+    dot segments are escaped so they cannot be resolved as path navigation.
+    """
+    segment = quote(str(value), safe="")
+    if segment in {".", ".."}:
+        return segment.replace(".", "%2E")
+    return segment

--- a/backend/app/services/jira_service.py
+++ b/backend/app/services/jira_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -314,7 +314,7 @@ class JiraService:
         """Download raw attachment content from Jira's content URL."""
         payload = self._request_absolute(
             "GET",
-            content_url,
+            self._same_origin_url(content_url, "attachment content URL"),
             headers={"Accept": "*/*"},
             expect_json=False,
         )
@@ -459,6 +459,37 @@ class JiraService:
 
     def _url(self, path: str) -> str:
         return urljoin(f"{self._base_url}/rest/api/{self._api_version}/", path.lstrip("/"))
+
+    def _same_origin_url(self, url: str, label: str) -> str:
+        """Resolve a Jira-supplied URL and refuse it if it leaves the credential's origin.
+
+        Response bodies choose these URLs, so an attacker who can place an issue
+        attachment could otherwise point one at their own host and receive the
+        credential's Basic auth header.
+        """
+        normalized = str(url or "").strip()
+        if not normalized:
+            raise ValueError(f"Jira {label} is empty")
+        resolved = urljoin(f"{self._base_url}/", normalized)
+        if self._origin(resolved) != self._origin(self._base_url):
+            raise ValueError(
+                f"Jira {label} points outside the credential base URL origin "
+                "and was refused to avoid sending Jira credentials to another host"
+            )
+        return resolved
+
+    @staticmethod
+    def _origin(url: str) -> tuple[str, str, int | None]:
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        if scheme not in {"http", "https"}:
+            raise ValueError("Jira URLs must use http or https")
+        try:
+            port = parsed.port
+        except ValueError as exc:
+            raise ValueError("Jira URL includes an invalid port") from exc
+        default_port = 443 if scheme == "https" else 80
+        return (scheme, (parsed.hostname or "").lower(), port or default_port)
 
     @property
     def _is_data_center(self) -> bool:

--- a/backend/app/services/jira_service.py
+++ b/backend/app/services/jira_service.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 
 from app.http_identity import merge_outbound_headers
+from app.services.http_paths import encode_path_segment
 from app.services.ssrf_guard import build_guarded_http_client, guard_http_url
 
 _DEFAULT_API_VERSION = "3"
@@ -96,7 +97,7 @@ class JiraService:
 
     def get_issue(self, issue_key: str) -> dict[str, Any]:
         """Fetch one Jira issue by key or ID."""
-        payload = self._request("GET", f"/issue/{issue_key}")
+        payload = self._request("GET", f"/issue/{encode_path_segment(issue_key)}")
         return self._expect_object(payload, "issue")
 
     def create_issue(
@@ -157,12 +158,17 @@ class JiraService:
             fields["labels"] = labels
         if not fields:
             raise ValueError("Jira updateIssue requires at least one field to update")
-        self._request("PUT", f"/issue/{issue_key}", json={"fields": fields}, expect_json=False)
+        self._request(
+            "PUT",
+            f"/issue/{encode_path_segment(issue_key)}",
+            json={"fields": fields},
+            expect_json=False,
+        )
         return self.get_issue(issue_key)
 
     def delete_issue(self, issue_key: str) -> bool:
         """Delete a Jira issue."""
-        self._request("DELETE", f"/issue/{issue_key}", expect_json=False)
+        self._request("DELETE", f"/issue/{encode_path_segment(issue_key)}", expect_json=False)
         return True
 
     def get_issue_changelog(
@@ -175,7 +181,7 @@ class JiraService:
             return self._get_issue_changelog_v2(issue_key, normalized_limit, offset)
         payload = self._request(
             "GET",
-            f"/issue/{issue_key}/changelog",
+            f"/issue/{encode_path_segment(issue_key)}/changelog",
             params={"maxResults": normalized_limit, "startAt": offset},
         )
         return self._expect_object(payload, "issue.changelog")
@@ -197,14 +203,19 @@ class JiraService:
         }
         if html_body:
             payload["htmlBody"] = html_body
-        self._request("POST", f"/issue/{issue_key}/notify", json=payload, expect_json=False)
+        self._request(
+            "POST",
+            f"/issue/{encode_path_segment(issue_key)}/notify",
+            json=payload,
+            expect_json=False,
+        )
         return True
 
     def list_comments(self, issue_key: str, limit: int = 50, start_at: int = 0) -> dict[str, Any]:
         """List comments on a Jira issue."""
         payload = self._request(
             "GET",
-            f"/issue/{issue_key}/comment",
+            f"/issue/{encode_path_segment(issue_key)}/comment",
             params={"maxResults": self._normalize_limit(limit), "startAt": max(start_at, 0)},
         )
         return self._expect_object(payload, "issue.comments")
@@ -213,34 +224,41 @@ class JiraService:
         """Add a comment to a Jira issue."""
         payload = self._request(
             "POST",
-            f"/issue/{issue_key}/comment",
+            f"/issue/{encode_path_segment(issue_key)}/comment",
             json={"body": self._text_document_payload(body)},
         )
         return self._expect_object(payload, "comment")
 
     def get_comment(self, issue_key: str, comment_id: str) -> dict[str, Any]:
         """Fetch one comment on a Jira issue."""
-        payload = self._request("GET", f"/issue/{issue_key}/comment/{comment_id}")
+        payload = self._request(
+            "GET",
+            f"/issue/{encode_path_segment(issue_key)}/comment/{encode_path_segment(comment_id)}",
+        )
         return self._expect_object(payload, "comment")
 
     def update_comment(self, issue_key: str, comment_id: str, body: str) -> dict[str, Any]:
         """Update a comment on a Jira issue."""
         payload = self._request(
             "PUT",
-            f"/issue/{issue_key}/comment/{comment_id}",
+            f"/issue/{encode_path_segment(issue_key)}/comment/{encode_path_segment(comment_id)}",
             json={"body": self._text_document_payload(body)},
         )
         return self._expect_object(payload, "comment")
 
     def delete_comment(self, issue_key: str, comment_id: str) -> bool:
         """Delete a comment from a Jira issue."""
-        self._request("DELETE", f"/issue/{issue_key}/comment/{comment_id}", expect_json=False)
+        self._request(
+            "DELETE",
+            f"/issue/{encode_path_segment(issue_key)}/comment/{encode_path_segment(comment_id)}",
+            expect_json=False,
+        )
         return True
 
     def list_transitions(self, issue_key: str) -> list[dict[str, Any]]:
         """List available transitions for a Jira issue."""
         payload = self._expect_object(
-            self._request("GET", f"/issue/{issue_key}/transitions"),
+            self._request("GET", f"/issue/{encode_path_segment(issue_key)}/transitions"),
             "issue.transitions",
         )
         transitions = payload.get("transitions")
@@ -252,7 +270,7 @@ class JiraService:
         """Transition a Jira issue using a transition ID."""
         self._request(
             "POST",
-            f"/issue/{issue_key}/transitions",
+            f"/issue/{encode_path_segment(issue_key)}/transitions",
             json={"transition": {"id": transition_id}},
             expect_json=False,
         )
@@ -270,7 +288,7 @@ class JiraService:
         """Add a file attachment to a Jira issue."""
         payload = self._request(
             "POST",
-            f"/issue/{issue_key}/attachments",
+            f"/issue/{encode_path_segment(issue_key)}/attachments",
             files={"file": (filename, content, mime_type or "application/octet-stream")},
             headers={"X-Atlassian-Token": "no-check"},
         )
@@ -280,7 +298,7 @@ class JiraService:
 
     def get_attachment(self, attachment_id: str) -> dict[str, Any]:
         """Fetch one Jira attachment metadata object."""
-        payload = self._request("GET", f"/attachment/{attachment_id}")
+        payload = self._request("GET", f"/attachment/{encode_path_segment(attachment_id)}")
         return self._expect_object(payload, "attachment")
 
     def list_attachments(
@@ -307,7 +325,9 @@ class JiraService:
 
     def delete_attachment(self, attachment_id: str) -> bool:
         """Delete a Jira attachment by ID."""
-        self._request("DELETE", f"/attachment/{attachment_id}", expect_json=False)
+        self._request(
+            "DELETE", f"/attachment/{encode_path_segment(attachment_id)}", expect_json=False
+        )
         return True
 
     def download_attachment(self, content_url: str) -> bytes:
@@ -357,7 +377,7 @@ class JiraService:
         """Fetch one Jira issue with a restricted fields list."""
         payload = self._request(
             "GET",
-            f"/issue/{issue_key}",
+            f"/issue/{encode_path_segment(issue_key)}",
             params={"fields": ",".join(fields)},
         )
         return self._expect_object(payload, "issue")
@@ -365,7 +385,7 @@ class JiraService:
     def _get_issue_changelog_v2(self, issue_key: str, limit: int, start_at: int) -> dict[str, Any]:
         payload = self._request(
             "GET",
-            f"/issue/{issue_key}",
+            f"/issue/{encode_path_segment(issue_key)}",
             params={"expand": "changelog", "fields": "none"},
         )
         issue = self._expect_object(payload, "issue")

--- a/backend/app/services/jira_service.py
+++ b/backend/app/services/jira_service.py
@@ -478,7 +478,10 @@ class JiraService:
         return payload
 
     def _url(self, path: str) -> str:
-        return urljoin(f"{self._base_url}/rest/api/{self._api_version}/", path.lstrip("/"))
+        # api_version comes from the credential, so it is encoded like any other
+        # interpolated segment. "2", "3" and "latest" pass through unchanged.
+        version = encode_path_segment(self._api_version)
+        return urljoin(f"{self._base_url}/rest/api/{version}/", path.lstrip("/"))
 
     def _same_origin_url(self, url: str, label: str) -> str:
         """Resolve a Jira-supplied URL and refuse it if it leaves the credential's origin.

--- a/backend/app/services/node_execution/nodes/discord_node.py
+++ b/backend/app/services/node_execution/nodes/discord_node.py
@@ -29,13 +29,13 @@ def execute(ctx: NodeExecutionContext) -> object:
     from app.db.session import SessionLocal
     from app.services.encryption import decrypt_config
 
-    webhook_url = ""
     with SessionLocal() as db:
         cred = self._get_accessible_credential(db, credential_id)
-        if cred:
-            config = decrypt_config(cred.encrypted_config)
-            webhook_url = config.get("webhook_url", "")
+        if cred is None:
+            raise ValueError("Discord credential not found or not accessible")
+        config = decrypt_config(cred.encrypted_config)
 
+    webhook_url = config.get("webhook_url", "")
     if not webhook_url:
         raise ValueError("Discord credential requires webhook_url")
 

--- a/backend/app/services/node_execution/nodes/grist_node.py
+++ b/backend/app/services/node_execution/nodes/grist_node.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+from app.services.http_paths import encode_path_segment
 from app.services.node_execution.base import NodeExecutionContext
 
 
@@ -48,10 +49,15 @@ def execute(ctx: NodeExecutionContext) -> object:
     table_id_template = node_data.get("gristTableId", "")
     table_id = self.evaluate_message_template(table_id_template, inputs, node_id)
 
+    # Both come from workflow data or upstream input, so they are encoded before
+    # they reach a path: httpx resolves "../" and would rewrite the endpoint.
+    doc_path = encode_path_segment(doc_id)
+    table_path = encode_path_segment(table_id)
+
     if operation == "listTables":
         if not doc_id:
             raise ValueError("Grist listTables requires a document ID")
-        response = client.get(f"/api/docs/{doc_id}/tables")
+        response = client.get(f"/api/docs/{doc_path}/tables")
         check_grist_response(response)
         data = response.json()
         output = {
@@ -63,7 +69,7 @@ def execute(ctx: NodeExecutionContext) -> object:
     elif operation == "listColumns":
         if not doc_id or not table_id:
             raise ValueError("Grist listColumns requires document ID and table ID")
-        response = client.get(f"/api/docs/{doc_id}/tables/{table_id}/columns")
+        response = client.get(f"/api/docs/{doc_path}/tables/{table_path}/columns")
         check_grist_response(response)
         data = response.json()
         output = {
@@ -81,7 +87,7 @@ def execute(ctx: NodeExecutionContext) -> object:
             raise ValueError("Grist getRecord requires a record ID")
         filter_param = json.dumps({"id": [int(record_id)]})
         response = client.get(
-            f"/api/docs/{doc_id}/tables/{table_id}/records",
+            f"/api/docs/{doc_path}/tables/{table_path}/records",
             params={"filter": filter_param},
         )
         check_grist_response(response)
@@ -126,7 +132,7 @@ def execute(ctx: NodeExecutionContext) -> object:
             params["limit"] = int(limit)
 
         response = client.get(
-            f"/api/docs/{doc_id}/tables/{table_id}/records",
+            f"/api/docs/{doc_path}/tables/{table_path}/records",
             params=params,
         )
         check_grist_response(response)
@@ -153,7 +159,7 @@ def execute(ctx: NodeExecutionContext) -> object:
 
         payload = {"records": [{"fields": record_data}]}
         response = client.post(
-            f"/api/docs/{doc_id}/tables/{table_id}/records",
+            f"/api/docs/{doc_path}/tables/{table_path}/records",
             json=payload,
         )
         check_grist_response(response)
@@ -185,7 +191,7 @@ def execute(ctx: NodeExecutionContext) -> object:
 
         payload = {"records": [{"fields": r} for r in records_data]}
         response = client.post(
-            f"/api/docs/{doc_id}/tables/{table_id}/records",
+            f"/api/docs/{doc_path}/tables/{table_path}/records",
             json=payload,
         )
         check_grist_response(response)
@@ -217,7 +223,7 @@ def execute(ctx: NodeExecutionContext) -> object:
 
         payload = {"records": [{"id": int(record_id), "fields": record_data}]}
         response = client.patch(
-            f"/api/docs/{doc_id}/tables/{table_id}/records",
+            f"/api/docs/{doc_path}/tables/{table_path}/records",
             json=payload,
         )
         check_grist_response(response)
@@ -250,7 +256,7 @@ def execute(ctx: NodeExecutionContext) -> object:
             ]
         }
         response = client.patch(
-            f"/api/docs/{doc_id}/tables/{table_id}/records",
+            f"/api/docs/{doc_path}/tables/{table_path}/records",
             json=payload,
         )
         check_grist_response(response)
@@ -286,7 +292,7 @@ def execute(ctx: NodeExecutionContext) -> object:
                 raise ValueError("Invalid record IDs for deleteRecord")
 
         response = client.post(
-            f"/api/docs/{doc_id}/tables/{table_id}/data/delete",
+            f"/api/docs/{doc_path}/tables/{table_path}/data/delete",
             json=record_ids,
         )
         check_grist_response(response)

--- a/backend/app/services/node_execution/nodes/send_email_node.py
+++ b/backend/app/services/node_execution/nodes/send_email_node.py
@@ -45,19 +45,28 @@ def execute(ctx: NodeExecutionContext) -> object:
     if not credential_id:
         raise ValueError("Send Email node requires an SMTP credential")
 
-    smtp_config: dict = {}
     with SessionLocal() as db:
         cred = self._get_accessible_credential(db, credential_id)
-        if cred:
-            smtp_config = decrypt_config(cred.encrypted_config)
+        if cred is None:
+            raise ValueError("SMTP credential not found or not accessible")
+        smtp_config: dict = decrypt_config(cred.encrypted_config)
 
     smtp_server = smtp_config.get("smtp_server", "")
     smtp_port = int(smtp_config.get("smtp_port", 587))
     smtp_email = smtp_config.get("smtp_email", "")
     smtp_password = smtp_config.get("smtp_password", "")
 
-    if not all([smtp_server, smtp_email, smtp_password]):
-        raise ValueError("SMTP credential is missing required fields")
+    missing_fields = [
+        name
+        for name, value in (
+            ("smtp_server", smtp_server),
+            ("smtp_email", smtp_email),
+            ("smtp_password", smtp_password),
+        )
+        if not value
+    ]
+    if missing_fields:
+        raise ValueError(f"SMTP credential requires {', '.join(missing_fields)}")
 
     if not to_address:
         raise ValueError("Email recipient (to) is required")

--- a/backend/app/services/node_execution/nodes/slack_node.py
+++ b/backend/app/services/node_execution/nodes/slack_node.py
@@ -23,13 +23,13 @@ def execute(ctx: NodeExecutionContext) -> object:
     from app.db.session import SessionLocal
     from app.services.encryption import decrypt_config
 
-    webhook_url = ""
     with SessionLocal() as db:
         cred = self._get_accessible_credential(db, credential_id)
-        if cred:
-            config = decrypt_config(cred.encrypted_config)
-            webhook_url = config.get("webhook_url", "")
+        if cred is None:
+            raise ValueError("Slack credential not found or not accessible")
+        config = decrypt_config(cred.encrypted_config)
 
+    webhook_url = config.get("webhook_url", "")
     if not webhook_url:
         raise ValueError("Slack credential requires webhook_url")
 

--- a/backend/app/services/node_execution/nodes/telegram_node.py
+++ b/backend/app/services/node_execution/nodes/telegram_node.py
@@ -32,11 +32,11 @@ def execute(ctx: NodeExecutionContext) -> object:
     from app.db.session import SessionLocal
     from app.services.encryption import decrypt_config
 
-    telegram_config: dict = {}
     with SessionLocal() as db:
         cred = self._get_accessible_credential(db, credential_id)
-        if cred:
-            telegram_config = decrypt_config(cred.encrypted_config)
+        if cred is None:
+            raise ValueError("Telegram credential not found or not accessible")
+        telegram_config: dict = decrypt_config(cred.encrypted_config)
 
     bot_token = str(telegram_config.get("bot_token", "")).strip()
     if not bot_token:

--- a/backend/app/services/sentry_service.py
+++ b/backend/app/services/sentry_service.py
@@ -1,11 +1,12 @@
 """Sentry REST API client used by workflow nodes and credentials."""
 
 from typing import Any
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 import httpx
 
 from app.http_identity import merge_outbound_headers
+from app.services.http_paths import encode_path_segment
 from app.services.ssrf_guard import build_guarded_http_client, guard_http_url
 
 
@@ -56,7 +57,7 @@ class SentryService:
 
     @staticmethod
     def _path_segment(value: str) -> str:
-        return quote(value, safe="")
+        return encode_path_segment(value)
 
     @staticmethod
     def _normalize_limit(value: int | str | None, default: int = 25, maximum: int = 100) -> int:

--- a/backend/tests/test_advisory_integration_path_segments.py
+++ b/backend/tests/test_advisory_integration_path_segments.py
@@ -99,6 +99,62 @@ class JiraPathSegmentTests(unittest.TestCase):
             "https://example.atlassian.net/rest/api/3/issue/%2E%2E",
         )
 
+    def test_credential_api_version_cannot_escape_the_rest_api_root(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"values": []})
+        service = JiraService(
+            {
+                "email": "ada@example.com",
+                "api_token": "jira-token",
+                "base_url": "https://jira.example",
+                "api_version": _TRAVERSAL,
+            },
+            client=client,
+        )
+
+        service.list_projects()
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(url.startswith("https://jira.example/rest/api/"))
+        self.assertNotIn("/admin/secrets", url)
+
+    def test_supported_api_versions_build_exactly_the_same_url_as_before(self) -> None:
+        """The encoder must be a no-op for every version a credential really holds."""
+        for version, expected in (
+            ("2", "https://jira.example/rest/api/2/project/search"),
+            ("3", "https://jira.example/rest/api/3/project/search"),
+            ("latest", "https://jira.example/rest/api/latest/project/search"),
+            ("", "https://jira.example/rest/api/3/project/search"),
+        ):
+            with self.subTest(api_version=version):
+                service = JiraService(
+                    {
+                        "email": "ada@example.com",
+                        "api_token": "jira-token",
+                        "base_url": "https://jira.example",
+                        "api_version": version,
+                    },
+                    client=MagicMock(),
+                )
+                self.assertEqual(service._url("/project/search"), expected)
+
+    def test_data_center_still_pins_itself_to_api_version_two(self) -> None:
+        service = JiraService(
+            {
+                "email": "ada@example.com",
+                "api_token": "jira-token",
+                "base_url": "https://jira.internal.example",
+                "deployment": "data_center",
+                "api_version": _TRAVERSAL,
+            },
+            client=MagicMock(),
+        )
+
+        self.assertEqual(service._api_version, "2")
+        self.assertEqual(
+            service._url("/project"), "https://jira.internal.example/rest/api/2/project"
+        )
+
     def test_ordinary_issue_keys_are_unchanged(self) -> None:
         client = MagicMock()
         client.request.return_value = _response({"key": "PROJ-42"})

--- a/backend/tests/test_advisory_integration_path_segments.py
+++ b/backend/tests/test_advisory_integration_path_segments.py
@@ -1,0 +1,248 @@
+"""Regression tests for user-controlled URL path segments in REST integrations.
+
+Jira issue keys, GitHub owners and repository paths, and Grist document and
+table IDs are all workflow-controlled values interpolated into a request path.
+Both httpx and :func:`urllib.parse.urljoin` apply RFC 3986 dot-segment removal,
+so a raw ``../`` in one of them silently retargets the request at a different
+endpoint of the same host, under the credential's own authorization.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from app.services.github_service import GitHubService
+from app.services.http_paths import encode_path_segment
+from app.services.jira_service import JiraService
+from app.services.node_execution.base import NodeExecutionContext
+from app.services.node_execution.nodes.grist_node import execute as grist_execute
+from app.services.sentry_service import SentryService
+
+_TRAVERSAL = "../../../../admin/secrets"
+
+
+def _response(payload: object, url: str = "https://example.test/") -> httpx.Response:
+    return httpx.Response(200, json=payload, request=httpx.Request("GET", url))
+
+
+class PathSegmentEncodingTests(unittest.TestCase):
+    """The shared helper is the single implementation for every client."""
+
+    def test_reserved_characters_and_slashes_are_encoded(self) -> None:
+        self.assertEqual(encode_path_segment("a/b"), "a%2Fb")
+        self.assertEqual(encode_path_segment("PROJ-1?x=1#y"), "PROJ-1%3Fx%3D1%23y")
+        self.assertEqual(encode_path_segment("a b"), "a%20b")
+
+    def test_dot_segments_are_escaped_rather_than_left_resolvable(self) -> None:
+        # quote(value, safe="") alone returns these unchanged: "." is always safe.
+        self.assertEqual(encode_path_segment(".."), "%2E%2E")
+        self.assertEqual(encode_path_segment("."), "%2E")
+        self.assertEqual(encode_path_segment("..foo"), "..foo")
+
+    def test_non_string_values_are_accepted(self) -> None:
+        self.assertEqual(encode_path_segment(42), "42")
+
+
+class JiraPathSegmentTests(unittest.TestCase):
+    def _service(self, client: MagicMock) -> JiraService:
+        return JiraService(
+            {
+                "email": "ada@example.com",
+                "api_token": "jira-token",
+                "base_url": "https://example.atlassian.net",
+            },
+            client=client,
+        )
+
+    def test_issue_key_traversal_cannot_leave_the_rest_api_prefix(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"key": "PROJ-1"})
+
+        self._service(client).get_issue(_TRAVERSAL)
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(url.startswith("https://example.atlassian.net/rest/api/3/issue/"))
+        self.assertNotIn("/admin/secrets", url)
+        self.assertIn("%2F", url)
+
+    def test_comment_id_is_encoded_too(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"id": "1"})
+
+        self._service(client).get_comment("PROJ-1", _TRAVERSAL)
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(
+            url.startswith("https://example.atlassian.net/rest/api/3/issue/PROJ-1/comment/")
+        )
+        self.assertNotIn("/admin/secrets", url)
+
+    def test_attachment_id_is_encoded(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"id": "1"})
+
+        self._service(client).get_attachment(_TRAVERSAL)
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(url.startswith("https://example.atlassian.net/rest/api/3/attachment/"))
+        self.assertNotIn("/admin/secrets", url)
+
+    def test_a_bare_dot_dot_issue_key_stays_inside_the_issue_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"key": "x"})
+
+        self._service(client).get_issue("..")
+
+        self.assertEqual(
+            client.request.call_args.args[1],
+            "https://example.atlassian.net/rest/api/3/issue/%2E%2E",
+        )
+
+    def test_ordinary_issue_keys_are_unchanged(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"key": "PROJ-42"})
+
+        self._service(client).get_issue("PROJ-42")
+
+        self.assertEqual(
+            client.request.call_args.args[1],
+            "https://example.atlassian.net/rest/api/3/issue/PROJ-42",
+        )
+
+
+class GitHubPathSegmentTests(unittest.TestCase):
+    def _service(self, client: MagicMock) -> GitHubService:
+        return GitHubService({"token": "gh-token"}, client=client)
+
+    def test_owner_traversal_cannot_retarget_the_repos_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"full_name": "o/r"})
+
+        self._service(client).get_repository(_TRAVERSAL, "repo")
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(url.startswith("https://api.github.com/repos/"))
+        self.assertNotIn("/admin/secrets", url)
+
+    def test_workflow_id_is_encoded(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"id": 1})
+
+        self._service(client).get_workflow("octo", "repo", _TRAVERSAL)
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(url.startswith("https://api.github.com/repos/octo/repo/actions/workflows/"))
+        self.assertNotIn("/admin/secrets", url)
+
+    def test_release_tag_is_still_encoded_after_moving_to_the_shared_helper(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response({"id": 1})
+
+        self._service(client).get_release_by_tag("octo", "repo", "v1.0/../../x")
+
+        self.assertEqual(
+            client.request.call_args.args[1],
+            "https://api.github.com/repos/octo/repo/releases/tags/v1.0%2F..%2F..%2Fx",
+        )
+
+    def test_content_path_keeps_its_slashes_but_escapes_dot_segments(self) -> None:
+        self.assertEqual(GitHubService._encode_content_path("/src/app/main.py"), "src/app/main.py")
+        self.assertEqual(
+            GitHubService._encode_content_path("../../etc/passwd"),
+            "%2E%2E/%2E%2E/etc/passwd",
+        )
+        self.assertEqual(GitHubService._encode_content_path("a dir/b?c"), "a%20dir/b%3Fc")
+
+    def test_get_file_path_traversal_stays_under_the_contents_endpoint(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response(
+            {"type": "file", "encoding": "base64", "content": "", "sha": "s", "path": "p"}
+        )
+
+        self._service(client).get_file("octo", "repo", "../../../../settings")
+
+        url = client.request.call_args.args[1]
+        self.assertTrue(url.startswith("https://api.github.com/repos/octo/repo/contents/"))
+        self.assertNotIn("/settings", url.split("/contents/")[0])
+        self.assertIn("%2E%2E", url)
+
+    def test_organization_and_username_are_encoded(self) -> None:
+        client = MagicMock()
+        client.request.return_value = _response([])
+        service = self._service(client)
+
+        service.list_organization_repositories(_TRAVERSAL)
+        self.assertTrue(client.request.call_args.args[1].startswith("https://api.github.com/orgs/"))
+
+        service.list_user_repositories(_TRAVERSAL)
+        self.assertTrue(
+            client.request.call_args.args[1].startswith("https://api.github.com/users/")
+        )
+
+
+class SentryPathSegmentTests(unittest.TestCase):
+    def test_a_bare_dot_dot_slug_no_longer_survives_encoding(self) -> None:
+        self.assertEqual(SentryService._path_segment(".."), "%2E%2E")
+        self.assertEqual(SentryService._path_segment("my-org"), "my-org")
+        self.assertEqual(SentryService._path_segment("a/b"), "a%2Fb")
+
+
+class GristPathSegmentTests(unittest.TestCase):
+    def _run(self, doc_id: str, table_id: str) -> str:
+        executor = MagicMock()
+        executor.evaluate_message_template.side_effect = lambda value, *_args, **_kw: value
+        client = MagicMock()
+        client.get.return_value = _response({"records": []})
+
+        node_data = {
+            "credentialId": "cred-1",
+            "gristOperation": "getRecords",
+            "gristDocId": doc_id,
+            "gristTableId": table_id,
+        }
+        ctx = NodeExecutionContext(
+            executor=executor,
+            node_id="n1",
+            inputs={},
+            allow_branch_skip=False,
+            start_time=0.0,
+            node={"id": "n1", "type": "grist", "data": node_data},
+            node_type="grist",
+            node_data=node_data,
+            node_label="grist",
+        )
+
+        with (
+            patch("app.db.session.SessionLocal", MagicMock()),
+            patch("app.services.grist_pool.get_grist_client", return_value=client),
+            patch(
+                "app.services.encryption.decrypt_config",
+                return_value={
+                    "api_key": "grist-key",
+                    "server_url": "https://grist.example.com",
+                },
+            ),
+        ):
+            grist_execute(ctx)
+
+        return client.get.call_args.args[0]
+
+    def test_document_and_table_ids_cannot_retarget_the_api(self) -> None:
+        path = self._run(_TRAVERSAL, "Table1")
+        self.assertTrue(path.startswith("/api/docs/"))
+        self.assertNotIn("/admin/secrets", path)
+
+        path = self._run("doc1", _TRAVERSAL)
+        self.assertTrue(path.startswith("/api/docs/doc1/tables/"))
+        self.assertNotIn("/admin/secrets", path)
+
+    def test_ordinary_ids_are_unchanged(self) -> None:
+        self.assertEqual(
+            self._run("abc123", "Table1"),
+            "/api/docs/abc123/tables/Table1/records",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_advisory_jira_attachment_origin.py
+++ b/backend/tests/test_advisory_jira_attachment_origin.py
@@ -1,0 +1,122 @@
+"""Regression tests for credential forwarding on Jira-supplied attachment URLs.
+
+Jira picks the ``content`` URL in an attachment response, so a workflow that
+downloads binary content follows a URL the API chose rather than one the
+operator configured. Without an origin policy an attacker who can attach a file
+to a readable issue points that URL at their own host and receives the
+credential's Basic auth header. The SSRF transport blocks private targets but
+says nothing about public ones, so credential forwarding is a separate control.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import httpx
+
+from app.services.jira_service import JiraService
+
+_BASE_URL = "https://example.atlassian.net"
+
+
+def _service(client: MagicMock, base_url: str = _BASE_URL) -> JiraService:
+    return JiraService(
+        {"email": "ada@example.com", "api_token": "jira-token", "base_url": base_url},
+        client=client,
+    )
+
+
+def _binary_response(url: str) -> httpx.Response:
+    return httpx.Response(200, content=b"payload", request=httpx.Request("GET", url))
+
+
+class JiraAttachmentOriginTests(unittest.TestCase):
+    def test_same_origin_content_url_is_downloaded_with_credentials(self) -> None:
+        client = MagicMock()
+        url = f"{_BASE_URL}/rest/api/3/attachment/content/10001"
+        client.request.return_value = _binary_response(url)
+
+        content = _service(client).download_attachment(url)
+
+        self.assertEqual(content, b"payload")
+        self.assertEqual(client.request.call_args.args[:2], ("GET", url))
+        self.assertEqual(client.request.call_args.kwargs["auth"], ("ada@example.com", "jira-token"))
+
+    def test_cross_origin_content_url_is_refused_before_any_request(self) -> None:
+        client = MagicMock()
+        service = _service(client)
+
+        with self.assertRaises(ValueError) as ctx:
+            service.download_attachment("https://attacker.example.com/steal")
+
+        self.assertIn("outside the credential base URL origin", str(ctx.exception))
+        client.request.assert_not_called()
+
+    def test_credentials_are_not_sent_to_a_host_prefixed_with_the_base_host(self) -> None:
+        client = MagicMock()
+        service = _service(client)
+
+        with self.assertRaises(ValueError):
+            service.download_attachment("https://example.atlassian.net.attacker.example/x")
+
+        client.request.assert_not_called()
+
+    def test_scheme_downgrade_and_port_change_are_both_cross_origin(self) -> None:
+        client = MagicMock()
+        service = _service(client)
+
+        for url in (
+            "http://example.atlassian.net/rest/api/3/attachment/content/1",
+            "https://example.atlassian.net:8443/rest/api/3/attachment/content/1",
+        ):
+            with self.subTest(url=url):
+                with self.assertRaises(ValueError):
+                    service.download_attachment(url)
+        client.request.assert_not_called()
+
+    def test_non_http_content_url_is_refused(self) -> None:
+        client = MagicMock()
+        service = _service(client)
+
+        with self.assertRaises(ValueError):
+            service.download_attachment("file:///etc/passwd")
+
+        client.request.assert_not_called()
+
+    def test_empty_content_url_is_refused(self) -> None:
+        client = MagicMock()
+        service = _service(client)
+
+        with self.assertRaises(ValueError) as ctx:
+            service.download_attachment("   ")
+
+        self.assertIn("empty", str(ctx.exception))
+        client.request.assert_not_called()
+
+    def test_relative_content_url_resolves_against_the_credential_base_url(self) -> None:
+        client = MagicMock()
+        resolved = f"{_BASE_URL}/secure/attachment/10001/report.pdf"
+        client.request.return_value = _binary_response(resolved)
+
+        content = _service(client).download_attachment("/secure/attachment/10001/report.pdf")
+
+        self.assertEqual(content, b"payload")
+        self.assertEqual(client.request.call_args.args[:2], ("GET", resolved))
+
+    def test_default_port_matches_an_explicit_default_port(self) -> None:
+        client = MagicMock()
+        url = "https://example.atlassian.net:443/rest/api/3/attachment/content/1"
+        client.request.return_value = _binary_response(url)
+
+        self.assertEqual(_service(client).download_attachment(url), b"payload")
+
+    def test_data_center_base_path_still_accepts_its_own_origin(self) -> None:
+        client = MagicMock()
+        base = "https://jira.internal.example:8080/jira"
+        url = f"{base}/secure/attachment/10001/report.pdf"
+        client.request.return_value = _binary_response(url)
+
+        self.assertEqual(_service(client, base).download_attachment(url), b"payload")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_credential_error_messages.py
+++ b/backend/tests/test_credential_error_messages.py
@@ -1,0 +1,117 @@
+"""Credential errors must say which of the two things actually went wrong.
+
+Slack, Discord, Telegram, and Send Email all read a missing or inaccessible
+credential into an empty config, then failed on the first absent field. The
+resulting "requires webhook_url" pointed the operator at the credential's
+contents when the real problem was that the node could not read the credential
+at all. Both cases still fail closed; only the message was wrong.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.services.node_execution.base import NodeExecutionContext
+from app.services.node_execution.nodes import (
+    discord_node,
+    send_email_node,
+    slack_node,
+    telegram_node,
+)
+
+_NODES = {
+    "slack": (slack_node, {"credentialId": "cred-1", "message": "hi"}),
+    "discord": (discord_node, {"credentialId": "cred-1", "message": "hi"}),
+    "telegram": (telegram_node, {"credentialId": "cred-1", "message": "hi", "chatId": "42"}),
+    "sendEmail": (
+        send_email_node,
+        {"credentialId": "cred-1", "to": "ada@example.com", "subject": "s", "emailBody": "b"},
+    ),
+}
+
+
+def _context(node_type: str, node_data: dict, credential: object | None) -> NodeExecutionContext:
+    executor = MagicMock()
+    executor.evaluate_message_template.side_effect = lambda template, *_a, **_kw: template
+    executor.resolve_expression.side_effect = lambda template, *_a, **_kw: template
+    executor._get_accessible_credential.return_value = credential
+    return NodeExecutionContext(
+        executor=executor,
+        node_id="n1",
+        inputs={},
+        allow_branch_skip=False,
+        start_time=0.0,
+        node={"id": "n1", "type": node_type, "data": node_data},
+        node_type=node_type,
+        node_data=node_data,
+        node_label=node_type,
+    )
+
+
+def _run(node_type: str, credential: object | None, config: dict) -> str:
+    module, node_data = _NODES[node_type]
+    ctx = _context(node_type, node_data, credential)
+    db = MagicMock()
+    db.__enter__ = MagicMock(return_value=db)
+    db.__exit__ = MagicMock(return_value=False)
+    with (
+        patch("app.db.session.SessionLocal", return_value=db),
+        patch("app.services.encryption.decrypt_config", return_value=config),
+    ):
+        with unittest.TestCase().assertRaises(ValueError) as ctx_manager:
+            module.execute(ctx)
+    return str(ctx_manager.exception)
+
+
+class UnreadableCredentialMessageTests(unittest.TestCase):
+    def test_an_unreadable_credential_is_not_reported_as_a_missing_field(self) -> None:
+        for node_type in _NODES:
+            with self.subTest(node=node_type):
+                message = _run(node_type, None, {})
+                self.assertIn("not found or not accessible", message)
+                self.assertNotIn("requires", message)
+
+    def test_each_node_names_its_own_credential_in_the_message(self) -> None:
+        expected = {
+            "slack": "Slack credential",
+            "discord": "Discord credential",
+            "telegram": "Telegram credential",
+            "sendEmail": "SMTP credential",
+        }
+        for node_type, prefix in expected.items():
+            with self.subTest(node=node_type):
+                self.assertTrue(_run(node_type, None, {}).startswith(prefix))
+
+
+class MissingFieldMessageTests(unittest.TestCase):
+    """A readable credential that is genuinely incomplete still names the field."""
+
+    def test_readable_credential_missing_its_field_still_says_requires(self) -> None:
+        expected = {
+            "slack": "Slack credential requires webhook_url",
+            "discord": "Discord credential requires webhook_url",
+            "telegram": "Telegram credential requires bot_token",
+        }
+        for node_type, message in expected.items():
+            with self.subTest(node=node_type):
+                self.assertEqual(_run(node_type, MagicMock(), {}), message)
+
+    def test_send_email_names_every_missing_smtp_field(self) -> None:
+        self.assertEqual(
+            _run("sendEmail", MagicMock(), {}),
+            "SMTP credential requires smtp_server, smtp_email, smtp_password",
+        )
+
+    def test_send_email_names_only_the_field_that_is_missing(self) -> None:
+        config = {
+            "smtp_server": "smtp.example.com",
+            "smtp_email": "bot@example.com",
+            "smtp_password": "",
+        }
+        self.assertEqual(
+            _run("sendEmail", MagicMock(), config),
+            "SMTP credential requires smtp_password",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix: keep Jira credentials on the credential's own origin

The `content` URL on a Jira attachment is chosen by the response body, not by
the operator, and `download_attachment` followed it with the credential's Basic
auth header attached. An attacker who can attach a file to an issue the
workflow reads could point that URL at a host they control and collect the Jira
email and API token.

The SSRF transport added in the previous change blocks private targets, but a
public attacker-controlled host is not an SSRF target, so credential forwarding
needs its own control. Attachment URLs are now resolved against the credential
base URL and refused unless scheme, host, and port all match it.