### PR TITLE
fix: support boolean ordering in workflow expressions

### DIFF
--- a/backend/app/services/workflow_executor.py
+++ b/backend/app/services/workflow_executor.py
@@ -1145,6 +1145,26 @@ class DotBool:
             return self._value == other._value
         return self._value == other
 
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, DotBool):
+            return self._value < other._value
+        return self._value < other  # type: ignore[operator]
+
+    def __le__(self, other: object) -> bool:
+        if isinstance(other, DotBool):
+            return self._value <= other._value
+        return self._value <= other  # type: ignore[operator]
+
+    def __gt__(self, other: object) -> bool:
+        if isinstance(other, DotBool):
+            return self._value > other._value
+        return self._value > other  # type: ignore[operator]
+
+    def __ge__(self, other: object) -> bool:
+        if isinstance(other, DotBool):
+            return self._value >= other._value
+        return self._value >= other  # type: ignore[operator]
+
     def toString(self) -> "DotStr":  # noqa: N802
         return DotStr(str(self._value).lower())
 

--- a/backend/tests/test_expression_evaluator_service.py
+++ b/backend/tests/test_expression_evaluator_service.py
@@ -25,8 +25,10 @@ from app.services.expression_evaluator import (
 )
 from app.services.expression_syntax import alias_reserved_context_names
 from app.services.workflow_executor import (
+    DotBool,
     WorkflowExecutor,
     _normalize_js_logical_ops_for_eval,
+    execute_workflow,
 )
 
 
@@ -1916,6 +1918,176 @@ class TestWorkflowMetadataVariables(unittest.TestCase):
             workflow_nodes=[], workflow_edges=[], workflow_id=uuid.uuid4()
         )
         self.assertEqual(service.evaluate("$executionId", {}).result, "")
