### PR TITLE
fix: handle unknown workflow node types

### DIFF
--- a/frontend/src/components/Canvas/MobileWorkflowTree.vue
+++ b/frontend/src/components/Canvas/MobileWorkflowTree.vue
@@ -11,7 +11,7 @@ import MobileWorkflowTreeHeader from "@/components/Canvas/MobileWorkflowTreeHead
 import MobileWorkflowTreeMore from "@/components/Canvas/MobileWorkflowTreeMore.vue";
 import MobileWorkflowTreeNodesTab from "@/components/Canvas/MobileWorkflowTreeNodesTab.vue";
 import DebugPanel from "@/components/Panels/DebugPanel.vue";
-import { NODE_DEFINITIONS } from "@/types/node";
+import { resolveNodeDisplay } from "@/lib/nodeDisplay";
 import { useThemeStore } from "@/stores/theme";
 import { useWorkflowStore } from "@/stores/workflow";
 
@@ -53,6 +53,13 @@ const statusText = computed(() => status.value.replace(/_/g, " "));
 const duration = computed(() => formatDuration(execution.value?.execution_time_ms));
 const isDashboardWidget = computed(() => workflowStore.currentWorkflow?.kind === "dashboard_widget");
 const isStandardWorkflow = computed(() => !isDashboardWidget.value);
