### PR TITLE
Make an offloaded run's failure visible instead of silent

### DIFF
--- a/backend/app/api/discord.py
+++ b/backend/app/api/discord.py
@@ -27,7 +27,7 @@ from app.api.workflows import (
 )
 from app.db.models import Credential, CredentialType, ExecutionHistory, Workflow
 from app.db.session import async_session_maker
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
 from app.services.hitl_service import build_default_public_base_url
@@ -293,12 +293,11 @@ async def _execute_workflow_background(
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via Discord trigger on another instance, status: %s",
-                    workflow.id,
-                    result.status,
+                log_offloaded_run(
+                    logger, workflow_id=workflow.id, trigger="Discord trigger", result=result
                 )
                 return
 

--- a/backend/app/api/slack.py
+++ b/backend/app/api/slack.py
@@ -24,7 +24,7 @@ from app.api.workflows import (
 )
 from app.db.models import Credential, CredentialType, ExecutionHistory, Workflow
 from app.db.session import async_session_maker
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
 from app.services.hitl_service import build_default_public_base_url
@@ -173,12 +173,11 @@ async def _execute_workflow_background(
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via Slack trigger on another instance, status: %s",
-                    workflow.id,
-                    result.status,
+                log_offloaded_run(
+                    logger, workflow_id=workflow.id, trigger="Slack trigger", result=result
                 )
                 return
 

--- a/backend/app/api/telegram.py
+++ b/backend/app/api/telegram.py
@@ -20,7 +20,7 @@ from app.api.workflows import (
 )
 from app.db.models import Credential, CredentialType, ExecutionHistory, Workflow
 from app.db.session import async_session_maker
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
 from app.services.hitl_service import build_default_public_base_url
@@ -174,12 +174,11 @@ async def _execute_workflow_background(
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via Telegram trigger on another instance, status: %s",
-                    workflow.id,
-                    result.status,
+                log_offloaded_run(
+                    logger, workflow_id=workflow.id, trigger="Telegram trigger", result=result
                 )
                 return
 

--- a/backend/app/services/cluster/dispatch.py
+++ b/backend/app/services/cluster/dispatch.py
@@ -25,6 +25,7 @@ from app.services.cluster.run_history import (
     offloaded_error,
     persist_pending_run_history,
     persist_run_history,
+    record_failed_dispatch,
     summarize,
 )
 from app.services.cluster.run_result_bus import DEFAULT_WAIT_SECONDS, run_result_bus
@@ -66,9 +67,39 @@ def resolve_placement(nodes: list[dict], workflow_cache: dict[str, dict] | None)
 
 
 def _timeout_error(execution_id: uuid.UUID) -> OffloadedRun:
+    # reported: the run may still be executing and still owns this history id.
     return offloaded_error(
         f"Run {execution_id} did not report a result in time. It may still be "
-        "executing on another instance; check the execution history."
+        "executing on another instance; check the execution history.",
+        reported=True,
+    )
+
+
+def log_offloaded_run(log: logging.Logger, *, workflow_id: Any, trigger: str, result: Any) -> None:
+    """Report an offloaded run's outcome with the reason it had, at its level.
+
+    A dispatch that never ran and a workflow that ran and failed both arrive
+    here as status "error". Logging them the same way, without the reason, is
+    what leaves an operator with nothing to act on.
+    """
+    error = getattr(result, "error", None)
+    if error:
+        log.error("Workflow %s could not be run via %s: %s", workflow_id, trigger, error)
+        return
+    instance = getattr(result, "instance", "") or "another instance"
+    status = getattr(result, "status", "unknown")
+    if status in {"success", "pending"}:
+        log.info(
+            "Workflow %s executed via %s on %s, status: %s", workflow_id, trigger, instance, status
+        )
+        return
+    log.warning(
+        "Workflow %s executed via %s on %s and finished with status %s; "
+        "its history row on that instance holds the failing node",
+        workflow_id,
+        trigger,
+        instance,
+        status,
     )
 
 
@@ -88,6 +119,8 @@ async def wait_for_result(
             status, result, error = await run_queue.read_terminal_result(execution_id)
             if run_queue.is_terminal(status):
                 if error or result is None:
+                    # Not reported: the queue retired this run, so no instance
+                    # wrote its history and the caller must record the failure.
                     return offloaded_error(error or "Run finished without a result")
                 return from_summary(result)
 
@@ -178,7 +211,17 @@ async def dispatch_workflow(
     if not wait_for_completion:
         run_result_bus.release(run_id)
         return None
-    return await wait_for_result(run_id, timeout_seconds=timeout_seconds)
+    result = await wait_for_result(run_id, timeout_seconds=timeout_seconds)
+    if not result.reported:
+        # Nothing executed this run, so nothing else will ever record it.
+        await record_failed_dispatch(
+            execution_id=run_id,
+            workflow_id=workflow_id,
+            inputs=inputs,
+            trigger_source=trigger_source,
+            message=result.error or "The run was retired before any instance executed it",
+        )
+    return result
 
 
 class RunQueueWorker:

--- a/backend/app/services/cluster/run_history.py
+++ b/backend/app/services/cluster/run_history.py
@@ -14,9 +14,12 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
 from app.api.analytics import upsert_workflow_analytics_snapshot
 from app.db.models import ExecutionHistory, Workflow
 from app.db.session import async_session_maker
+from app.services.cluster import identity
 from app.services.cluster.attribution import attribution_fields
 
 
@@ -33,6 +36,8 @@ def summarize(result: Any, execution_id: uuid.UUID) -> dict[str, Any]:
         "outputs": result.outputs,
         "execution_time_ms": result.execution_time_ms,
         "history_written": True,
+        # Named so the caller's log can say where to look for the run.
+        "instance": identity.instance_name(),
     }
 
 
@@ -46,19 +51,30 @@ async def persist_run_history(
     trigger_source: str | None,
     result: Any,
 ) -> None:
-    """Write the run, its analytics bucket, and any sub-workflow runs."""
+    """Write the run, its analytics bucket, and any sub-workflow runs.
+
+    The run's own row is written last-writer-wins: the queue may already have
+    given up on this execution and recorded it as failed, and the instance that
+    actually ran it holds the real answer.
+    """
     async with async_session_maker() as db:
-        db.add(
-            ExecutionHistory(
-                id=execution_id,
-                workflow_id=workflow_id,
-                inputs=inputs,
-                outputs=result.outputs,
-                node_results=result.node_results,
-                status=result.status,
-                execution_time_ms=result.execution_time_ms,
-                trigger_source=trigger_source,
-                **attribution_fields(),
+        values = {
+            "id": execution_id,
+            "workflow_id": workflow_id,
+            "inputs": inputs,
+            "outputs": result.outputs,
+            "node_results": result.node_results,
+            "status": result.status,
+            "execution_time_ms": result.execution_time_ms,
+            "trigger_source": trigger_source,
+            **attribution_fields(),
+        }
+        await db.execute(
+            pg_insert(ExecutionHistory)
+            .values(**values)
+            .on_conflict_do_update(
+                index_elements=["id"],
+                set_={k: v for k, v in values.items() if k != "id"},
             )
         )
         await upsert_workflow_analytics_snapshot(
@@ -140,6 +156,12 @@ class OffloadedRun:
     Trigger call sites read `.status`, `.outputs` and `.execution_time_ms` and
     then write history. `history_written` tells them the executing instance
     already did, so the same call site serves both paths with one guard.
+
+    `reported` separates the two ways this object carries status "error": a run
+    that executed somewhere and failed (reported, history written there), and a
+    run the queue retired before any instance produced a result (not reported,
+    nothing written anywhere). Only the caller can tell them apart, and it can
+    only tell them apart if we say so.
     """
 
     status: str
@@ -150,6 +172,8 @@ class OffloadedRun:
     node_results: list = field(default_factory=list)
     sub_workflow_executions: list = field(default_factory=list)
     history_written: bool = True
+    reported: bool = True
+    instance: str = ""
     # The executing instance already joined any allow-downstream work locally.
     allow_downstream_pending: bool = False
 
@@ -164,9 +188,72 @@ def from_summary(summary: dict[str, Any]) -> OffloadedRun:
         workflow_id=str(summary.get("workflow_id") or ""),
         execution_time_ms=float(summary.get("execution_time_ms") or 0.0),
         error=summary.get("error"),
+        instance=str(summary.get("instance") or ""),
     )
 
 
-def offloaded_error(message: str) -> OffloadedRun:
-    """A failure the caller must surface without a history row of its own."""
-    return OffloadedRun(status="error", outputs={}, error=message)
+def offloaded_error(message: str, *, reported: bool = False) -> OffloadedRun:
+    """A failure the caller must surface, carrying its reason in the outputs.
+
+    `reported=True` means an instance may still be executing this run - a wait
+    that timed out - so its history row is not ours to write.
+    """
+    return OffloadedRun(
+        status="error",
+        outputs={"error": message},
+        error=message,
+        reported=reported,
+    )
+
+
+async def record_failed_dispatch(
+    *,
+    execution_id: uuid.UUID,
+    workflow_id: uuid.UUID,
+    inputs: dict,
+    trigger_source: str | None,
+    message: str,
+) -> bool:
+    """Write the run that no instance ever reported, and say whether we did.
+
+    The queue retired it - never claimed inside the grace window, claimed by an
+    instance that stopped, or a claim that raised - so no ExecutionHistory row
+    exists anywhere and the run is simply missing from the user's history. The
+    insert is conditional because a run that reports late still owns this id.
+    """
+    async with async_session_maker() as db:
+        workflow = await db.get(Workflow, workflow_id)
+        if workflow is None:
+            return False
+        inserted = (
+            await db.execute(
+                pg_insert(ExecutionHistory)
+                .values(
+                    id=execution_id,
+                    workflow_id=workflow_id,
+                    inputs=inputs,
+                    outputs={"error": message},
+                    node_results=[],
+                    status="error",
+                    execution_time_ms=0.0,
+                    trigger_source=trigger_source,
+                    # The dispatcher recorded this, no one executed it.
+                    **attribution_fields(),
+                )
+                .on_conflict_do_nothing(index_elements=["id"])
+                .returning(ExecutionHistory.id)
+            )
+        ).scalar_one_or_none()
+        if inserted is None:
+            await db.rollback()
+            return False
+        await upsert_workflow_analytics_snapshot(
+            db,
+            workflow_id=workflow_id,
+            owner_id=workflow.owner_id,
+            workflow_name_snapshot=workflow.name,
+            status="error",
+            execution_time_ms=0.0,
+        )
+        await db.commit()
+        return True

--- a/backend/app/services/cron_scheduler.py
+++ b/backend/app/services/cron_scheduler.py
@@ -20,7 +20,7 @@ from app.services.alerts.cleanup import cleanup_old_alert_events
 from app.services.alerts.evaluator import evaluate_due_alerts
 from app.services.cluster import registry, run_queue
 from app.services.cluster.autoweight import apply_automatic_weighting
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.cron_slot_state import claim_cron_slot, cleanup_cron_slot_claims
 from app.services.distributed_lock import lock_service
 from app.services.global_variables_service import get_global_variables_context
@@ -202,7 +202,9 @@ class CronScheduler:
                 workflow_id=workflow.id,
                 execution_id=execution_id,
                 inputs=enriched_inputs,
-                trigger_source="schedule",
+                # Same word the in-process path writes to history, or the same
+                # run reads as two different trigger sources in the UI.
+                trigger_source="cron",
                 actor_user_id=workflow.owner_id,
             )
             try:
@@ -214,7 +216,7 @@ class CronScheduler:
                     edges=workflow.edges,
                     inputs=enriched_inputs,
                     workflow_cache=workflow_cache,
-                    trigger_source="schedule",
+                    trigger_source="cron",
                     credentials_owner_id=workflow.owner_id,
                     execution_id=execution_id,
                     run_in_thread=True,
@@ -228,13 +230,10 @@ class CronScheduler:
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via cron on another instance, status: %s",
-                    workflow.id,
-                    result.status,
-                )
+                log_offloaded_run(logger, workflow_id=workflow.id, trigger="cron", result=result)
                 return
             if result.allow_downstream_pending:
                 result.join_allow_downstream()

--- a/backend/app/services/heym_event_dispatcher.py
+++ b/backend/app/services/heym_event_dispatcher.py
@@ -212,7 +212,7 @@ class HeymEventDispatcher:
             get_credentials_context,
         )
         from app.db.models import ExecutionHistory
-        from app.services.cluster.dispatch import dispatch_workflow
+        from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
         from app.services.execution_cancellation import clear_execution, register_execution
         from app.services.global_variables_service import get_global_variables_context
         from app.services.hitl_service import build_default_public_base_url
@@ -263,12 +263,14 @@ class HeymEventDispatcher:
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via Heym event trigger on another instance, status: %s",
-                    fresh_workflow.id,
-                    result.status,
+                log_offloaded_run(
+                    logger,
+                    workflow_id=fresh_workflow.id,
+                    trigger="Heym event trigger",
+                    result=result,
                 )
                 return
 

--- a/backend/app/services/imap_trigger_service.py
+++ b/backend/app/services/imap_trigger_service.py
@@ -21,7 +21,7 @@ from app.api.workflows import (
 )
 from app.db.models import Credential, CredentialType, ExecutionHistory, Workflow
 from app.db.session import async_session_maker
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.distributed_lock import lock_service
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
@@ -460,12 +460,11 @@ class ImapTriggerManager:
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via IMAP trigger on another instance, status: %s",
-                    fresh_workflow.id,
-                    result.status,
+                log_offloaded_run(
+                    logger, workflow_id=fresh_workflow.id, trigger="IMAP trigger", result=result
                 )
                 return
 

--- a/backend/app/services/rabbitmq_consumer.py
+++ b/backend/app/services/rabbitmq_consumer.py
@@ -17,7 +17,7 @@ from app.api.workflows import (
 )
 from app.db.models import Credential, ExecutionHistory, Workflow
 from app.db.session import async_session_maker
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.distributed_lock import lock_service
 from app.services.encryption import decrypt_config
 from app.services.global_variables_service import get_global_variables_context
@@ -370,12 +370,11 @@ class RabbitMQConsumerManager:
                 finally:
                     clear_execution(execution_id)
 
-                # An offloaded run wrote its own history on the instance that ran it.
+                # An offloaded run's history is written where it ran, or by the
+                # dispatcher itself when the queue retired it before it ran.
                 if getattr(result, "history_written", False):
-                    logger.info(
-                        "Workflow %s executed via RabbitMQ trigger on another instance, status: %s",
-                        workflow.id,
-                        result.status,
+                    log_offloaded_run(
+                        logger, workflow_id=workflow.id, trigger="RabbitMQ trigger", result=result
                     )
                     return
 

--- a/backend/app/services/websocket_trigger_service.py
+++ b/backend/app/services/websocket_trigger_service.py
@@ -19,7 +19,7 @@ from app.api.workflows import (
 )
 from app.db.models import ExecutionHistory, Workflow
 from app.db.session import async_session_maker
-from app.services.cluster.dispatch import dispatch_workflow
+from app.services.cluster.dispatch import dispatch_workflow, log_offloaded_run
 from app.services.distributed_lock import lock_service
 from app.services.global_variables_service import get_global_variables_context
 from app.services.hitl_service import build_default_public_base_url
@@ -448,12 +448,11 @@ class WebSocketTriggerManager:
             finally:
                 clear_execution(execution_id)
 
-            # An offloaded run wrote its own history on the instance that ran it.
+            # An offloaded run's history is written where it ran, or by the
+            # dispatcher itself when the queue retired it before it ran.
             if getattr(result, "history_written", False):
-                logger.info(
-                    "Workflow %s executed via WebSocket trigger on another instance, status: %s",
-                    workflow.id,
-                    result.status,
+                log_offloaded_run(
+                    logger, workflow_id=workflow.id, trigger="WebSocket trigger", result=result
                 )
                 return
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Test-run defaults that must not come from the developer's own .env.
+
+`Settings` reads .env at import, so a machine that runs Heym with a cluster
+enabled ran different code than CI: API, trigger and cron runs were enqueued
+onto the run queue instead of executed in-process, and a dozen suites failed
+here and nowhere else. Pinning the cluster off makes a local run mean what a
+CI run means; the suites that are about the cluster turn it back on themselves.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+
+
+@pytest.fixture(autouse=True)
+def cluster_disabled_unless_a_test_asks_for_it():
+    with patch.object(settings, "cluster_enabled", False):
+        yield

--- a/backend/tests/test_cluster_dispatch.py
+++ b/backend/tests/test_cluster_dispatch.py
@@ -1,6 +1,7 @@
 """When a run is kept in-process, and how an offloaded result comes back."""
 
 import asyncio
+import logging
 import unittest
 import uuid
 from types import SimpleNamespace
@@ -433,3 +434,245 @@ class ClaimedRunContextTests(unittest.IsolatedAsyncioTestCase):
         )
         persist: AsyncMock = claimed["persist_globals"]  # type: ignore[assignment]
         persist.assert_not_awaited()
+
+
+class RetiredRunTests(unittest.IsolatedAsyncioTestCase):
+    """A run the queue retired must still reach the user's execution history.
+
+    offloaded_error() reported history_written=True, so every trigger call site
+    took the "the instance that ran it already wrote history" branch for a run
+    no instance ever ran. Nothing was written, the reason was dropped, and the
+    only trace was one INFO line saying "status: error".
+    """
+
+    async def test_a_queue_failure_is_not_reported_by_any_instance(self) -> None:
+        execution_id = uuid.uuid4()
+        bus_module.run_result_bus.register(execution_id).set()
+        with patch(
+            "app.services.cluster.dispatch.run_queue.read_terminal_result",
+            new=AsyncMock(return_value=("failed", None, "boom")),
+        ):
+            result = await wait_for_result(execution_id, timeout_seconds=1.0)
+        self.assertFalse(result.reported)
+
+    async def test_the_reason_survives_where_history_can_show_it(self) -> None:
+        execution_id = uuid.uuid4()
+        bus_module.run_result_bus.register(execution_id).set()
+        with patch(
+            "app.services.cluster.dispatch.run_queue.read_terminal_result",
+            new=AsyncMock(return_value=("skipped_late", None, "too late")),
+        ):
+            result = await wait_for_result(execution_id, timeout_seconds=1.0)
+        self.assertEqual(result.outputs, {"error": "too late"})
+
+    async def test_a_reported_run_is_left_to_the_instance_that_ran_it(self) -> None:
+        execution_id = uuid.uuid4()
+        bus_module.run_result_bus.register(execution_id).set()
+        with patch(
+            "app.services.cluster.dispatch.run_queue.read_terminal_result",
+            new=AsyncMock(return_value=("done", {"status": "error", "outputs": {}}, None)),
+        ):
+            result = await wait_for_result(execution_id, timeout_seconds=1.0)
+        self.assertTrue(result.reported)
+
+    async def test_a_timeout_is_left_to_the_run_that_may_still_be_going(self) -> None:
+        """The live run still owns this execution id; a second row would collide."""
+        execution_id = uuid.uuid4()
+        with patch(
+            "app.services.cluster.dispatch.run_queue.read_terminal_result",
+            new=AsyncMock(return_value=("claimed", None, None)),
+        ):
+            result = await wait_for_result(execution_id, timeout_seconds=0.05)
+        self.assertTrue(result.reported)
+
+    async def _dispatch(self, waited: object) -> AsyncMock:
+        from app.services.cluster.dispatch import dispatch_workflow
+
+        record = AsyncMock(return_value=True)
+        with (
+            patch("app.services.cluster.dispatch.settings.cluster_enabled", True),
+            patch("app.services.cluster.dispatch.identity.is_main", return_value=False),
+            patch(
+                "app.services.cluster.dispatch.run_queue.enqueue",
+                new=AsyncMock(return_value="worker-1"),
+            ),
+            patch("app.services.cluster.dispatch.run_queue.notify_queue", new=AsyncMock()),
+            patch(
+                "app.services.cluster.dispatch.wait_for_result",
+                new=AsyncMock(return_value=waited),
+            ),
+            patch("app.services.cluster.dispatch.record_failed_dispatch", record),
+        ):
+            await dispatch_workflow(
+                workflow_id=uuid.uuid4(),
+                nodes=[{"type": "http", "data": {}}],
+                edges=[],
+                inputs={"triggered_by": "cron"},
+                trigger_source="cron",
+            )
+        return record
+
+    async def test_a_run_no_instance_reported_is_recorded_by_the_dispatcher(self) -> None:
+        from app.services.cluster.run_history import offloaded_error
+
+        record = await self._dispatch(offloaded_error("boom"))
+        record.assert_awaited_once()
+        self.assertEqual(record.await_args.kwargs["message"], "boom")
+        self.assertEqual(record.await_args.kwargs["trigger_source"], "cron")
+
+    async def test_a_reported_run_is_not_recorded_twice(self) -> None:
+        from app.services.cluster.run_history import from_summary
+
+        record = await self._dispatch(from_summary({"status": "error", "outputs": {}}))
+        record.assert_not_awaited()
+
+
+class OffloadedRunLoggingTests(unittest.TestCase):
+    """The log line is the only thing an operator sees for an offloaded run."""
+
+    def _log(self, result: object) -> tuple[str, str]:
+        from app.services.cluster.dispatch import log_offloaded_run
+
+        with self.assertLogs("cluster", level="INFO") as captured:
+            log_offloaded_run(
+                logging.getLogger("cluster"), workflow_id="wf-1", trigger="cron", result=result
+            )
+        return captured.records[0].levelname, captured.records[0].getMessage()
+
+    def test_a_dispatch_failure_names_its_reason(self) -> None:
+        from app.services.cluster.run_history import offloaded_error
+
+        level, message = self._log(offloaded_error("Skipped: not claimed in time"))
+        self.assertEqual(level, "ERROR")
+        self.assertIn("Skipped: not claimed in time", message)
+
+    def test_a_successful_run_names_the_instance_that_ran_it(self) -> None:
+        from app.services.cluster.run_history import from_summary
+
+        level, message = self._log(
+            from_summary({"status": "success", "outputs": {}, "instance": "worker-1"})
+        )
+        self.assertEqual(level, "INFO")
+        self.assertIn("worker-1", message)
+
+    def test_a_workflow_that_ran_and_failed_is_a_warning(self) -> None:
+        """Not an error of dispatch: the run happened, its history holds the node."""
+        from app.services.cluster.run_history import from_summary
+
+        level, message = self._log(
+            from_summary({"status": "error", "outputs": {}, "instance": "worker-1"})
+        )
+        self.assertEqual(level, "WARNING")
+        self.assertIn("history", message)
+
+
+class RecordFailedDispatchTests(unittest.IsolatedAsyncioTestCase):
+    """The row written for a run that never executed anywhere."""
+
+    def _session(self, inserted: object) -> tuple[MagicMock, MagicMock]:
+        workflow = SimpleNamespace(id=uuid.uuid4(), owner_id=uuid.uuid4(), name="Nightly")
+        db = MagicMock()
+        db.get = AsyncMock(return_value=workflow)
+        db.execute = AsyncMock(return_value=SimpleNamespace(scalar_one_or_none=lambda: inserted))
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=db)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+        return db, factory
+
+    async def _record(self, inserted: object) -> tuple[MagicMock, AsyncMock, bool]:
+        from app.services.cluster.run_history import record_failed_dispatch
+
+        db, factory = self._session(inserted)
+        snapshot = AsyncMock()
+        with (
+            patch("app.services.cluster.run_history.async_session_maker", factory),
+            patch("app.services.cluster.run_history.upsert_workflow_analytics_snapshot", snapshot),
+        ):
+            written = await record_failed_dispatch(
+                execution_id=uuid.uuid4(),
+                workflow_id=uuid.uuid4(),
+                inputs={"triggered_by": "cron"},
+                trigger_source="cron",
+                message="Skipped: not claimed inside the misfire grace window",
+            )
+        return db, snapshot, written
+
+    async def test_the_failed_run_is_written_with_its_reason(self) -> None:
+        _db, _snapshot, written = await self._record(uuid.uuid4())
+        self.assertTrue(written)
+
+    async def test_the_failed_run_counts_in_analytics(self) -> None:
+        _db, snapshot, _written = await self._record(uuid.uuid4())
+        snapshot.assert_awaited_once()
+        self.assertEqual(snapshot.await_args.kwargs["status"], "error")
+
+    async def test_a_run_that_reported_late_keeps_its_own_row(self) -> None:
+        """The insert conflicts, so the analytics bucket must not count it twice."""
+        db, snapshot, written = await self._record(None)
+        self.assertFalse(written)
+        snapshot.assert_not_awaited()
+        db.commit.assert_not_awaited()
+
+    async def test_a_deleted_workflow_is_not_recorded(self) -> None:
+        from app.services.cluster.run_history import record_failed_dispatch
+
+        _db, factory = self._session(uuid.uuid4())
+        factory.return_value.__aenter__.return_value.get = AsyncMock(return_value=None)
+        with patch("app.services.cluster.run_history.async_session_maker", factory):
+            written = await record_failed_dispatch(
+                execution_id=uuid.uuid4(),
+                workflow_id=uuid.uuid4(),
+                inputs={},
+                trigger_source="cron",
+                message="boom",
+            )
+        self.assertFalse(written)
+
+
+class RunHistoryLastWriterWinsTests(unittest.IsolatedAsyncioTestCase):
+    """The instance that ran it holds the real answer, even if the queue gave up.
+
+    A stranded claim is retired while its run may still be going. The retiring
+    pass records the failure under the same execution id, so the run's own
+    history write has to replace that row rather than collide with it.
+    """
+
+    async def test_the_run_row_replaces_a_row_already_recorded_for_it(self) -> None:
+        from sqlalchemy.dialects import postgresql
+
+        from app.services.cluster.run_history import persist_run_history
+
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.commit = AsyncMock()
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=db)
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+        result = SimpleNamespace(
+            status="success",
+            outputs={},
+            node_results=[],
+            execution_time_ms=1.0,
+            sub_workflow_executions=[],
+        )
+        with (
+            patch("app.services.cluster.run_history.async_session_maker", factory),
+            patch(
+                "app.services.cluster.run_history.upsert_workflow_analytics_snapshot",
+                new=AsyncMock(),
+            ),
+        ):
+            await persist_run_history(
+                execution_id=uuid.uuid4(),
+                workflow_id=uuid.uuid4(),
+                owner_id=uuid.uuid4(),
+                workflow_name="Nightly",
+                inputs={},
+                trigger_source="cron",
+                result=result,
+            )
+        statement = db.execute.await_args.args[0]
+        compiled = str(statement.compile(dialect=postgresql.dialect())).upper()
+        self.assertIn("ON CONFLICT (ID) DO UPDATE", compiled)

--- a/backend/tests/test_cron_scheduler.py
+++ b/backend/tests/test_cron_scheduler.py
@@ -448,3 +448,56 @@ class CronExecutorThreadingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(run_threads), 1)
         self.assertNotEqual(run_threads[0], threading.current_thread().name)
+
+
+class CronOffloadedRunTests(unittest.IsolatedAsyncioTestCase):
+    """What the cron path hands the queue, and what it does with the answer."""
+
+    async def _dispatch_kwargs(self, result: object) -> dict:
+        scheduler = CronScheduler()
+        workflow = SimpleNamespace(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Cron workflow",
+            nodes=[],
+            edges=[],
+        )
+        db = SimpleNamespace(add=lambda row: None, commit=AsyncMock())
+        dispatch = AsyncMock(return_value=result)
+        with (
+            patch(
+                "app.services.cron_scheduler.collect_referenced_workflows",
+                AsyncMock(return_value={}),
+            ),
+            patch(
+                "app.services.cron_scheduler.get_credentials_context", AsyncMock(return_value={})
+            ),
+            patch(
+                "app.services.cron_scheduler.get_global_variables_context",
+                AsyncMock(return_value={}),
+            ),
+            patch("app.services.cron_scheduler.dispatch_workflow", dispatch),
+            patch(
+                "app.services.cron_scheduler.upsert_workflow_analytics_snapshot", AsyncMock()
+            ) as snapshot,
+            patch(
+                "app.services.cron_scheduler._persist_global_variables_from_execution", AsyncMock()
+            ),
+        ):
+            await scheduler._execute_workflow(db, workflow)
+        return {"dispatch": dispatch, "snapshot": snapshot, "workflow": workflow}
+
+    async def test_an_offloaded_cron_run_carries_the_same_trigger_source(self) -> None:
+        """History said 'schedule' when offloaded and 'cron' when not - one run, two labels."""
+        from app.services.cluster.run_history import from_summary
+
+        called = await self._dispatch_kwargs(from_summary({"status": "success", "outputs": {}}))
+        dispatch: AsyncMock = called["dispatch"]
+        self.assertEqual(dispatch.await_args.kwargs["trigger_source"], "cron")
+
+    async def test_a_run_recorded_elsewhere_is_not_written_again_here(self) -> None:
+        from app.services.cluster.run_history import from_summary
+
+        called = await self._dispatch_kwargs(from_summary({"status": "error", "outputs": {}}))
+        snapshot: AsyncMock = called["snapshot"]
+        snapshot.assert_not_awaited()

--- a/backend/tests/test_mcp_stdio_sandbox.py
+++ b/backend/tests/test_mcp_stdio_sandbox.py
@@ -35,7 +35,13 @@ def _flag_value(argv: list[str], flag: str) -> str | None:
 
 class SandboxModeTests(unittest.TestCase):
     def test_defaults_to_auto(self) -> None:
-        with patch.dict(os.environ, {}, clear=False):
+        # The setting is pinned as well as the variable: a developer's own .env
+        # is read into settings at import, and "the default" must mean the
+        # default here, not whatever this machine happens to configure.
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch("app.services.mcp_stdio_sandbox.settings.mcp_stdio_sandbox", "auto"),
+        ):
             os.environ.pop("HEYM_MCP_STDIO_SANDBOX", None)
             self.assertEqual(sandbox_mode(), "auto")
 
@@ -62,13 +68,17 @@ class SandboxDecouplingTests(unittest.TestCase):
         self.addCleanup(reset_docker_available_cache)
 
     def test_python_tool_subprocess_does_not_downgrade_mcp_stdio(self) -> None:
-        with patch.dict(os.environ, {"HEYM_PYTHON_TOOL_SANDBOX": "subprocess"}):
+        with (
+            patch.dict(os.environ, {"HEYM_PYTHON_TOOL_SANDBOX": "subprocess"}),
+            patch("app.services.mcp_stdio_sandbox.settings.mcp_stdio_sandbox", "auto"),
+        ):
             os.environ.pop("HEYM_MCP_STDIO_SANDBOX", None)
             self.assertEqual(sandbox_mode(), "auto")
 
     def test_python_tool_subprocess_still_fails_closed_without_docker(self) -> None:
         with (
             patch.dict(os.environ, {"HEYM_PYTHON_TOOL_SANDBOX": "subprocess"}),
+            patch("app.services.mcp_stdio_sandbox.settings.mcp_stdio_sandbox", "auto"),
             patch("app.services.mcp_stdio_sandbox.docker_available", return_value=False),
         ):
             os.environ.pop("HEYM_MCP_STDIO_SANDBOX", None)

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -11,6 +11,7 @@ class TestSettingsDatabaseUrl(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             encryption_key="0" * 64,
+            secret_key="t" * 32,
             database_url="",
             postgres_host="db",
             postgres_port=5432,
@@ -28,6 +29,7 @@ class TestSettingsDatabaseUrl(unittest.TestCase):
         settings = Settings(
             _env_file=None,
             encryption_key="0" * 64,
+            secret_key="t" * 32,
             database_url="postgresql+asyncpg://explicit:secret@custom:6544/app",
             postgres_host="db",
             postgres_port=5432,
@@ -44,13 +46,17 @@ class TestSettingsDatabaseUrl(unittest.TestCase):
 
 class TestSettingsVersion(unittest.TestCase):
     def test_resolved_version_reads_version_file_when_app_version_is_blank(self) -> None:
-        settings = Settings(_env_file=None, encryption_key="0" * 64, app_version="")
+        settings = Settings(
+            _env_file=None, encryption_key="0" * 64, secret_key="t" * 32, app_version=""
+        )
 
         with patch("app.config._read_version", return_value="0.0.24"):
             self.assertEqual(settings.resolved_version, "0.0.24")
 
     def test_explicit_app_version_takes_precedence(self) -> None:
-        settings = Settings(_env_file=None, encryption_key="0" * 64, app_version="0.0.25")
+        settings = Settings(
+            _env_file=None, encryption_key="0" * 64, secret_key="t" * 32, app_version="0.0.25"
+        )
 
         with patch("app.config._read_version", return_value="0.0.24"):
             self.assertEqual(settings.resolved_version, "0.0.25")


### PR DESCRIPTION
## The report

A cron workflow kept logging:

```
INFO [cron_scheduler] Workflow <id> executed via cron on another instance, status: error
```

and there was no way to tell why. In the reported case the workflow itself was
failing — the queue row's `error` was NULL, so the run executed and reported
status error. But finding that out required reading the database, because the
line collapses five different outcomes into one INFO message and throws the
reason away.

Two of those five were worse than undiagnosable. `offloaded_error()` returned
`history_written=True`, so all eight trigger call sites took the "the instance
that ran it already wrote history" branch for a run **no instance ever ran** —
retired as `skipped_late`, claimed by an instance that stopped, or a claim that
raised. Nothing wrote the row, `result.error` was discarded, and the run was
absent from Execution History entirely.

Worth noting: with `HEYM_CLUSTER_ENABLED=true` and a single main instance, "on
another instance" is not even true. Only a `main_only` run on main skips the
queue, so every `anywhere` run is executed by another *process* of the same
instance.

## What changed

- `OffloadedRun` carries `reported`, which separates a run that executed
  somewhere and failed (history written there) from one the queue retired before
  any instance produced a result (nothing written anywhere).
- `dispatch_workflow` records the second kind itself, with the reason in
  `outputs`. `ON CONFLICT DO NOTHING`, so a run that reports late keeps its row.
- `persist_run_history` is now an upsert. A stranded claim is retired while its
  run may still be going, and the instance that actually ran it holds the real
  answer — it must be able to replace the placeholder rather than collide with it.
- One `log_offloaded_run` helper for all eight call sites: a dispatch failure at
  ERROR with its reason, a workflow that ran and failed at WARNING naming the
  instance and pointing at its history row, success at INFO.
- Cron writes `trigger_source` `"cron"` on both paths. Offloaded cron runs were
  written as `"schedule"`, so one job read as two trigger sources in the history
  filter.

## Test hygiene

`Settings` reads `.env` at import, so a developer running Heym with a cluster
enabled ran different code than CI: 23 tests failed locally and none in CI.
`backend/tests/conftest.py` pins the cluster off for the suites that are not
about it (the cluster suites turn it back on themselves), and the settings and
MCP sandbox suites now pin what they mean by "the default" instead of inheriting
this machine's configuration.

## Behaviour change to be aware of

A run the queue retires now produces an `error` row in Execution History and
counts in the analytics bucket. That is the point — such runs used to vanish —
but an error-rate alert may now fire on failures it never saw before.

## Verification

`./check.sh`: 3960 tests, all passing (23 were failing on the same machine before
this branch). `ruff check` and `ruff format --check` clean.