### PR TITLE
fix: align delete endpoints with shared-user access model

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -10,7 +10,9 @@ router = APIRouter()
 
 
 @router.get("/reserved-variable-names")
-async def get_reserved_variable_names() -> list[str]:
+async def get_reserved_variable_names(
+    _current_user: User = Depends(get_current_user),
+) -> list[str]:
     return RESERVED_VARIABLE_NAMES
 
 

--- a/backend/app/api/global_variables.py
+++ b/backend/app/api/global_variables.py
@@ -386,13 +386,7 @@ async def delete_global_variable(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    result = await db.execute(
-        select(GlobalVariable).where(
-            GlobalVariable.id == variable_id,
-            GlobalVariable.owner_id == current_user.id,
-        )
-    )
-    variable = result.scalar_one_or_none()
+    variable = await _get_editable_variable(db, variable_id, current_user.id)
     if variable is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -415,13 +409,11 @@ async def bulk_delete_global_variables(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    result = await db.execute(
-        select(GlobalVariable).where(
-            GlobalVariable.id.in_(body.ids),
-            GlobalVariable.owner_id == current_user.id,
-        )
-    )
-    variables = result.scalars().all()
+    variables = []
+    for variable_id in body.ids:
+        variable = await _get_editable_variable(db, variable_id, current_user.id)
+        if variable is not None:
+            variables.append(variable)
     audit(
         action="variable.bulk_delete",
         actor=current_user,

--- a/backend/app/api/vector_stores.py
+++ b/backend/app/api/vector_stores.py
@@ -1046,19 +1046,7 @@ async def delete_items_by_source(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    result = await db.execute(
-        select(VectorStore).where(
-            VectorStore.id == vector_store_id,
-            VectorStore.owner_id == current_user.id,
-        )
-    )
-    store = result.scalar_one_or_none()
-
-    if store is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Vector store not found",
-        )
+    store = await _get_accessible_store(vector_store_id, current_user.id, db)
 
     cred_result = await db.execute(select(Credential).where(Credential.id == store.credential_id))
     credential = cred_result.scalar_one_or_none()
@@ -1091,19 +1079,7 @@ async def delete_item(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> None:
-    result = await db.execute(
-        select(VectorStore).where(
-            VectorStore.id == vector_store_id,
-            VectorStore.owner_id == current_user.id,
-        )
-    )
-    store = result.scalar_one_or_none()
-
-    if store is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Vector store not found",
-        )
+    store = await _get_accessible_store(vector_store_id, current_user.id, db)
 
     cred_result = await db.execute(select(Credential).where(Credential.id == store.credential_id))
     credential = cred_result.scalar_one_or_none()


### PR DESCRIPTION
## Summary

Three authorization inconsistencies where delete endpoints used owner-only checks while related read/write endpoints used share-aware access helpers.

**Global variables:**
- `DELETE /{id}` and `POST /bulk-delete` now use `_get_editable_variable()` (owner + user-share + team-share), matching `PATCH /{id}`

**Vector stores:**
- `DELETE /{id}/items/by-source` and `DELETE /{id}/items/{point_id}` now use `_get_accessible_store()` (owner + user-share + team-share), matching `POST /{id}/upload`

**Config:**
- `GET /reserved-variable-names` now requires authentication via `get_current_user`

## Motivation

Shared users could edit variables but not delete them. Shared users could upload vector store items but not delete them. The `/reserved-variable-names` endpoint exposed platform constants to unauthenticated callers.