+const selectedNodeLabel = computed(() => {
+  if (!selectedNode.value) return null;
+  return resolveNodeDisplay(
+    selectedNode.value.type,
+    selectedNode.value.data as Record<string, unknown>,
+  ).label;
+});
 
 function formatDuration(value: number | undefined): string {
   if (!value) return "—";
@@ -135,7 +142,7 @@ function openAiAssistant(): void {
             Node properties
           </p>
           <p class="mt-2 text-xs text-muted-foreground">
-            {{ selectedNode ? `${selectedNode.data.label || NODE_DEFINITIONS[selectedNode.type].label} is selected.` : "Select a node from the workflow tree." }}
+            {{ selectedNode ? `${selectedNodeLabel} is selected.` : "Select a node from the workflow tree." }}
           </p>
         </section>
       </slot>

--- a/frontend/src/components/Canvas/MobileWorkflowTreeConnectionSheet.vue
+++ b/frontend/src/components/Canvas/MobileWorkflowTreeConnectionSheet.vue
@@ -2,9 +2,10 @@
 import { computed, ref, watch } from "vue";
 import { Check, GitBranch, Search, X } from "lucide-vue-next";
 
-import { resolveNodeDisplay, type NodeDisplayMetadata } from "@/lib/nodeDisplay";
-import type { WorkflowNode } from "@/types/workflow";
 import type { MobileWorkflowConnectionMode } from "@/components/Canvas/mobileWorkflowTreeConnections";
+import type { NodeDisplayMetadata } from "@/lib/nodeDisplay";
+import type { WorkflowNode } from "@/types/workflow";
+import { resolveNodeDisplay } from "@/lib/nodeDisplay";
 
 interface Props {
   open: boolean;
@@ -170,7 +171,7 @@ function submit(): void {
               </span>
               <span class="min-w-0 flex-1">
                 <span class="block truncate text-xs font-semibold">{{ nodeLabel(candidate) }}</span>
-                <span class="block truncate text-[10px] text-muted-foreground">{{ nodeDisplay(candidate).summary }}</span>
+                <span class="block truncate text-[10px] text-muted-foreground">{{ nodeDisplay(candidate).typeLabel }}</span>
               </span>
               <Check
                 v-if="anchorId === candidate.id"

--- a/frontend/src/components/Canvas/MobileWorkflowTreeConnectionSheet.vue
+++ b/frontend/src/components/Canvas/MobileWorkflowTreeConnectionSheet.vue
@@ -2,8 +2,7 @@
 import { computed, ref, watch } from "vue";
 import { Check, GitBranch, Search, X } from "lucide-vue-next";
 
-import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
-import { NODE_DEFINITIONS } from "@/types/node";
+import { resolveNodeDisplay, type NodeDisplayMetadata } from "@/lib/nodeDisplay";
 import type { WorkflowNode } from "@/types/workflow";
 import type { MobileWorkflowConnectionMode } from "@/components/Canvas/mobileWorkflowTreeConnections";
 
@@ -30,7 +29,7 @@ const candidates = computed(() => {
     .filter((node) => node.id !== props.node?.id)
     .filter((node) => mode.value === "before" || node.type !== "output" || node.data.allowDownstream === true)
     .filter((node) => {
-      const label = String(node.data.label || NODE_DEFINITIONS[node.type].label).toLowerCase();
+      const label = nodeDisplay(node).label.toLowerCase();
       return !normalizedQuery || label.includes(normalizedQuery);
     })
     .sort((left, right) => left.position.y - right.position.y || left.position.x - right.position.x);
@@ -69,7 +68,11 @@ function canConnectAfter(node: WorkflowNode): boolean {
 }
 
 function nodeLabel(node: WorkflowNode): string {
-  return String(node.data.label || NODE_DEFINITIONS[node.type].label);
+  return nodeDisplay(node).label;
+}
+
+function nodeDisplay(node: WorkflowNode): NodeDisplayMetadata {
+  return resolveNodeDisplay(node.type, node.data as unknown as Record<string, unknown>);
 }
 
 function submit(): void {
@@ -158,16 +161,16 @@ function submit(): void {
             >
               <span
                 class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted"
-                :class="nodeIconColorClass[candidate.type]"
+                :class="nodeDisplay(candidate).iconColorClass"
               >
                 <component
-                  :is="nodeIcons[candidate.type]"
-                  :class="isTileFillingIcon(candidate.type) ? 'h-full w-full' : 'h-3.5 w-3.5'"
+                  :is="nodeDisplay(candidate).icon"
+                  :class="nodeDisplay(candidate).tileFilling ? 'h-full w-full' : 'h-3.5 w-3.5'"
                 />
               </span>
               <span class="min-w-0 flex-1">
                 <span class="block truncate text-xs font-semibold">{{ nodeLabel(candidate) }}</span>
-                <span class="block truncate text-[10px] text-muted-foreground">{{ NODE_DEFINITIONS[candidate.type].label }}</span>
+                <span class="block truncate text-[10px] text-muted-foreground">{{ nodeDisplay(candidate).summary }}</span>
               </span>
               <Check
                 v-if="anchorId === candidate.id"

--- a/frontend/src/components/Canvas/MobileWorkflowTreeNode.vue
+++ b/frontend/src/components/Canvas/MobileWorkflowTreeNode.vue
@@ -3,8 +3,7 @@ import { computed } from "vue";
 import { GitBranch } from "lucide-vue-next";
 
 import type { MobileWorkflowTreeAccent, MobileWorkflowTreeEntry } from "@/components/Canvas/mobileWorkflowTree";
-import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
-import { NODE_DEFINITIONS } from "@/types/node";
+import { resolveNodeDisplay, type NodeDisplayMetadata } from "@/lib/nodeDisplay";
 import type { NodeResult, WorkflowNode } from "@/types/workflow";
 import { useWorkflowStore } from "@/stores/workflow";
 
@@ -27,7 +26,7 @@ function formatDuration(value: number | undefined): string {
 }
 
 function nodeLabel(node: WorkflowNode): string {
-  return String(node.data.label || NODE_DEFINITIONS[node.type].label);
+  return resolveNodeDisplay(node.type, node.data as unknown as Record<string, unknown>).label;
 }
 
 function nodeSummary(node: WorkflowNode): string {
@@ -36,7 +35,7 @@ function nodeSummary(node: WorkflowNode): string {
     const value = data[key];
     if (typeof value === "string" && value.trim()) return value.trim();
   }
-  return NODE_DEFINITIONS[node.type].description;
+  return resolveNodeDisplay(node.type, data).summary;
 }
 
 function accentClass(accent: MobileWorkflowTreeAccent): string {
@@ -66,6 +65,10 @@ function selectNode(): void {
   }
   emit("idle-node");
 }
+
+function nodeDisplay(node: WorkflowNode): NodeDisplayMetadata {
+  return resolveNodeDisplay(node.type, node.data as unknown as Record<string, unknown>);
+}
 </script>
 
 <template>
@@ -88,11 +91,11 @@ function selectNode(): void {
         <div class="flex min-w-0 items-center gap-2">
           <span
             class="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-emerald-500/10"
-            :class="nodeIconColorClass[entry.node.type]"
+            :class="nodeDisplay(entry.node).iconColorClass"
           >
             <component
-              :is="nodeIcons[entry.node.type]"
-              :class="isTileFillingIcon(entry.node.type) ? 'h-full w-full' : 'h-3 w-3'"
+              :is="nodeDisplay(entry.node).icon"
+              :class="nodeDisplay(entry.node).tileFilling ? 'h-full w-full' : 'h-3 w-3'"
             />
           </span>
           <span class="min-w-0 text-left">

--- a/frontend/src/components/Canvas/MobileWorkflowTreeNodesTab.vue
+++ b/frontend/src/components/Canvas/MobileWorkflowTreeNodesTab.vue
@@ -11,6 +11,7 @@ import {
 } from "@/components/Canvas/mobileWorkflowTreeConnections";
 import { TOOL_INPUT_HANDLE, isNoRegularInputNodeType } from "@/lib/canvasConnectionRules";
 import { generateId } from "@/lib/utils";
+import { resolveNodeDisplay } from "@/lib/nodeDisplay";
 import { NODE_DEFINITIONS } from "@/types/node";
 import type { NodeType, WorkflowNode } from "@/types/workflow";
 import { useWorkflowStore } from "@/stores/workflow";
@@ -26,7 +27,10 @@ const treeEntries = computed(() => buildMobileWorkflowTree(workflowStore.nodes, 
 const selectedNode = computed(() => workflowStore.selectedNode);
 const selectedLabel = computed(() => {
   if (!selectedNode.value) return null;
-  return String(selectedNode.value.data.label || NODE_DEFINITIONS[selectedNode.value.type].label);
+  return resolveNodeDisplay(
+    selectedNode.value.type,
+    selectedNode.value.data as Record<string, unknown>,
+  ).label;
 });
 const canConnectSelectedNode = computed(
   () => selectedNode.value !== null && !isNoRegularInputNodeType(selectedNode.value.type),
@@ -100,7 +104,9 @@ function connectSelectedNode(payload: { anchorId: string; mode: MobileWorkflowCo
 
 function removeSelectedNode(): void {
   const node = workflowStore.selectedNode;
-  if (!node || !window.confirm(`Remove ${node.data.label || NODE_DEFINITIONS[node.type].label}?`)) return;
+  if (!node) return;
+  const label = resolveNodeDisplay(node.type, node.data as Record<string, unknown>).label;
+  if (!window.confirm(`Remove ${label}?`)) return;
   workflowStore.removeNode(node.id);
 }
 </script>

--- a/frontend/src/components/Panels/propertiesPanel/MobileNodeExecutionDetail.vue
+++ b/frontend/src/components/Panels/propertiesPanel/MobileNodeExecutionDetail.vue
@@ -2,10 +2,9 @@
 import { computed, nextTick, ref, watch } from "vue";
 import { AlertCircle, Check, CheckCircle2, ChevronLeft, ChevronRight, Copy, Settings2, X } from "lucide-vue-next";
 
-import JsonTree from "@/components/ui/JsonTree.vue";
-import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
-import { NODE_DEFINITIONS } from "@/types/node";
 import type { NodeResult, WorkflowNode } from "@/types/workflow";
+import JsonTree from "@/components/ui/JsonTree.vue";
+import { resolveNodeDisplay } from "@/lib/nodeDisplay";
 
 interface Props {
   open: boolean;
@@ -31,15 +30,26 @@ const activeTab = ref<DetailTab>("output");
 const copied = ref(false);
 const detailRef = ref<HTMLElement | null>(null);
 
-const nodeIcon = computed(() => (props.node ? nodeIcons[props.node.type] : AlertCircle));
+const nodeDisplay = computed(() => {
+  if (props.node) {
+    return resolveNodeDisplay(props.node.type, props.node.data as unknown as Record<string, unknown>);
+  }
+  if (props.result?.node_type) {
+    return resolveNodeDisplay(props.result.node_type);
+  }
+  return null;
+});
+
+const nodeIcon = computed(() => nodeDisplay.value?.icon ?? AlertCircle);
 const nodeIconClass = computed(() =>
-  props.node ? nodeIconColorClass[props.node.type] : "text-muted-foreground",
+  nodeDisplay.value?.iconColorClass ?? "text-muted-foreground",
 );
+const isTileFilling = computed(() => nodeDisplay.value?.tileFilling ?? false);
 const nodeName = computed(
-  () => props.node?.data.label || props.result?.node_label || "Workflow node",
+  () => props.node?.data.label || props.result?.node_label || nodeDisplay.value?.label || "Workflow node",
 );
 const nodeType = computed(() => {
-  if (props.node) return NODE_DEFINITIONS[props.node.type].label;
+  if (nodeDisplay.value) return nodeDisplay.value.typeLabel;
   return props.result?.node_type || "Node";
 });
 const status = computed(() => props.result?.status || "pending");
@@ -198,7 +208,7 @@ watch(
                 >
                   <component
                     :is="nodeIcon"
-                    :class="isTileFillingIcon(node?.type ?? 'http') ? 'h-full w-full' : 'h-5 w-5'"
+                    :class="isTileFilling ? 'h-full w-full' : 'h-5 w-5'"
                   />
                 </div>
                 <div class="min-w-0">

--- a/frontend/src/lib/mobileSurfaces.test.ts
+++ b/frontend/src/lib/mobileSurfaces.test.ts
@@ -1,147 +1,256 @@
-/**
- * Source-level regression tests for the four mobile workflow editor components.
- *
- * These tests read each component's source file (following the same pattern as
- * NodePanel.test.ts and ExecutionSpanDetails.test.ts in this repository) and
- * assert that:
- *
- *   1. The component imports / calls resolveNodeDisplay() — the shared resolver
- *      that safely handles unknown runtime node types.
- *   2. The previously-unsafe direct NODE_DEFINITIONS[node.type].label /
- *      .description accesses are gone from the components that must not use them.
- *   3. The previously-unsafe direct nodeIcons[node.type] and
- *      nodeIconColorClass[node.type] accesses are gone from components where the
- *      resolver is now responsible for icon / color resolution.
- *
- * These tests intentionally do not mount Vue components or call resolveNodeDisplay()
- * themselves — that is covered by nodeDisplay.test.ts.  The purpose here is to
- * guard against regressions where a future edit re-introduces the unsafe accesses.
- */
+import { createSSRApp, h, type Component } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "vue/server-renderer";
 
-import { readFile } from "node:fs/promises";
+vi.mock("@/stores/theme", () => ({
+  useThemeStore: () => ({
+    isDark: false,
+    toggle: vi.fn(),
+    setTheme: vi.fn(),
+  }),
+}));
 
-import { describe, expect, it } from "vitest";
+import type { NodeType, WorkflowNode } from "@/types/workflow";
+import MobileNodeExecutionDetail from "@/components/Panels/propertiesPanel/MobileNodeExecutionDetail.vue";
+import MobileWorkflowTree from "@/components/Canvas/MobileWorkflowTree.vue";
+import MobileWorkflowTreeConnectionSheet from "@/components/Canvas/MobileWorkflowTreeConnectionSheet.vue";
+import MobileWorkflowTreeNode from "@/components/Canvas/MobileWorkflowTreeNode.vue";
+import MobileWorkflowTreeNodesTab from "@/components/Canvas/MobileWorkflowTreeNodesTab.vue";
+import { useWorkflowStore } from "@/stores/workflow";
 
-// Resolve each component path relative to this test file, matching the
-// pattern used by NodePanel.test.ts and ExecutionSpanDetails.test.ts.
-const componentUrl = (name: string): URL =>
-  new URL(`../components/Canvas/${name}`, import.meta.url);
+async function renderComponent(component: Component, props: Record<string, unknown> = {}): Promise<string> {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const app = createSSRApp({
+    render: () => h(component, props),
+  });
+  app.use(pinia);
+  const ssrContext: { teleports?: Record<string, string> } = {};
+  const html = await renderToString(app, ssrContext);
+  const teleports = ssrContext.teleports
+    ? Object.values(ssrContext.teleports).join("\n")
+    : "";
+  return `${html}\n${teleports}`;
+}
 
-describe("MobileWorkflowTreeNode.vue", () => {
-  it("imports resolveNodeDisplay from the shared resolver", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
-    expect(src).toMatch(
-      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
-    );
+describe("Mobile surface SSR rendering with unknown/stale node types", () => {
+  describe("mobile node tree", () => {
+    it("renders MobileWorkflowTreeNode with unknown node type safely", async () => {
+      const unknownNode: WorkflowNode = {
+        id: "node-unknown-1",
+        type: "legacyCustomAction" as NodeType,
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Custom Stale Action",
+          url: "https://example.com/api",
+        },
+      };
+
+      const html = await renderComponent(MobileWorkflowTreeNode, {
+        entry: {
+          node: unknownNode,
+          children: [],
+          depth: 0,
+          accent: "violet",
+          hasSuccessor: false,
+        },
+      });
+
+      expect(html).toContain("Custom Stale Action");
+      expect(html).toContain("https://example.com/api");
+    });
+
+    it("renders MobileWorkflowTreeNode with default humanized label when label is absent", async () => {
+      const unknownNode: WorkflowNode = {
+        id: "node-unknown-2",
+        type: "stalePluginNode" as NodeType,
+        position: { x: 0, y: 0 },
+        data: { label: "" },
+      };
+
+      const html = await renderComponent(MobileWorkflowTreeNode, {
+        entry: {
+          node: unknownNode,
+          children: [],
+          depth: 0,
+          accent: "emerald",
+          hasSuccessor: false,
+        },
+      });
+
+      expect(html).toContain("Stale Plugin Node");
+    });
+
+    it("renders MobileWorkflowTreeNodesTab containing selected unknown node without label safely", async () => {
+      const pinia = createPinia();
+      setActivePinia(pinia);
+      const store = useWorkflowStore();
+
+      const unknownNode: WorkflowNode = {
+        id: "node-unknown-tab",
+        type: "deprecatedCustomAction" as NodeType,
+        position: { x: 0, y: 0 },
+        data: { label: "" },
+      };
+
+      store.nodes = [unknownNode];
+      store.selectNode(unknownNode.id);
+
+      const app = createSSRApp({
+        render: () => h(MobileWorkflowTreeNodesTab),
+      });
+      app.use(pinia);
+
+      const ssrContext: { teleports?: Record<string, string> } = {};
+      const html = await renderToString(app, ssrContext);
+
+      expect(html).toContain("Deprecated Custom Action");
+    });
+
+    it("renders MobileWorkflowTree containing unknown node types and selections safely", async () => {
+      const pinia = createPinia();
+      setActivePinia(pinia);
+      const store = useWorkflowStore();
+
+      const unknownNode: WorkflowNode = {
+        id: "node-unknown-tree",
+        type: "deprecatedTrigger" as NodeType,
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Legacy Webhook Trigger",
+        },
+      };
+
+      store.nodes = [unknownNode];
+      store.selectNode(unknownNode.id);
+
+      const app = createSSRApp({
+        render: () => h(MobileWorkflowTree),
+      });
+      app.use(pinia);
+
+      const ssrContext: { teleports?: Record<string, string> } = {};
+      const html = await renderToString(app, ssrContext);
+
+      expect(html).toContain("Legacy Webhook Trigger");
+    });
   });
 
-  it("calls resolveNodeDisplay() for icon / color / label resolution", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
-    expect(src).toContain("resolveNodeDisplay(");
+  describe("connection sheet", () => {
+    it("renders connection sheet with known and unknown candidate node types without throwing", async () => {
+      const activeNode: WorkflowNode = {
+        id: "source-node",
+        type: "http",
+        position: { x: 0, y: 0 },
+        data: { label: "Source HTTP" },
+      };
+
+      const knownCandidate: WorkflowNode = {
+        id: "candidate-known",
+        type: "http",
+        position: { x: 0, y: 100 },
+        data: {
+          label: "My Webhook Step",
+          url: "https://api.example.com/hook",
+        },
+      };
+
+      const unknownCandidate: WorkflowNode = {
+        id: "candidate-unknown",
+        type: "staleCustomIntegration" as NodeType,
+        position: { x: 0, y: 200 },
+        data: {
+          label: "Archived Integration",
+          url: "https://archive.example.com",
+        },
+      };
+
+      const unlabelledCandidate: WorkflowNode = {
+        id: "candidate-unlabelled",
+        type: "deletedWorkerType" as NodeType,
+        position: { x: 0, y: 300 },
+        data: {
+          label: "   ",
+        },
+      };
+
+      const html = await renderComponent(MobileWorkflowTreeConnectionSheet, {
+        open: true,
+        node: activeNode,
+        nodes: [activeNode, knownCandidate, unknownCandidate, unlabelledCandidate],
+      });
+
+      // Verify connection sheet dialog renders
+      expect(html).toContain("Connect Source HTTP");
+
+      // Verify candidates render their labels
+      expect(html).toContain("My Webhook Step");
+      expect(html).toContain("Archived Integration");
+
+      // Verify candidate secondary lines display typeLabel, not summary URL
+      expect(html).toContain("HTTP");
+      expect(html).toContain("Stale Custom Integration");
+      expect(html).not.toContain("https://api.example.com/hook");
+
+      // Verify candidate with empty/whitespace label falls back to typeLabel
+      expect(html).toContain("Deleted Worker Type");
+    });
   });
 
-  it("does not directly access NODE_DEFINITIONS for node type lookups", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
-    // NODE_DEFINITIONS should not be imported at all — it is no longer needed
-    // in this component since resolveNodeDisplay() encapsulates the lookup.
-    expect(src).not.toMatch(
-      /import\s*\{[^}]*\bNODE_DEFINITIONS\b[^}]*\}\s*from\s*"@\/types\/node"/,
-    );
-  });
+  describe("mobile node execution detail", () => {
+    it("renders execution detail with unknown node type safely", async () => {
+      const unknownNode: WorkflowNode = {
+        id: "node-exec-unknown",
+        type: "deletedWorkerType" as NodeType,
+        position: { x: 0, y: 0 },
+        data: {
+          label: "Stale Worker Step",
+        },
+      };
 
-  it("does not directly index nodeIcons by node type", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
-    expect(src).not.toMatch(/\bnodeIcons\s*\[/);
-  });
+      const html = await renderComponent(MobileNodeExecutionDetail, {
+        open: true,
+        node: unknownNode,
+        result: {
+          node_id: "node-exec-unknown",
+          node_label: "Stale Worker Step",
+          node_type: "deletedWorkerType",
+          status: "success",
+          output: { count: 42 },
+          execution_time_ms: 120,
+          error: null,
+        },
+        output: { count: 42 },
+        workflowName: "Demo Workflow",
+      });
 
-  it("does not directly index nodeIconColorClass by node type", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
-    expect(src).not.toMatch(/\bnodeIconColorClass\s*\[/);
-  });
-});
+      expect(html).toContain("Stale Worker Step");
+      expect(html).toContain("Deleted Worker Type");
+      expect(html).toContain("node-exec-unknown");
+      expect(html).toContain("success");
+    });
 
-describe("MobileWorkflowTreeConnectionSheet.vue", () => {
-  it("imports resolveNodeDisplay from the shared resolver", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
-    expect(src).toMatch(
-      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
-    );
-  });
+    it("renders execution detail when node is null and only result has unknown node type", async () => {
+      const html = await renderComponent(MobileNodeExecutionDetail, {
+        open: true,
+        node: null,
+        result: {
+          node_id: "orphan-node-1",
+          node_label: "Orphan Execution",
+          node_type: "unregisteredCustomNode",
+          status: "error",
+          output: {},
+          execution_time_ms: 350,
+          error: "Execution failed",
+        },
+        output: {},
+        workflowName: "Demo Workflow",
+      });
 
-  it("calls resolveNodeDisplay() for candidate node display", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
-    expect(src).toContain("resolveNodeDisplay(");
-  });
-
-  it("does not directly access NODE_DEFINITIONS for node type lookups", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
-    expect(src).not.toMatch(
-      /import\s*\{[^}]*\bNODE_DEFINITIONS\b[^}]*\}\s*from\s*"@\/types\/node"/,
-    );
-  });
-
-  it("does not directly index nodeIcons by node type", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
-    expect(src).not.toMatch(/\bnodeIcons\s*\[/);
-  });
-
-  it("does not directly index nodeIconColorClass by node type", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
-    expect(src).not.toMatch(/\bnodeIconColorClass\s*\[/);
-  });
-
-  it("does not use NODE_DEFINITIONS to resolve candidate labels", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
-    // The old pattern was: NODE_DEFINITIONS[node.type].label or [candidate.type].label
-    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*label/);
-  });
-});
-
-describe("MobileWorkflowTreeNodesTab.vue", () => {
-  it("imports resolveNodeDisplay from the shared resolver", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNodesTab.vue"), "utf8");
-    expect(src).toMatch(
-      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
-    );
-  });
-
-  it("calls resolveNodeDisplay() for selectedLabel and remove confirmation", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNodesTab.vue"), "utf8");
-    expect(src).toContain("resolveNodeDisplay(");
-  });
-
-  it("does not use NODE_DEFINITIONS to look up a runtime node type label", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTreeNodesTab.vue"), "utf8");
-    // NODE_DEFINITIONS[nodeType].defaultData is a legitimate safe call (known NodeType
-    // from the editor palette) and is allowed to remain.  The unsafe pattern that was
-    // removed is indexing by a runtime .type property for label / description.
-    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*label/);
-    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*description/);
-  });
-});
-
-describe("MobileWorkflowTree.vue", () => {
-  it("imports resolveNodeDisplay from the shared resolver", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
-    expect(src).toMatch(
-      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
-    );
-  });
-
-  it("calls resolveNodeDisplay() for the selected node label", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
-    expect(src).toContain("resolveNodeDisplay(");
-  });
-
-  it("does not directly access NODE_DEFINITIONS for node type lookups", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
-    expect(src).not.toMatch(
-      /import\s*\{[^}]*\bNODE_DEFINITIONS\b[^}]*\}\s*from\s*"@\/types\/node"/,
-    );
-  });
-
-  it("does not use NODE_DEFINITIONS to resolve the selected node label", async () => {
-    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
-    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*label/);
+      expect(html).toContain("Orphan Execution");
+      expect(html).toContain("Unregistered Custom Node");
+      expect(html).toContain("orphan-node-1");
+    });
   });
 });

