### PR TITLE
fix: handle quotes and newlines in arithmetic string expressions

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -6236,14 +6236,14 @@ class WorkflowExecutor:
                 if result is None:
                     return "None"
                 if isinstance(result, str):
-                    return f'"{result}"'
+                    return repr(result)
                 return str(result)
             except Exception as e:
                 result = self._fallback_after_eval_error(e, expr, combined)
                 if result is None:
                     return "None"
                 if isinstance(result, str):
-                    return f'"{result}"'
+                    return repr(result)
                 return str(result)
 
         processed = self._replace_expressions(expression, replace_dollar_ref)

--- a/backend/tests/test_expression_evaluator_service.py
+++ b/backend/tests/test_expression_evaluator_service.py
@@ -975,6 +975,8 @@ class TestExpressionEvaluatorServiceEvaluate(unittest.TestCase):
             ("Hello world", "Hello world!"),
             ('He said "hello"', 'He said "hello"!'),
             ("Line 1\nLine 2", "Line 1\nLine 2!"),
+            ("C:\\next", "C:\\next!"),
+            ('" + upper("pwn") + "', '" + upper("pwn") + "!'),
         ]
 
         for input_text, expected in cases:

--- a/backend/tests/test_expression_evaluator_service.py
+++ b/backend/tests/test_expression_evaluator_service.py
@@ -962,6 +962,32 @@ class TestExpressionEvaluatorServiceEvaluate(unittest.TestCase):
         self.assertTrue(response.preserved_type)
         self.assertIsNone(response.error)
 
+    def test_arithmetic_string_concatenation_with_quotes_and_newlines(self) -> None:
+        """resolve_arithmetic_expression must safely handle runtime strings with quotes and newlines."""
+        expr = '$userInput.body.text + "!"'
+        ex = WorkflowExecutor(nodes=[], edges=[])
+        self.assertTrue(
+            ex._has_arithmetic(expr),
+            "precondition: set node must choose resolve_arithmetic_expression for this template",
+        )
+
+        cases = [
+            ("Hello world", "Hello world!"),
+            ('He said "hello"', 'He said "hello"!'),
+            ("Line 1\nLine 2", "Line 1\nLine 2!"),
+        ]
+
+        for input_text, expected in cases:
+            with self.subTest(input_text=input_text):
+                ctx = {"userInput": {"body": {"text": input_text}}}
+                arith_result = ex.resolve_arithmetic_expression(expr, ctx, None, preserve_type=True)
+                self.assertEqual(arith_result, expected)
+
+                response = self._service().evaluate(expr, ctx)
+                self.assertEqual(response.result, expected)
+                self.assertEqual(response.result_type, "string")
+                self.assertIsNone(response.error)
+
     def test_nested_map_filter_resolves_outer_item_in_executor_and_preview(self) -> None:
         expr = (
             '$distinctTypes.types.map("dict(issue_type=item, '


### PR DESCRIPTION
## Summary

Fixes an issue where runtime strings containing double quotes or newlines were incorrectly embedded into arithmetic expressions.

For example:

```text
$userInput.body.text + "!"
```

with:

```
He said "hello"
```

previously produced malformed expression text instead of:

```
He said "hello"!
```

The root cause was `resolve_arithmetic_expression()` wrapping runtime strings with `f'"{result}"'` before AST evaluation. This change uses `repr(result)` instead, matching the existing safe handling in the related expression evaluation paths.

## Changes

* Replace unsafe runtime string quoting with `repr(result)` in both affected branches of `resolve_arithmetic_expression()`.
* Add regression coverage for:
  * quoted runtime strings
  * multiline runtime strings
  * normal string concatenation

## Validation

* 178 expression evaluator tests passed.
* 113 related expression/execution tests passed.
* Verified with a real local Heym instance using PostgreSQL, Uvicorn, and the workflow execution HTTP API.
* Verified plain text, quotes, newlines, JSON-like text, backslashes, Unicode, and a dynamically generated runtime value.
* All real workflow executions returned the expected `input + "!"` result with `success` status.

Discussion: #539