+
+
+class TestDotBoolComparisonsAndPreview(unittest.TestCase):
+    """Regression coverage for DotBool rich comparisons across execution and preview."""
+
+    def _service(self) -> ExpressionEvaluatorService:
+        return ExpressionEvaluatorService()
+
+    def test_dotbool_rich_comparisons_direct(self) -> None:
+        t = DotBool(True)
+        f = DotBool(False)
+
+        # Ordering semantics
+        self.assertTrue(f < t)
+        self.assertFalse(t < f)
+        self.assertTrue(f <= t)
+        self.assertTrue(t <= t)
+        self.assertTrue(t > f)
+        self.assertFalse(f > t)
+        self.assertTrue(t >= f)
+        self.assertTrue(f >= f)
+
+        # DotBool vs native bool
+        self.assertTrue(f < True)
+        self.assertFalse(t < False)
+        self.assertTrue(f <= True)
+        self.assertTrue(t >= False)
+
+        # native bool vs DotBool (reflected operations)
+        self.assertTrue(False < t)
+        self.assertFalse(True < f)
+        self.assertTrue(False <= t)
+        self.assertTrue(True >= f)
+
+        # Incompatible type raises TypeError
+        with self.assertRaises(TypeError):
+            _ = t < "incompatible"
+
+    def test_expression_preview_boolean_comparisons(self) -> None:
+        service = self._service()
+        context = {"node": {"flag": True, "other": False}}
+
+        res_gt = service.evaluate("$node.flag > false", context)
+        self.assertIsNone(res_gt.error)
+        self.assertEqual(res_gt.result_type, "boolean")
+        self.assertTrue(res_gt.result)
+
+        res_gte = service.evaluate("$node.flag >= true", context)
+        self.assertIsNone(res_gte.error)
+        self.assertEqual(res_gte.result_type, "boolean")
+        self.assertTrue(res_gte.result)
+
+        res_lt = service.evaluate("$node.flag < true", context)
+        self.assertIsNone(res_lt.error)
+        self.assertEqual(res_lt.result_type, "boolean")
+        self.assertFalse(res_lt.result)
+
+        res_lte = service.evaluate("$node.flag <= false", context)
+        self.assertIsNone(res_lte.error)
+        self.assertEqual(res_lte.result_type, "boolean")
+        self.assertFalse(res_lte.result)
+
+        res_two_nodes = service.evaluate("$node.flag > $node.other", context)
+        self.assertIsNone(res_two_nodes.error)
+        self.assertEqual(res_two_nodes.result_type, "boolean")
+        self.assertTrue(res_two_nodes.result)
+
+    def test_expression_preview_boolean_sorting(self) -> None:
+        service = self._service()
+        context = {
+            "node": {
+                "flags": [True, False, True],
+                "users": [
+                    {"name": "alice", "active": True},
+                    {"name": "bob", "active": False},
+                ],
+            }
+        }
+
+        res_sort = service.evaluate("$node.flags.sort()", context)
+        self.assertIsNone(res_sort.error)
+        self.assertEqual(res_sort.result, [False, True, True])
+
+        res_sort_by = service.evaluate("$node.users.sort('item.active').map('item.name')", context)
+        self.assertIsNone(res_sort_by.error)
+        self.assertEqual(res_sort_by.result, ["bob", "alice"])
+
+    def test_expression_preview_boolean_filtering(self) -> None:
+        service = self._service()
+        context = {
+            "node": {
+                "users": [
+                    {"name": "alice", "active": True},
+                    {"name": "bob", "active": False},
+                ],
+            }
+        }
+
+        res_filter = service.evaluate(
+            "$node.users.filter('item.active > false').map('item.name')", context
+        )
+        self.assertIsNone(res_filter.error)
+        self.assertEqual(res_filter.result, ["alice"])
+
+    def test_maintainer_two_node_workflow_execution(self) -> None:
+        nodes = [
+            {
+                "id": "sample_node",
+                "type": "set",
+                "data": {
+                    "label": "sample",
+                    "mappings": [
+                        {"key": "flag", "value": "$bool(1)"},
+                        {"key": "flags", "value": "$array(true, false, true)"},
+                        {
+                            "key": "users",
+                            "value": (
+                                "$array(dict(name='alice', active=true), "
+                                "dict(name='bob', active=false))"
+                            ),
+                        },
+                    ],
+                },
+            },
+            {
+                "id": "check_node",
+                "type": "set",
+                "data": {
+                    "label": "check",
+                    "mappings": [
+                        {"key": "compare", "value": "$sample.flag > false"},
+                        {"key": "sortFlags", "value": "$sample.flags.sort()"},
+                        {
+                            "key": "sortUsers",
+                            "value": "$sample.users.sort('item.active').map('item.name')",
+                        },
+                        {
+                            "key": "filterUsers",
+                            "value": "$sample.users.filter('item.active > false').map('item.name')",
+                        },
+                    ],
+                },
+            },
+        ]
+        edges = [{"id": "e1", "source": "sample_node", "target": "check_node"}]
+
+        result = execute_workflow(
+            workflow_id=uuid.uuid4(),
+            nodes=nodes,
+            edges=edges,
+            inputs={},
+            test_run=True,
+        )
+        self.assertEqual(result.status, "success")
+
+        check_output = {}
+        for nr in result.node_results:
+            label = nr["node_label"] if isinstance(nr, dict) else nr.node_label
+            if label == "check":
+                check_output = nr["output"] if isinstance(nr, dict) else nr.output
+
+        self.assertEqual(
+            check_output,
+            {
+                "compare": True,
+                "sortFlags": [False, True, True],
+                "sortUsers": ["bob", "alice"],
+                "filterUsers": ["alice"],
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_expression_operator_smoke.py
+++ b/backend/tests/test_expression_operator_smoke.py
@@ -43,6 +43,8 @@ FIXED_DATE = "2026-03-05T14:30:00"
 SAMPLE_WORDS = ["beta", "alpha", "beta"]
 SAMPLE_PEOPLE = [{"name": "ada", "age": 36}, {"name": "bob", "age": 24}]
 SAMPLE_PROFILE = {"name": "ada", "age": 36}
+SAMPLE_FLAGS = [True, False, True]
+SAMPLE_USERS = [{"name": "alice", "active": True}, {"name": "bob", "active": False}]
 
 SAMPLE_MAPPINGS: list[dict[str, str]] = [
     {"key": "text", "value": SAMPLE_TEXT},
@@ -52,10 +54,15 @@ SAMPLE_MAPPINGS: list[dict[str, str]] = [
     {"key": "num", "value": "$int(7)"},
     {"key": "ratio", "value": "$float(2.5)"},
     {"key": "flag", "value": "$bool(1)"},
+    {"key": "flags", "value": "$array(true, false, true)"},
     {"key": "words", "value": "$array('beta', 'alpha', 'beta')"},
     {"key": "nullable", "value": "$array('beta', null)"},
     {"key": "nested", "value": "$array($array('a', 'b'), $array('c'))"},
     {"key": "people", "value": "$array(dict(name='ada', age=36), dict(name='bob', age=24))"},
+    {
+        "key": "users",
+        "value": "$array(dict(name='alice', active=true), dict(name='bob', active=false))",
+    },
     {"key": "profile", "value": "$dict(name='ada', age=36)"},
 ]
 
@@ -101,6 +108,10 @@ OPERATOR_CASES: list[tuple[str, str, Expected]] = [
     ("intToString", "$sample.num.toString()", "7"),
     ("floatToString", "$sample.ratio.toString()", "2.5"),
     ("boolToString", "$sample.flag.toString()", "true"),
+    ("boolGreaterThan", "$sample.flag > false", True),
+    ("boolGreaterThanOrEqual", "$sample.flag >= true", True),
+    ("boolLessThan", "$sample.flag < true", False),
+    ("boolLessThanOrEqual", "$sample.flag <= false", False),
     ("intArithmetic", "$sample.num + 3", 10),
     ("floatArithmetic", "$sample.ratio - 0.5", 2.0),
     # --- DotList -----------------------------------------------------------------
@@ -109,6 +120,7 @@ OPERATOR_CASES: list[tuple[str, str, Expected]] = [
     ("listLast", "$sample.words.last()", "beta"),
     ("listDistinct", "$sample.words.distinct()", ["beta", "alpha"]),
     ("listSort", "$sample.words.sort()", ["alpha", "beta", "beta"]),
+    ("listSortBooleans", "$sample.flags.sort()", [False, True, True]),
     ("listReverse", "$sample.words.reverse()", ["beta", "alpha", "beta"]),
     ("listTake", "$sample.words.take(2)", ["beta", "alpha"]),
     ("listJoin", "$sample.words.join('|')", "beta|alpha|beta"),
@@ -118,8 +130,14 @@ OPERATOR_CASES: list[tuple[str, str, Expected]] = [
     ("listFlat", "$sample.nested.flat()", ["a", "b", "c"]),
     ("listMap", "$sample.people.map('item.name')", ["ada", "bob"]),
     ("listFilter", "$sample.people.filter('item.age > 30')", [SAMPLE_PEOPLE[0]]),
+    (
+        "listFilterBooleanOrdering",
+        "$sample.users.filter('item.active > false').map('item.name')",
+        ["alice"],
+    ),
     ("listDistinctBy", "$sample.people.distinctBy('item.name').length", 2),
     ("listSortBy", "$sample.people.sort('item.age')", [SAMPLE_PEOPLE[1], SAMPLE_PEOPLE[0]]),
+    ("listSortByBoolean", "$sample.users.sort('item.active').map('item.name')", ["bob", "alice"]),
     ("listToString", "$sample.words.toString()", json.dumps(SAMPLE_WORDS)),
     ("listRandom", "$sample.words.random()", lambda v: v in SAMPLE_WORDS),
     # --- DotDict -----------------------------------------------------------------
@@ -223,7 +241,9 @@ def _sample_fixture() -> dict[str, Any]:
         "nullable": ["beta", None],
         "nested": [["a", "b"], ["c"]],
         "people": [dict(person) for person in SAMPLE_PEOPLE],
+        "users": [dict(person) for person in SAMPLE_USERS],
         "profile": dict(SAMPLE_PROFILE),
+        "flags": list(SAMPLE_FLAGS),
     }
 
 


### PR DESCRIPTION
## Summary

Fixes boolean ordering for `DotBool` values in workflow expressions.

Boolean values coming from workflow context are wrapped in `DotBool`, but `DotBool` was missing the rich comparison operators required for `<`, `<=`, `>`, and `>=`.

This caused boolean comparisons to fail and also broke operations that rely on ordering, such as sorting and filtering.

## Changes

- Added `__lt__`, `__le__`, `__gt__`, and `__ge__` to `DotBool`.
- Added regression coverage for:
  - boolean comparisons
  - sorting boolean arrays
  - sorting objects by boolean fields
  - filtering using boolean ordering
- Covered both workflow execution and expression preview paths.

## Validation

- 3,996 backend tests passed
- Ruff check passed
- Ruff format check passed
- Frontend lint and typecheck passed
- File line-limit check passed

## Related

Closes #547