--- a/frontend/src/lib/mobileSurfaces.test.ts
+++ b/frontend/src/lib/mobileSurfaces.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Source-level regression tests for the four mobile workflow editor components.
+ *
+ * These tests read each component's source file (following the same pattern as
+ * NodePanel.test.ts and ExecutionSpanDetails.test.ts in this repository) and
+ * assert that:
+ *
+ *   1. The component imports / calls resolveNodeDisplay() — the shared resolver
+ *      that safely handles unknown runtime node types.
+ *   2. The previously-unsafe direct NODE_DEFINITIONS[node.type].label /
+ *      .description accesses are gone from the components that must not use them.
+ *   3. The previously-unsafe direct nodeIcons[node.type] and
+ *      nodeIconColorClass[node.type] accesses are gone from components where the
+ *      resolver is now responsible for icon / color resolution.
+ *
+ * These tests intentionally do not mount Vue components or call resolveNodeDisplay()
+ * themselves — that is covered by nodeDisplay.test.ts.  The purpose here is to
+ * guard against regressions where a future edit re-introduces the unsafe accesses.
+ */
+
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+// Resolve each component path relative to this test file, matching the
+// pattern used by NodePanel.test.ts and ExecutionSpanDetails.test.ts.
+const componentUrl = (name: string): URL =>
+  new URL(`../components/Canvas/${name}`, import.meta.url);
+
+describe("MobileWorkflowTreeNode.vue", () => {
+  it("imports resolveNodeDisplay from the shared resolver", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
+    );
+  });
+
+  it("calls resolveNodeDisplay() for icon / color / label resolution", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
+    expect(src).toContain("resolveNodeDisplay(");
+  });
+
+  it("does not directly access NODE_DEFINITIONS for node type lookups", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
+    // NODE_DEFINITIONS should not be imported at all — it is no longer needed
+    // in this component since resolveNodeDisplay() encapsulates the lookup.
+    expect(src).not.toMatch(
+      /import\s*\{[^}]*\bNODE_DEFINITIONS\b[^}]*\}\s*from\s*"@\/types\/node"/,
+    );
+  });
+
+  it("does not directly index nodeIcons by node type", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
+    expect(src).not.toMatch(/\bnodeIcons\s*\[/);
+  });
+
+  it("does not directly index nodeIconColorClass by node type", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNode.vue"), "utf8");
+    expect(src).not.toMatch(/\bnodeIconColorClass\s*\[/);
+  });
+});
+
+describe("MobileWorkflowTreeConnectionSheet.vue", () => {
+  it("imports resolveNodeDisplay from the shared resolver", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
+    );
+  });
+
+  it("calls resolveNodeDisplay() for candidate node display", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
+    expect(src).toContain("resolveNodeDisplay(");
+  });
+
+  it("does not directly access NODE_DEFINITIONS for node type lookups", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
+    expect(src).not.toMatch(
+      /import\s*\{[^}]*\bNODE_DEFINITIONS\b[^}]*\}\s*from\s*"@\/types\/node"/,
+    );
+  });
+
+  it("does not directly index nodeIcons by node type", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
+    expect(src).not.toMatch(/\bnodeIcons\s*\[/);
+  });
+
+  it("does not directly index nodeIconColorClass by node type", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
+    expect(src).not.toMatch(/\bnodeIconColorClass\s*\[/);
+  });
+
+  it("does not use NODE_DEFINITIONS to resolve candidate labels", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeConnectionSheet.vue"), "utf8");
+    // The old pattern was: NODE_DEFINITIONS[node.type].label or [candidate.type].label
+    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*label/);
+  });
+});
+
+describe("MobileWorkflowTreeNodesTab.vue", () => {
+  it("imports resolveNodeDisplay from the shared resolver", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNodesTab.vue"), "utf8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
+    );
+  });
+
+  it("calls resolveNodeDisplay() for selectedLabel and remove confirmation", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNodesTab.vue"), "utf8");
+    expect(src).toContain("resolveNodeDisplay(");
+  });
+
+  it("does not use NODE_DEFINITIONS to look up a runtime node type label", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTreeNodesTab.vue"), "utf8");
+    // NODE_DEFINITIONS[nodeType].defaultData is a legitimate safe call (known NodeType
+    // from the editor palette) and is allowed to remain.  The unsafe pattern that was
+    // removed is indexing by a runtime .type property for label / description.
+    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*label/);
+    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*description/);
+  });
+});
+
+describe("MobileWorkflowTree.vue", () => {
+  it("imports resolveNodeDisplay from the shared resolver", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*\bresolveNodeDisplay\b[^}]*\}\s*from\s*"@\/lib\/nodeDisplay"/,
+    );
+  });
+
+  it("calls resolveNodeDisplay() for the selected node label", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
+    expect(src).toContain("resolveNodeDisplay(");
+  });
+
+  it("does not directly access NODE_DEFINITIONS for node type lookups", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
+    expect(src).not.toMatch(
+      /import\s*\{[^}]*\bNODE_DEFINITIONS\b[^}]*\}\s*from\s*"@\/types\/node"/,
+    );
+  });
+
+  it("does not use NODE_DEFINITIONS to resolve the selected node label", async () => {
+    const src = await readFile(componentUrl("MobileWorkflowTree.vue"), "utf8");
+    expect(src).not.toMatch(/NODE_DEFINITIONS\s*\[\s*\w+\.type\s*\]\s*\.\s*label/);
+  });
+});

--- a/frontend/src/lib/nodeDisplay.test.ts
+++ b/frontend/src/lib/nodeDisplay.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { LayoutTemplate } from "lucide-vue-next";
+
+import { nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
+
+import { resolveNodeDisplay } from "./nodeDisplay";
+
+describe("resolveNodeDisplay", () => {
+  describe("known node types", () => {
+    it("preserves label and summary from node data", () => {
+      expect(resolveNodeDisplay("llm", { label: "Summarize", model: "gpt-4o" })).toMatchObject({
+        label: "Summarize",
+        summary: "gpt-4o",
+        icon: nodeIcons.llm,
+        iconColorClass: nodeIconColorClass.llm,
+        tileFilling: false,
+      });
+    });
+
+    it("uses definition label when node data label is empty", () => {
+      const display = resolveNodeDisplay("llm", { label: "", model: "gpt-4o" });
+      expect(display.label).toBe("LLM");
+      expect(display.summary).toBe("gpt-4o");
+    });
+
+    it("preserves tile-filling behavior for branded nodes", () => {
+      expect(resolveNodeDisplay("heym", {}).tileFilling).toBe(true);
+      expect(resolveNodeDisplay("llm", {}).tileFilling).toBe(false);
+    });
+
+    it("returns definition icon and color for known types", () => {
+      const display = resolveNodeDisplay("slack", {});
+      expect(display.icon).toBe(nodeIcons.slack);
+      expect(display.iconColorClass).toBe(nodeIconColorClass.slack);
+    });
+  });
+
+  describe("unknown node types", () => {
+    it("does not throw when node type is not in NODE_DEFINITIONS", () => {
+      expect(() => resolveNodeDisplay("unknownNodeType", {})).not.toThrow();
+    });
+
+    it("returns humanized type as label for unknown nodes", () => {
+      const display = resolveNodeDisplay("deletedNode", {});
+      expect(display.label).toBe("Deleted Node");
+    });
+
+    it("returns humanized type as summary when no specific data is available", () => {
+      const display = resolveNodeDisplay("legacyCustomNode", {});
+      expect(display.summary).toBe("Unsupported node type: Legacy Custom Node");
+    });
+
+    it("preserves custom label for unknown node types", () => {
+      const display = resolveNodeDisplay("unknownType", { label: "My custom node" });
+      expect(display.label).toBe("My custom node");
+    });
+
+    it("extracts operation data for unknown integration-like types", () => {
+      const display = resolveNodeDisplay("legacyIntegration", { legacyOperation: "archive" });
+      expect(display.summary).toBe("archive");
+    });
+
+    it("uses LayoutTemplate icon for unknown node types", () => {
+      const display = resolveNodeDisplay("unknownType", {});
+      expect(display.icon).toBe(LayoutTemplate);
+    });
+
+    it("uses muted foreground color for unknown node types", () => {
+      const display = resolveNodeDisplay("unknownType", {});
+      expect(display.iconColorClass).toBe("text-muted-foreground");
+    });
+
+    it("disables tile-filling for unknown node types", () => {
+      const display = resolveNodeDisplay("unknownBrandNode", {});
+      expect(display.tileFilling).toBe(false);
+    });
+
+    it("preserves stale node label and metadata", () => {
+      expect(resolveNodeDisplay("legacyNode", { label: "Legacy step", url: "https://example.com" })).toMatchObject({
+        label: "Legacy step",
+        summary: "https://example.com",
+        icon: LayoutTemplate,
+        iconColorClass: "text-muted-foreground",
+        tileFilling: false,
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty label gracefully", () => {
+      const display = resolveNodeDisplay("unknownType", { label: "" });
+      expect(display.label).toBe("Unknown Type");
+    });
+
+    it("handles whitespace-only label gracefully", () => {
+      const display = resolveNodeDisplay("unknownType", { label: "   " });
+      expect(display.label).toBe("Unknown Type");
+    });
+
+    it("ignores non-string data when resolving summary", () => {
+      const display = resolveNodeDisplay("unknownType", { model: 123, url: null });
+      expect(display.summary).toContain("Unsupported node type");
+    });
+  });
+});

--- a/frontend/src/lib/nodeDisplay.test.ts
+++ b/frontend/src/lib/nodeDisplay.test.ts
@@ -11,6 +11,7 @@ describe("resolveNodeDisplay", () => {
     it("preserves label and summary from node data", () => {
       expect(resolveNodeDisplay("llm", { label: "Summarize", model: "gpt-4o" })).toMatchObject({
         label: "Summarize",
+        typeLabel: "LLM",
         summary: "gpt-4o",
         icon: nodeIcons.llm,
         iconColorClass: nodeIconColorClass.llm,
@@ -21,6 +22,7 @@ describe("resolveNodeDisplay", () => {
     it("uses definition label when node data label is empty", () => {
       const display = resolveNodeDisplay("llm", { label: "", model: "gpt-4o" });
       expect(display.label).toBe("LLM");
+      expect(display.typeLabel).toBe("LLM");
       expect(display.summary).toBe("gpt-4o");
     });
 
@@ -33,6 +35,7 @@ describe("resolveNodeDisplay", () => {
       const display = resolveNodeDisplay("slack", {});
       expect(display.icon).toBe(nodeIcons.slack);
       expect(display.iconColorClass).toBe(nodeIconColorClass.slack);
+      expect(display.typeLabel).toBe("Slack");
     });
   });
 
@@ -41,9 +44,10 @@ describe("resolveNodeDisplay", () => {
       expect(() => resolveNodeDisplay("unknownNodeType", {})).not.toThrow();
     });
 
-    it("returns humanized type as label for unknown nodes", () => {
+    it("returns humanized type as label and typeLabel for unknown nodes", () => {
       const display = resolveNodeDisplay("deletedNode", {});
       expect(display.label).toBe("Deleted Node");
+      expect(display.typeLabel).toBe("Deleted Node");
     });
 
     it("returns humanized type as summary when no specific data is available", () => {
@@ -51,9 +55,10 @@ describe("resolveNodeDisplay", () => {
       expect(display.summary).toBe("Unsupported node type: Legacy Custom Node");
     });
 
-    it("preserves custom label for unknown node types", () => {
+    it("preserves custom label for unknown node types while keeping humanized typeLabel", () => {
       const display = resolveNodeDisplay("unknownType", { label: "My custom node" });
       expect(display.label).toBe("My custom node");
+      expect(display.typeLabel).toBe("Unknown Type");
     });
 
     it("extracts operation data for unknown integration-like types", () => {

--- a/frontend/src/lib/nodeDisplay.ts
+++ b/frontend/src/lib/nodeDisplay.ts
@@ -1,0 +1,66 @@
+import { LayoutTemplate } from "lucide-vue-next";
+import type { Component } from "vue";
+
+import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
+import { describeNode, humanizeNodeType } from "@/lib/workflowPreview";
+import { NODE_DEFINITIONS } from "@/types/node";
+import type { NodeData, NodeType, WorkflowNode } from "@/types/workflow";
+
+const SUMMARY_KEYS = ["url", "path", "operation", "model", "prompt", "message", "code"];
+
+export interface NodeDisplayMetadata {
+  label: string;
+  summary: string;
+  icon: Component;
+  iconColorClass: string;
+  tileFilling: boolean;
+}
+
+function knownNodeType(nodeType: string): NodeType | null {
+  return Object.prototype.hasOwnProperty.call(NODE_DEFINITIONS, nodeType)
+    ? (nodeType as NodeType)
+    : null;
+}
+
+function nodeSpecificSummary(data: Record<string, unknown>): string | null {
+  for (const key of SUMMARY_KEYS) {
+    const value = data[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function unknownNodeSummary(nodeType: string, data: Record<string, unknown>): string {
+  const humanizedType = humanizeNodeType(nodeType) || "Unknown node";
+  const described = describeNode({
+    id: "unknown-node",
+    type: nodeType as NodeType,
+    position: { x: 0, y: 0 },
+    data: data as unknown as NodeData,
+  } satisfies WorkflowNode);
+  return described !== humanizedType
+    ? described
+    : `Unsupported node type: ${humanizedType}`;
+}
+
+export function resolveNodeDisplay(
+  nodeType: string,
+  data: Record<string, unknown> = {},
+): NodeDisplayMetadata {
+  const knownType = knownNodeType(nodeType);
+  const definition = knownType ? NODE_DEFINITIONS[knownType] : undefined;
+  const label = typeof data.label === "string" && data.label.trim()
+    ? data.label.trim()
+    : definition?.label || humanizeNodeType(nodeType) || "Unknown node";
+  const summary = nodeSpecificSummary(data)
+    || definition?.description
+    || unknownNodeSummary(nodeType, data);
+
+  return {
+    label,
+    summary,
+    icon: knownType ? nodeIcons[knownType] : LayoutTemplate,
+    iconColorClass: knownType ? nodeIconColorClass[knownType] : "text-muted-foreground",
+    tileFilling: knownType ? isTileFillingIcon(knownType) : false,
+  };
+}

--- a/frontend/src/lib/nodeDisplay.ts
+++ b/frontend/src/lib/nodeDisplay.ts
@@ -1,15 +1,16 @@
-import { LayoutTemplate } from "lucide-vue-next";
 import type { Component } from "vue";
+import { LayoutTemplate } from "lucide-vue-next";
 
-import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
-import { describeNode, humanizeNodeType } from "@/lib/workflowPreview";
 import { NODE_DEFINITIONS } from "@/types/node";
 import type { NodeData, NodeType, WorkflowNode } from "@/types/workflow";
+import { isTileFillingIcon, nodeIconColorClass, nodeIcons } from "@/lib/nodeIcons";
+import { describeNode, humanizeNodeType } from "@/lib/workflowPreview";
 
 const SUMMARY_KEYS = ["url", "path", "operation", "model", "prompt", "message", "code"];
 
 export interface NodeDisplayMetadata {
   label: string;
+  typeLabel: string;
   summary: string;
   icon: Component;
   iconColorClass: string;
@@ -49,15 +50,17 @@ export function resolveNodeDisplay(
 ): NodeDisplayMetadata {
   const knownType = knownNodeType(nodeType);
   const definition = knownType ? NODE_DEFINITIONS[knownType] : undefined;
+  const typeLabel = definition?.label || humanizeNodeType(nodeType) || "Unknown node";
   const label = typeof data.label === "string" && data.label.trim()
     ? data.label.trim()
-    : definition?.label || humanizeNodeType(nodeType) || "Unknown node";
+    : typeLabel;
   const summary = nodeSpecificSummary(data)
     || definition?.description
     || unknownNodeSummary(nodeType, data);
 
   return {
     label,
+    typeLabel,
     summary,
     icon: knownType ? nodeIcons[knownType] : LayoutTemplate,
     iconColorClass: knownType ? nodeIconColorClass[knownType] : "text-muted-foreground",

--- a/frontend/src/lib/workflowEdges.test.ts
+++ b/frontend/src/lib/workflowEdges.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowEdge, WorkflowNode } from "@/types/workflow";
+
+import { resolveRenderedSourceHandle } from "./workflowEdges";
+
+describe("workflowEdges", () => {
+  describe("resolveRenderedSourceHandle with unknown source node types", () => {
+    it("does not throw when source node type is unknown and no sourceHandle is provided", () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "source-unknown",
+          type: "unknownNodeType" as never,
+          position: { x: 0, y: 0 },
+          data: { label: "Unknown source" },
+        },
+        {
+          id: "target",
+          type: "llm",
+          position: { x: 100, y: 0 },
+          data: { label: "LLM node" },
+        },
+      ];
+
+      const edge: WorkflowEdge = {
+        id: "edge-1",
+        source: "source-unknown",
+        target: "target",
+      };
+
+      // Should not throw. Unknown node types are assumed to have outputs, so the
+      // function resolves the primary output handle "output" rather than undefined.
+      const result = resolveRenderedSourceHandle(edge, nodes);
+      expect(result).toBe("output");
+    });
+
+    it("returns undefined when source node is not found", () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "target",
+          type: "llm",
+          position: { x: 100, y: 0 },
+          data: { label: "LLM node" },
+        },
+      ];
+
+      const edge: WorkflowEdge = {
+        id: "edge-1",
+        source: "missing-source",
+        target: "target",
+      };
+
+      const result = resolveRenderedSourceHandle(edge, nodes);
+      expect(result).toBeUndefined();
+    });
+
+    it("preserves existing behavior for known source node types", () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "source-llm",
+          type: "llm",
+          position: { x: 0, y: 0 },
+          data: { label: "LLM node" },
+        },
+        {
+          id: "target",
+          type: "llm",
+          position: { x: 100, y: 0 },
+          data: { label: "Another LLM node" },
+        },
+      ];
+
+      const edge: WorkflowEdge = {
+        id: "edge-1",
+        source: "source-llm",
+        target: "target",
+      };
+
+      // LLM has a primary output handle, so the function resolves to "output".
+      const result = resolveRenderedSourceHandle(edge, nodes);
+      expect(result).toBe("output");
+    });
+
+    it("uses sourceHandle when explicitly provided, even if source node type is unknown", () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "source-unknown",
+          type: "unknownNodeType" as never,
+          position: { x: 0, y: 0 },
+          data: { label: "Unknown source" },
+        },
+        {
+          id: "target",
+          type: "llm",
+          position: { x: 100, y: 0 },
+          data: { label: "LLM node" },
+        },
+      ];
+
+      const edge: WorkflowEdge = {
+        id: "edge-1",
+        source: "source-unknown",
+        target: "target",
+        sourceHandle: "custom-output",
+      };
+
+      const result = resolveRenderedSourceHandle(edge, nodes);
+      expect(result).toBe("custom-output");
+    });
+
+    it("returns 'tool-output' for tool-input edges regardless of source node type", () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "source-unknown",
+          type: "unknownNodeType" as never,
+          position: { x: 0, y: 0 },
+          data: { label: "Unknown source" },
+        },
+        {
+          id: "target",
+          type: "agent",
+          position: { x: 100, y: 0 },
+          data: { label: "Agent node" },
+        },
+      ];
+
+      const edge: WorkflowEdge = {
+        id: "edge-1",
+        source: "source-unknown",
+        target: "target",
+        targetHandle: "tool-input",
+      };
+
+      const result = resolveRenderedSourceHandle(edge, nodes);
+      expect(result).toBe("tool-output");
+    });
+  });
+});

--- a/frontend/src/lib/workflowEdges.ts
+++ b/frontend/src/lib/workflowEdges.ts
@@ -50,7 +50,9 @@ function hasPrimaryOutputHandle(node: WorkflowNode): boolean {
     return false;
   }
 
-  return NODE_DEFINITIONS[node.type].outputs > 0;
+  // Safely handle unknown node types: most workflow nodes have outputs, so unknown types are assumed to have outputs.
+  const definition = NODE_DEFINITIONS[node.type as NodeType];
+  return definition ? definition.outputs > 0 : true;
 }
 
 export function resolveRenderedSourceHandle(


### PR DESCRIPTION
## Summary

Fixes a mobile workflow editor crash when a persisted workflow contains an unknown, stale, or unsupported node type.

## What changed

- Added a shared safe node display resolver for mobile workflow surfaces.
- Added safe fallbacks for labels, summaries, icons, and icon colors.
- Preserved unknown nodes instead of dropping them.
- Guarded workflow edge handling when an unknown source node has no explicit source handle.
- Added focused tests for the resolver, mobile surfaces, and workflow edge behavior.

## Validation

- `npm test -- --run`
- `vue-tsc --noEmit`
- ESLint
- `git diff --check`
- `./check.sh`

The backend portion of `./check.sh` reaches 358 failures caused by missing `SECRET_KEY` / `ENCRYPTION_KEY` configuration; the same failures reproduce on the pre-change baseline.
  
Related: #534